### PR TITLE
fix: AUTO orientation mode now respects system auto-rotate setting

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
@@ -622,7 +622,8 @@ if (NativeBridge.isFullscreen()) {
                 activity.requestedOrientation = when (orientation.lowercase()) {
                     "landscape" -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
                     "portrait" -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    "auto", "sensor" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                    "auto" -> ActivityInfo.SCREEN_ORIENTATION_USER
+                    "sensor" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
                     "reverse_landscape" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
                     "reverse_portrait" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
                     else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
@@ -681,7 +682,7 @@ if (NativeBridge.isFullscreen()) {
         scope.launch(Dispatchers.Main) {
             try {
                 val activity = context as? Activity ?: return@launch
-                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                 AppLogger.d("NativeBridge", "屏幕方向已解锁")
             } catch (e: Exception) {
                 AppLogger.e("NativeBridge", "解锁屏幕方向失败", e)

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -226,8 +226,8 @@ fun ShellScreen(
                 activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             }
             "AUTO" -> {
-                // ★ 自动旋转：跟随重力感应，平板设备友好
-                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                // ★ Auto rotation: respects the system auto-rotate setting
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
             }
             else -> {
                 if (TvUtils.isTv(context)) {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -813,7 +813,7 @@ fun WebViewScreen(
                     activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
                 }
                 com.webtoapp.data.model.OrientationMode.AUTO -> {
-                    activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                    activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                 }
                 com.webtoapp.data.model.OrientationMode.PORTRAIT -> {
                     if (!com.webtoapp.util.TvUtils.isTv(context)) {
@@ -919,8 +919,8 @@ fun WebViewScreen(
                         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
                     }
                     com.webtoapp.data.model.OrientationMode.AUTO -> {
-                        // ★ 自动旋转：跟随重力感应，平板设备友好
-                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                        // ★ Auto rotation: respects the system auto-rotate setting
+                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                     }
                     com.webtoapp.data.model.OrientationMode.PORTRAIT -> {
                         if (com.webtoapp.util.TvUtils.isTv(context)) {


### PR DESCRIPTION
The AUTO orientation mode was using SCREEN_ORIENTATION_SENSOR which always follows the device sensor regardless of the system auto-rotate setting. This meant the app would rotate even when the user had disabled auto-rotate in Android settings.

Changed to SCREEN_ORIENTATION_USER which respects the system setting:
- Auto-rotate ON → app rotates with device
- Auto-rotate OFF → app stays in current orientation

This matches the expected native app behavior. The JavaScript bridge "sensor" option still uses SCREEN_ORIENTATION_SENSOR for web apps that explicitly need sensor-based rotation.