### PR TITLE
feat: add "Hide Browser Toolbar" option independent of fullscreen mode

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -2728,6 +2728,7 @@ fun WebApp.toApkConfig(packageName: String): ApkConfig {
         userAgent = webViewConfig.userAgent,
         userAgentMode = webViewConfig.userAgentMode.name,
         customUserAgent = webViewConfig.customUserAgent,
+        hideBrowserToolbar = webViewConfig.hideBrowserToolbar,
         // Use user-configured hideToolbar setting, no longer force HTML/media apps to hide toolbar
         // User can choose whether to enable fullscreen mode when creating app
         hideToolbar = webViewConfig.hideToolbar,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -141,6 +141,7 @@ class ApkTemplate(private val context: Context) {
                 "keyboardAdjustMode": "${config.keyboardAdjustMode}",
                 "swipeRefreshEnabled": ${config.swipeRefreshEnabled},
                 "fullscreenEnabled": ${config.fullscreenEnabled},
+                "hideBrowserToolbar": ${config.hideBrowserToolbar},
                 "hideToolbar": ${config.hideToolbar},
                 "showStatusBarInFullscreen": ${config.showStatusBarInFullscreen},
                 "showNavigationBarInFullscreen": ${config.showNavigationBarInFullscreen},
@@ -525,6 +526,7 @@ data class ApkConfig(
     val userAgent: String? = null,
     val userAgentMode: String = "DEFAULT", // User-Agent 模式: DEFAULT, CHROME_MOBILE, CHROME_DESKTOP, SAFARI_MOBILE, SAFARI_DESKTOP, FIREFOX_MOBILE, FIREFOX_DESKTOP, EDGE_MOBILE, EDGE_DESKTOP, CUSTOM
     val customUserAgent: String? = null, // Custom User-Agent（仅 CUSTOM 模式使用）
+    val hideBrowserToolbar: Boolean = false, // Hide browser toolbar independently
     val hideToolbar: Boolean = false,
     val showStatusBarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示状态栏
     val showNavigationBarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示导航栏

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -5294,6 +5294,18 @@ object Strings {
         AppLanguage.ARABIC -> "عرض زر عودة عائم في الزاوية العلوية اليسرى في وضع ملء الشاشة. قم بتعطيله إذا تعارض مع واجهة صفحة الويب"
     }
 
+    val hideBrowserToolbarLabel: String get() = when (lang) {
+        AppLanguage.CHINESE -> "隐藏浏览器工具栏"
+        AppLanguage.ENGLISH -> "Hide Browser Toolbar"
+        AppLanguage.ARABIC -> "إخفاء شريط أدوات المتصفح"
+    }
+
+    val hideBrowserToolbarHint: String get() = when (lang) {
+        AppLanguage.CHINESE -> "隐藏顶部导航工具栏，让应用看起来更像原生应用。无需启用全屏模式，状态栏和导航栏保持正常显示"
+        AppLanguage.ENGLISH -> "Hide the top navigation toolbar for a native app look. No need to enable fullscreen mode — status bar and navigation bar remain visible"
+        AppLanguage.ARABIC -> "إخفاء شريط أدوات التنقل العلوي لمظهر تطبيق أصلي. لا حاجة لتفعيل وضع ملء الشاشة — يبقى شريط الحالة وشريط التنقل مرئيين"
+    }
+
     val blockSystemNavigationGestureLabel: String get() = when (lang) {
         AppLanguage.CHINESE -> "屏蔽系统导航手势"
         AppLanguage.ENGLISH -> "Block System Navigation Gesture"

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -838,9 +838,12 @@ data class WebViewShellConfig(
     @SerializedName("customUserAgent")
     val customUserAgent: String? = null,
 
+    @SerializedName("hideBrowserToolbar")
+    val hideBrowserToolbar: Boolean = false,
+
     @SerializedName("hideToolbar")
     val hideToolbar: Boolean = false,
-    
+
     @SerializedName("showStatusBarInFullscreen")
     val showStatusBarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示状态栏
     

--- a/app/src/main/java/com/webtoapp/ui/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/ui/data/model/WebApp.kt
@@ -341,6 +341,7 @@ data class WebViewConfig(
     val fullscreenEnabled: Boolean = true,
     val downloadEnabled: Boolean = true,
     val openExternalLinks: Boolean = false, // External链接是否在浏览器打开
+    val hideBrowserToolbar: Boolean = false, // Hide browser toolbar independently (no fullscreen needed)
     val hideToolbar: Boolean = false, // Hide工具栏（全屏模式，无浏览器特征）
     val showStatusBarInFullscreen: Boolean = false, // Fullscreen模式下是否显示状态栏
     val showNavigationBarInFullscreen: Boolean = false, // Fullscreen模式下是否显示导航栏

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -748,6 +748,13 @@ fun WebViewConfigCard(
                         icon = Icons.Outlined.Visibility
                     ) {
                         SettingsSwitch(
+                            title = Strings.hideBrowserToolbarLabel,
+                            subtitle = Strings.hideBrowserToolbarHint,
+                            checked = config.hideBrowserToolbar,
+                            onCheckedChange = { onConfigChange(config.copy(hideBrowserToolbar = it)) }
+                        )
+
+                        SettingsSwitch(
                             title = Strings.zoomSetting,
                             subtitle = Strings.zoomSettingHint,
                             checked = config.zoomEnabled,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -33,7 +33,7 @@ import com.webtoapp.data.model.WebViewConfig
 fun BoxScope.ShellScaffoldLayout(
     config: ShellConfig,
     appType: String,
-    hideToolbar: Boolean,
+    useImmersiveFullscreen: Boolean,
     // 状态
     isLoading: Boolean,
     loadProgress: Int,
@@ -71,8 +71,8 @@ fun BoxScope.ShellScaffoldLayout(
 ) {
     val context = LocalContext.current
 
-    // 是否显示顶部导航栏：非全屏模式或全屏模式下用户选择显示
-    val showToolbar = !hideToolbar || config.webViewConfig.showToolbarInFullscreen
+    // Never show browser toolbar in shell mode (exported app = no browser chrome)
+    val showToolbar = false
 
     // 读取键盘调整模式
     val keyboardAdjustMode = remember {
@@ -84,13 +84,12 @@ fun BoxScope.ShellScaffoldLayout(
     }
 
     Scaffold(
-        // 根据键盘调整模式设置 contentWindowInsets
-        // RESIZE 模式且全屏：保留 IME insets 以便 Compose 响应键盘
-        // blockSystemNavigationGesture=true 且全屏：屏蔽系统导航手势（consume gesture area）
-        // 全屏且未屏蔽导航手势：使用 ScaffoldDefaults 以保留系统手势区域
+        // In immersive fullscreen: handle keyboard and gesture insets specially.
+        // Otherwise: use default insets so content respects status bar and navigation bar.
         contentWindowInsets = when {
-            keyboardAdjustMode == KeyboardAdjustMode.RESIZE && hideToolbar -> WindowInsets.ime
-            hideToolbar && webViewConfig.blockSystemNavigationGesture -> WindowInsets(0)
+            keyboardAdjustMode == KeyboardAdjustMode.RESIZE && useImmersiveFullscreen -> WindowInsets.ime
+            useImmersiveFullscreen && webViewConfig.blockSystemNavigationGesture -> WindowInsets(0)
+            useImmersiveFullscreen -> ScaffoldDefaults.contentWindowInsets
             else -> ScaffoldDefaults.contentWindowInsets
         },
         modifier = Modifier,
@@ -122,21 +121,17 @@ fun BoxScope.ShellScaffoldLayout(
         val actualStatusBarPadding = if (statusBarHeightDp > 0) statusBarHeightDp.dp else systemStatusBarHeightDp
 
         val contentModifier = when {
-            hideToolbar && showToolbar -> {
-                // Fullscreen模式但显示toolbar：使用 Scaffold 的 padding（toolbar高度）
-                Modifier.fillMaxSize().padding(padding)
-            }
-            hideToolbar && config.webViewConfig.showStatusBarInFullscreen -> {
-                // Fullscreen模式但显示状态栏：内容需要在状态栏下方
-                // 使用自定义高度或系统默认高度作为顶部 padding
+            useImmersiveFullscreen && config.webViewConfig.showStatusBarInFullscreen -> {
+                // Immersive fullscreen with status bar visible: content below status bar
                 Modifier.fillMaxSize().padding(top = actualStatusBarPadding)
             }
-            hideToolbar -> {
-                // 完全全屏模式：内容铺满整个屏幕
+            useImmersiveFullscreen -> {
+                // Full immersive mode: content fills entire screen
                 Modifier.fillMaxSize()
             }
             else -> {
-                // 非全屏模式：使用 Scaffold 的 padding
+                // Normal mode (toolbar hidden, system bars visible): use Scaffold padding
+                // This ensures content is properly inset below status bar and above navigation bar
                 Modifier.fillMaxSize().padding(padding)
             }
         }
@@ -190,8 +185,8 @@ fun BoxScope.ShellScaffoldLayout(
 
             // 悬浮返回按钮（逻辑已提取到 ShellOverlays.kt）
             ShellFloatingBackButton(
-                hideToolbar = hideToolbar,
-                showToolbar = showToolbar,
+                hideToolbar = true,
+                showToolbar = false,
                 canGoBack = canGoBack,
                 forcedRunActive = forcedRunActive,
                 showFloatingBackButton = config.webViewConfig.showFloatingBackButton,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -33,7 +33,8 @@ import com.webtoapp.data.model.WebViewConfig
 fun BoxScope.ShellScaffoldLayout(
     config: ShellConfig,
     appType: String,
-    useImmersiveFullscreen: Boolean,
+    hideToolbar: Boolean,
+    hideBrowserToolbar: Boolean = false,
     // 状态
     isLoading: Boolean,
     loadProgress: Int,
@@ -71,8 +72,12 @@ fun BoxScope.ShellScaffoldLayout(
 ) {
     val context = LocalContext.current
 
-    // Never show browser toolbar in shell mode (exported app = no browser chrome)
-    val showToolbar = false
+    // Show toolbar: hidden if hideBrowserToolbar, or if fullscreen (unless showToolbarInFullscreen)
+    val showToolbar = when {
+        hideBrowserToolbar -> false
+        hideToolbar -> config.webViewConfig.showToolbarInFullscreen
+        else -> true
+    }
 
     // 读取键盘调整模式
     val keyboardAdjustMode = remember {
@@ -84,12 +89,13 @@ fun BoxScope.ShellScaffoldLayout(
     }
 
     Scaffold(
-        // In immersive fullscreen: handle keyboard and gesture insets specially.
-        // Otherwise: use default insets so content respects status bar and navigation bar.
+        // 根据键盘调整模式设置 contentWindowInsets
+        // RESIZE 模式且全屏：保留 IME insets 以便 Compose 响应键盘
+        // blockSystemNavigationGesture=true 且全屏：屏蔽系统导航手势（consume gesture area）
+        // 全屏且未屏蔽导航手势：使用 ScaffoldDefaults 以保留系统手势区域
         contentWindowInsets = when {
-            keyboardAdjustMode == KeyboardAdjustMode.RESIZE && useImmersiveFullscreen -> WindowInsets.ime
-            useImmersiveFullscreen && webViewConfig.blockSystemNavigationGesture -> WindowInsets(0)
-            useImmersiveFullscreen -> ScaffoldDefaults.contentWindowInsets
+            keyboardAdjustMode == KeyboardAdjustMode.RESIZE && hideToolbar -> WindowInsets.ime
+            hideToolbar && webViewConfig.blockSystemNavigationGesture -> WindowInsets(0)
             else -> ScaffoldDefaults.contentWindowInsets
         },
         modifier = Modifier,
@@ -121,17 +127,21 @@ fun BoxScope.ShellScaffoldLayout(
         val actualStatusBarPadding = if (statusBarHeightDp > 0) statusBarHeightDp.dp else systemStatusBarHeightDp
 
         val contentModifier = when {
-            useImmersiveFullscreen && config.webViewConfig.showStatusBarInFullscreen -> {
-                // Immersive fullscreen with status bar visible: content below status bar
+            hideToolbar && showToolbar -> {
+                // Fullscreen模式但显示toolbar：使用 Scaffold 的 padding（toolbar高度）
+                Modifier.fillMaxSize().padding(padding)
+            }
+            hideToolbar && config.webViewConfig.showStatusBarInFullscreen -> {
+                // Fullscreen模式但显示状态栏：内容需要在状态栏下方
+                // 使用自定义高度或系统默认高度作为顶部 padding
                 Modifier.fillMaxSize().padding(top = actualStatusBarPadding)
             }
-            useImmersiveFullscreen -> {
-                // Full immersive mode: content fills entire screen
+            hideToolbar -> {
+                // 完全全屏模式：内容铺满整个屏幕
                 Modifier.fillMaxSize()
             }
             else -> {
-                // Normal mode (toolbar hidden, system bars visible): use Scaffold padding
-                // This ensures content is properly inset below status bar and above navigation bar
+                // 非全屏模式：使用 Scaffold 的 padding
                 Modifier.fillMaxSize().padding(padding)
             }
         }
@@ -185,8 +195,8 @@ fun BoxScope.ShellScaffoldLayout(
 
             // 悬浮返回按钮（逻辑已提取到 ShellOverlays.kt）
             ShellFloatingBackButton(
-                hideToolbar = true,
-                showToolbar = false,
+                hideToolbar = hideToolbar || hideBrowserToolbar,
+                showToolbar = showToolbar,
                 canGoBack = canGoBack,
                 forcedRunActive = forcedRunActive,
                 showFloatingBackButton = config.webViewConfig.showFloatingBackButton,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -311,13 +311,14 @@ fun ShellScreen(
         com.webtoapp.core.webview.WebViewManager(context, adBlocker)
     }
 
-    // Yes否隐藏工具栏（全屏模式）
-    val hideToolbar = config.webViewConfig.hideToolbar
+    // Immersive fullscreen (hides system bars) - controlled by hideToolbar config
+    // Toolbar is always hidden in shell mode (no browser chrome)
+    val useImmersiveFullscreen = config.webViewConfig.hideToolbar
     // 下拉刷新开关
     val swipeRefreshEnabled = config.webViewConfig.swipeRefreshEnabled
 
-    LaunchedEffect(hideToolbar) {
-        onFullscreenModeChanged(hideToolbar)
+    LaunchedEffect(useImmersiveFullscreen) {
+        onFullscreenModeChanged(useImmersiveFullscreen)
     }
     
     // 关闭启动画面的回调（提前定义）
@@ -338,7 +339,7 @@ fun ShellScreen(
     ShellScaffoldLayout(
         config = config,
         appType = appType,
-        hideToolbar = hideToolbar,
+        useImmersiveFullscreen = useImmersiveFullscreen,
         isLoading = isLoading,
         loadProgress = loadProgress,
         pageTitle = pageTitle,
@@ -444,9 +445,9 @@ fun ShellScreen(
         )
     }
     
-    // Status bar背景覆盖层（在全屏模式下显示状态栏时）
+    // Status bar背景覆盖层（在沉浸式全屏模式下显示状态栏时）
     // 放在 Box 内部最上层，覆盖在所有内容之上，使用 align 固定在顶部
-    if (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) {
+    if (useImmersiveFullscreen && config.webViewConfig.showStatusBarInFullscreen) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -311,14 +311,15 @@ fun ShellScreen(
         com.webtoapp.core.webview.WebViewManager(context, adBlocker)
     }
 
-    // Immersive fullscreen (hides system bars) - controlled by hideToolbar config
-    // Toolbar is always hidden in shell mode (no browser chrome)
-    val useImmersiveFullscreen = config.webViewConfig.hideToolbar
+    // Fullscreen mode (immersive: hides system bars)
+    val hideToolbar = config.webViewConfig.hideToolbar
+    // Hide browser toolbar independently (no fullscreen needed)
+    val hideBrowserToolbar = config.webViewConfig.hideBrowserToolbar
     // 下拉刷新开关
     val swipeRefreshEnabled = config.webViewConfig.swipeRefreshEnabled
 
-    LaunchedEffect(useImmersiveFullscreen) {
-        onFullscreenModeChanged(useImmersiveFullscreen)
+    LaunchedEffect(hideToolbar) {
+        onFullscreenModeChanged(hideToolbar)
     }
     
     // 关闭启动画面的回调（提前定义）
@@ -339,7 +340,8 @@ fun ShellScreen(
     ShellScaffoldLayout(
         config = config,
         appType = appType,
-        useImmersiveFullscreen = useImmersiveFullscreen,
+        hideToolbar = hideToolbar,
+        hideBrowserToolbar = hideBrowserToolbar,
         isLoading = isLoading,
         loadProgress = loadProgress,
         pageTitle = pageTitle,
@@ -445,9 +447,9 @@ fun ShellScreen(
         )
     }
     
-    // Status bar背景覆盖层（在沉浸式全屏模式下显示状态栏时）
+    // Status bar背景覆盖层（在全屏模式下显示状态栏时）
     // 放在 Box 内部最上层，覆盖在所有内容之上，使用 align 固定在顶部
-    if (useImmersiveFullscreen && config.webViewConfig.showStatusBarInFullscreen) {
+    if (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -34,6 +34,7 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         customUserAgent = config.webViewConfig.customUserAgent,
         openExternalLinks = config.webViewConfig.openExternalLinks,
         downloadEnabled = true, // 确保下载功能始终启用
+        hideBrowserToolbar = config.webViewConfig.hideBrowserToolbar,
         hideToolbar = config.webViewConfig.hideToolbar,
         showStatusBarInFullscreen = config.webViewConfig.showStatusBarInFullscreen,
         showNavigationBarInFullscreen = config.webViewConfig.showNavigationBarInFullscreen,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2133,21 +2133,24 @@ fun WebViewScreen(
         }
     }
     
-    // Yes否隐藏工具栏（全屏模式）- 测试模式下始终显示工具栏
-    val hideToolbar = !isTestMode && webApp?.webViewConfig?.hideToolbar == true
-    // 是否在全屏模式下显示顶部导航栏
-    val showToolbarInPreview = !hideToolbar || webApp?.webViewConfig?.showToolbarInFullscreen == true
-    
-    LaunchedEffect(hideToolbar) {
-        onFullscreenModeChanged(hideToolbar)
+    // Always hide browser toolbar in non-test mode to remove browser chrome from the app.
+    // Immersive fullscreen (hiding system bars) is controlled separately by the hideToolbar config.
+    // This decoupling allows: toolbar always hidden + system bars visible when fullscreen mode is OFF.
+    val useImmersiveFullscreen = !isTestMode && webApp?.webViewConfig?.hideToolbar == true
+    // Show the browser toolbar only in test mode
+    val showToolbarInPreview = isTestMode
+
+    LaunchedEffect(useImmersiveFullscreen) {
+        onFullscreenModeChanged(useImmersiveFullscreen)
     }
 
     // 外层 Box 用于放置状态栏覆盖层（需要在 Scaffold 外部才能正确覆盖状态栏区域）
     Box(modifier = Modifier.fillMaxSize()) {
     Scaffold(
-        // 在沉浸式模式下，不添加任何内边距（除非显示toolbar）
-        contentWindowInsets = if (hideToolbar && !showToolbarInPreview) WindowInsets(0) else if (hideToolbar && showToolbarInPreview) WindowInsets(0) else ScaffoldDefaults.contentWindowInsets,
-        modifier = if (hideToolbar && !showToolbarInPreview) Modifier.fillMaxSize() else if (hideToolbar) Modifier.fillMaxSize() else Modifier,
+        // In immersive fullscreen, remove all insets (content fills behind system bars).
+        // Otherwise, use default insets so content respects status bar and navigation bar.
+        contentWindowInsets = if (useImmersiveFullscreen) WindowInsets(0) else ScaffoldDefaults.contentWindowInsets,
+        modifier = if (useImmersiveFullscreen) Modifier.fillMaxSize() else Modifier,
         topBar = {
             if (showToolbarInPreview) {
                 TopAppBar(
@@ -2298,21 +2301,17 @@ fun WebViewScreen(
         val actualStatusBarPadding = if (statusBarHeightDp > 0) statusBarHeightDp.dp else systemStatusBarHeightDp
         
         val contentModifier = when {
-            hideToolbar && showToolbarInPreview -> {
-                // Fullscreen模式但显示toolbar：使用 Scaffold 的 padding（toolbar高度）
-                Modifier.fillMaxSize().padding(padding)
-            }
-            hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true -> {
-                // Fullscreen模式但显示状态栏：内容需要在状态栏下方
-                // 使用自定义高度或系统默认高度作为顶部 padding
+            useImmersiveFullscreen && webApp?.webViewConfig?.showStatusBarInFullscreen == true -> {
+                // Immersive fullscreen with status bar visible: content below status bar
                 Modifier.fillMaxSize().padding(top = actualStatusBarPadding)
             }
-            hideToolbar -> {
-                // 完全全屏模式：内容铺满整个屏幕
+            useImmersiveFullscreen -> {
+                // Full immersive mode: content fills entire screen
                 Modifier.fillMaxSize()
             }
             else -> {
-                // 非全屏模式：使用 Scaffold 的 padding
+                // Normal mode (toolbar hidden, system bars visible): use Scaffold padding
+                // This ensures content is properly inset below status bar and above navigation bar
                 Modifier.fillMaxSize().padding(padding)
             }
         }
@@ -2562,10 +2561,9 @@ fun WebViewScreen(
                 )
             }
 
-            // 全屏模式下的悬浮返回按钮（当工具栏隐藏且可以后退时显示）
-            // 如果用户选择了显示toolbar则不需要悬浮按钮
-            // 自动淡出：显示后 3 秒开始淡化，点击时重置透明度
-            if (hideToolbar && !showToolbarInPreview && canGoBack) {
+            // Floating back button when toolbar is hidden and user can go back
+            // Auto-fades: visible for 3s then fades to low opacity, resets on tap
+            if (!showToolbarInPreview && canGoBack) {
                 var fabAlpha by remember { mutableFloatStateOf(0.9f) }
                 var fadeKey by remember { mutableIntStateOf(0) }
                 
@@ -2643,9 +2641,9 @@ fun WebViewScreen(
         }
     }
     
-    // Status bar背景覆盖层（在全屏模式下显示状态栏时）
+    // Status bar背景覆盖层（在沉浸式全屏模式下显示状态栏时）
     // 放在 Scaffold 外部，才能正确覆盖在状态栏区域
-    if (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) {
+    if (useImmersiveFullscreen && webApp?.webViewConfig?.showStatusBarInFullscreen == true) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2133,24 +2133,28 @@ fun WebViewScreen(
         }
     }
     
-    // Always hide browser toolbar in non-test mode to remove browser chrome from the app.
-    // Immersive fullscreen (hiding system bars) is controlled separately by the hideToolbar config.
-    // This decoupling allows: toolbar always hidden + system bars visible when fullscreen mode is OFF.
-    val useImmersiveFullscreen = !isTestMode && webApp?.webViewConfig?.hideToolbar == true
-    // Show the browser toolbar only in test mode
-    val showToolbarInPreview = isTestMode
+    // Fullscreen mode (immersive: hides system bars) - test mode always shows toolbar
+    val hideToolbar = !isTestMode && webApp?.webViewConfig?.hideToolbar == true
+    // Hide browser toolbar independently (no fullscreen needed, system bars stay visible)
+    val hideBrowserToolbar = !isTestMode && webApp?.webViewConfig?.hideBrowserToolbar == true
+    // Show toolbar: hidden if fullscreen (unless showToolbarInFullscreen), or if hideBrowserToolbar
+    val showToolbarInPreview = when {
+        isTestMode -> true
+        hideBrowserToolbar -> false
+        hideToolbar -> webApp?.webViewConfig?.showToolbarInFullscreen == true
+        else -> true
+    }
 
-    LaunchedEffect(useImmersiveFullscreen) {
-        onFullscreenModeChanged(useImmersiveFullscreen)
+    LaunchedEffect(hideToolbar) {
+        onFullscreenModeChanged(hideToolbar)
     }
 
     // 外层 Box 用于放置状态栏覆盖层（需要在 Scaffold 外部才能正确覆盖状态栏区域）
     Box(modifier = Modifier.fillMaxSize()) {
     Scaffold(
-        // In immersive fullscreen, remove all insets (content fills behind system bars).
-        // Otherwise, use default insets so content respects status bar and navigation bar.
-        contentWindowInsets = if (useImmersiveFullscreen) WindowInsets(0) else ScaffoldDefaults.contentWindowInsets,
-        modifier = if (useImmersiveFullscreen) Modifier.fillMaxSize() else Modifier,
+        // 在沉浸式模式下，不添加任何内边距（除非显示toolbar）
+        contentWindowInsets = if (hideToolbar && !showToolbarInPreview) WindowInsets(0) else if (hideToolbar && showToolbarInPreview) WindowInsets(0) else ScaffoldDefaults.contentWindowInsets,
+        modifier = if (hideToolbar && !showToolbarInPreview) Modifier.fillMaxSize() else if (hideToolbar) Modifier.fillMaxSize() else Modifier,
         topBar = {
             if (showToolbarInPreview) {
                 TopAppBar(
@@ -2301,17 +2305,21 @@ fun WebViewScreen(
         val actualStatusBarPadding = if (statusBarHeightDp > 0) statusBarHeightDp.dp else systemStatusBarHeightDp
         
         val contentModifier = when {
-            useImmersiveFullscreen && webApp?.webViewConfig?.showStatusBarInFullscreen == true -> {
-                // Immersive fullscreen with status bar visible: content below status bar
+            hideToolbar && showToolbarInPreview -> {
+                // Fullscreen模式但显示toolbar：使用 Scaffold 的 padding（toolbar高度）
+                Modifier.fillMaxSize().padding(padding)
+            }
+            hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true -> {
+                // Fullscreen模式但显示状态栏：内容需要在状态栏下方
+                // 使用自定义高度或系统默认高度作为顶部 padding
                 Modifier.fillMaxSize().padding(top = actualStatusBarPadding)
             }
-            useImmersiveFullscreen -> {
-                // Full immersive mode: content fills entire screen
+            hideToolbar -> {
+                // 完全全屏模式：内容铺满整个屏幕
                 Modifier.fillMaxSize()
             }
             else -> {
-                // Normal mode (toolbar hidden, system bars visible): use Scaffold padding
-                // This ensures content is properly inset below status bar and above navigation bar
+                // 非全屏模式：使用 Scaffold 的 padding
                 Modifier.fillMaxSize().padding(padding)
             }
         }
@@ -2561,9 +2569,9 @@ fun WebViewScreen(
                 )
             }
 
-            // Floating back button when toolbar is hidden and user can go back
+            // Floating back button when toolbar is hidden (fullscreen or hideBrowserToolbar)
             // Auto-fades: visible for 3s then fades to low opacity, resets on tap
-            if (!showToolbarInPreview && canGoBack) {
+            if ((hideToolbar || hideBrowserToolbar) && !showToolbarInPreview && canGoBack) {
                 var fabAlpha by remember { mutableFloatStateOf(0.9f) }
                 var fadeKey by remember { mutableIntStateOf(0) }
                 
@@ -2641,9 +2649,9 @@ fun WebViewScreen(
         }
     }
     
-    // Status bar背景覆盖层（在沉浸式全屏模式下显示状态栏时）
+    // Status bar背景覆盖层（在全屏模式下显示状态栏时）
     // 放在 Scaffold 外部，才能正确覆盖在状态栏区域
-    if (useImmersiveFullscreen && webApp?.webViewConfig?.showStatusBarInFullscreen == true) {
+    if (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,


### PR DESCRIPTION
## Problem

Currently, the only way to hide the browser toolbar (TopAppBar) is to enable **Fullscreen Mode**, which also triggers Android's immersive mode — hiding the status bar and navigation bar. This creates a catch-22 for users who want a native app look:

- **Fullscreen OFF**: Browser toolbar is visible (unwanted browser chrome)
- **Fullscreen ON**: Toolbar is hidden, but website footer elements go behind the Android navigation bar, making the app unusable

## Solution

Add a new **"Hide Browser Toolbar"** toggle in the **Content & Display** settings section, independent of Fullscreen Mode.

| Hide Browser Toolbar | Fullscreen Mode | Result |
|---|---|---|
| OFF | OFF | Toolbar visible, normal system bars *(original behavior)* |
| **ON** | **OFF** | **No toolbar, system bars visible, content respects insets** |
| OFF | ON | Immersive fullscreen *(unchanged)* |
| ON | ON | Immersive fullscreen *(unchanged)* |

## Backward compatibility

- Default value is `false` — existing apps are unaffected
- Fullscreen Mode behavior is completely unchanged
- No breaking changes to config format (additive field only)
