### PR TITLE
feat: status bar improvements, bug fixes & UX enhancements

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -312,6 +312,7 @@
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
             android:exported="false"
             android:hardwareAccelerated="true"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.WebToApp.Shell" />
         

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -294,7 +294,7 @@
         <!-- 使用Shell主题，支持动态控制是否全屏 -->
         <activity
             android:name=".ui.webview.WebViewActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
+            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
             android:exported="true"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize"
@@ -309,7 +309,7 @@
         <!-- 使用Shell主题，支持动态控制是否全屏 -->
         <activity
             android:name=".ui.shell.ShellActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
+            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
             android:exported="false"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize"

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -2731,6 +2731,7 @@ fun WebApp.toApkConfig(packageName: String): ApkConfig {
         // Use user-configured hideToolbar setting, no longer force HTML/media apps to hide toolbar
         // User can choose whether to enable fullscreen mode when creating app
         hideToolbar = webViewConfig.hideToolbar,
+        hideBrowserToolbar = webViewConfig.hideBrowserToolbar,
         showStatusBarInFullscreen = webViewConfig.showStatusBarInFullscreen,
         showNavigationBarInFullscreen = webViewConfig.showNavigationBarInFullscreen,
         showToolbarInFullscreen = webViewConfig.showToolbarInFullscreen,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -2773,6 +2773,13 @@ fun WebApp.toApkConfig(packageName: String): ApkConfig {
         statusBarBackgroundImage = webViewConfig.statusBarBackgroundImage,
         statusBarBackgroundAlpha = webViewConfig.statusBarBackgroundAlpha,
         statusBarHeightDp = webViewConfig.statusBarHeightDp,
+        // Status bar dark mode config
+        statusBarColorModeDark = webViewConfig.statusBarColorModeDark.name,
+        statusBarColorDark = webViewConfig.statusBarColorDark,
+        statusBarDarkIconsDark = webViewConfig.statusBarDarkIconsDark,
+        statusBarBackgroundTypeDark = webViewConfig.statusBarBackgroundTypeDark.name,
+        statusBarBackgroundImageDark = webViewConfig.statusBarBackgroundImageDark,
+        statusBarBackgroundAlphaDark = webViewConfig.statusBarBackgroundAlphaDark,
         longPressMenuEnabled = webViewConfig.longPressMenuEnabled,
         longPressMenuStyle = webViewConfig.longPressMenuStyle.name,
         adBlockToggleEnabled = webViewConfig.adBlockToggleEnabled,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -142,6 +142,7 @@ class ApkTemplate(private val context: Context) {
                 "swipeRefreshEnabled": ${config.swipeRefreshEnabled},
                 "fullscreenEnabled": ${config.fullscreenEnabled},
                 "hideToolbar": ${config.hideToolbar},
+                "hideBrowserToolbar": ${config.hideBrowserToolbar},
                 "showStatusBarInFullscreen": ${config.showStatusBarInFullscreen},
                 "showNavigationBarInFullscreen": ${config.showNavigationBarInFullscreen},
                 "showToolbarInFullscreen": ${config.showToolbarInFullscreen},
@@ -526,6 +527,7 @@ data class ApkConfig(
     val userAgentMode: String = "DEFAULT", // User-Agent 模式: DEFAULT, CHROME_MOBILE, CHROME_DESKTOP, SAFARI_MOBILE, SAFARI_DESKTOP, FIREFOX_MOBILE, FIREFOX_DESKTOP, EDGE_MOBILE, EDGE_DESKTOP, CUSTOM
     val customUserAgent: String? = null, // Custom User-Agent（仅 CUSTOM 模式使用）
     val hideToolbar: Boolean = false,
+    val hideBrowserToolbar: Boolean = false,
     val showStatusBarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示状态栏
     val showNavigationBarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示导航栏
     val showToolbarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示顶部导航栏

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -157,6 +157,12 @@ class ApkTemplate(private val context: Context) {
                 "statusBarBackgroundImage": ${if (config.statusBarBackgroundType == "IMAGE" && !config.statusBarBackgroundImage.isNullOrEmpty()) "\"statusbar_background.png\"" else "null"},
                 "statusBarBackgroundAlpha": ${config.statusBarBackgroundAlpha},
                 "statusBarHeightDp": ${config.statusBarHeightDp},
+                "statusBarColorModeDark": "${config.statusBarColorModeDark}",
+                "statusBarColorDark": ${config.statusBarColorDark?.let { "\"${escapeJson(it)}\"" } ?: "null"},
+                "statusBarDarkIconsDark": ${config.statusBarDarkIconsDark ?: "null"},
+                "statusBarBackgroundTypeDark": "${config.statusBarBackgroundTypeDark}",
+                "statusBarBackgroundImageDark": ${if (config.statusBarBackgroundTypeDark == "IMAGE" && !config.statusBarBackgroundImageDark.isNullOrEmpty()) "\"statusbar_background_dark.png\"" else "null"},
+                "statusBarBackgroundAlphaDark": ${config.statusBarBackgroundAlphaDark},
                 "longPressMenuEnabled": ${config.longPressMenuEnabled},
                 "longPressMenuStyle": "${config.longPressMenuStyle}",
                 "adBlockToggleEnabled": ${config.adBlockToggleEnabled},
@@ -543,6 +549,13 @@ data class ApkConfig(
     val statusBarBackgroundImage: String? = null, // Cropped image path
     val statusBarBackgroundAlpha: Float = 1.0f, // Alpha 0.0-1.0
     val statusBarHeightDp: Int = 0, // Custom高度dp（0=系统默认）
+    // Status bar深色模式配置
+    val statusBarColorModeDark: String = "THEME",
+    val statusBarColorDark: String? = null,
+    val statusBarDarkIconsDark: Boolean? = null,
+    val statusBarBackgroundTypeDark: String = "COLOR",
+    val statusBarBackgroundImageDark: String? = null,
+    val statusBarBackgroundAlphaDark: Float = 1.0f,
     val longPressMenuEnabled: Boolean = true, // Yes否启用长按菜单
     val longPressMenuStyle: String = "FULL", // DISABLED, SIMPLE, FULL
     val adBlockToggleEnabled: Boolean = false, // Allow用户在运行时切换广告拦截开关

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -10405,7 +10405,19 @@ object Strings {
         AppLanguage.ENGLISH -> "Allow video fullscreen playback"
         AppLanguage.ARABIC -> "السماح بتشغيل الفيديو بملء الشاشة"
     }
-    
+
+    val hideBrowserToolbarLabel: String get() = when (lang) {
+        AppLanguage.CHINESE -> "隐藏浏览器工具栏"
+        AppLanguage.ENGLISH -> "Hide Browser Toolbar"
+        AppLanguage.ARABIC -> "إخفاء شريط أدوات المتصفح"
+    }
+
+    val hideBrowserToolbarHint: String get() = when (lang) {
+        AppLanguage.CHINESE -> "隐藏顶部浏览器导航栏（独立于全屏模式）"
+        AppLanguage.ENGLISH -> "Hide the top browser navigation bar (independent of fullscreen mode)"
+        AppLanguage.ARABIC -> "إخفاء شريط التنقل العلوي للمتصفح (مستقل عن وضع ملء الشاشة)"
+    }
+
     val externalLinksSetting: String get() = when (lang) {
         AppLanguage.CHINESE -> "外部链接"
         AppLanguage.ENGLISH -> "External Links"

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -18654,7 +18654,19 @@ object Strings {
         AppLanguage.ENGLISH -> "Status Bar Style Config"
         AppLanguage.ARABIC -> "إعدادات نمط شريط الحالة"
     }
-    
+
+    val statusBarLightModeLabel: String get() = when (lang) {
+        AppLanguage.CHINESE -> "浅色模式"
+        AppLanguage.ENGLISH -> "Light Mode"
+        AppLanguage.ARABIC -> "الوضع الفاتح"
+    }
+
+    val statusBarDarkModeLabel: String get() = when (lang) {
+        AppLanguage.CHINESE -> "深色模式"
+        AppLanguage.ENGLISH -> "Dark Mode"
+        AppLanguage.ARABIC -> "الوضع الداكن"
+    }
+
     val splashHint: String get() = when (lang) {
         AppLanguage.CHINESE -> "设置应用启动时显示的图片或视频"
         AppLanguage.ENGLISH -> "Set image or video to display when app launches"

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -840,6 +840,9 @@ data class WebViewShellConfig(
 
     @SerializedName("hideToolbar")
     val hideToolbar: Boolean = false,
+
+    @SerializedName("hideBrowserToolbar")
+    val hideBrowserToolbar: Boolean = false,
     
     @SerializedName("showStatusBarInFullscreen")
     val showStatusBarInFullscreen: Boolean = false,  // Fullscreen模式下是否显示状态栏

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -882,7 +882,26 @@ data class WebViewShellConfig(
     
     @SerializedName("statusBarHeightDp")
     val statusBarHeightDp: Int = 0, // Custom高度dp（0=系统默认）
-    
+
+    // Status bar深色模式配置
+    @SerializedName("statusBarColorModeDark")
+    val statusBarColorModeDark: String = "THEME",
+
+    @SerializedName("statusBarColorDark")
+    val statusBarColorDark: String? = null,
+
+    @SerializedName("statusBarDarkIconsDark")
+    val statusBarDarkIconsDark: Boolean? = null,
+
+    @SerializedName("statusBarBackgroundTypeDark")
+    val statusBarBackgroundTypeDark: String = "COLOR",
+
+    @SerializedName("statusBarBackgroundImageDark")
+    val statusBarBackgroundImageDark: String? = null,
+
+    @SerializedName("statusBarBackgroundAlphaDark")
+    val statusBarBackgroundAlphaDark: Float = 1.0f,
+
     @SerializedName("longPressMenuEnabled")
     val longPressMenuEnabled: Boolean = true, // Yes否启用长按菜单
     

--- a/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/NativeBridge.kt
@@ -622,7 +622,8 @@ if (NativeBridge.isFullscreen()) {
                 activity.requestedOrientation = when (orientation.lowercase()) {
                     "landscape" -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
                     "portrait" -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    "auto", "sensor" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                    "auto" -> ActivityInfo.SCREEN_ORIENTATION_USER
+                    "sensor" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
                     "reverse_landscape" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
                     "reverse_portrait" -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
                     else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
@@ -681,7 +682,7 @@ if (NativeBridge.isFullscreen()) {
         scope.launch(Dispatchers.Main) {
             try {
                 val activity = context as? Activity ?: return@launch
-                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                 AppLogger.d("NativeBridge", "屏幕方向已解锁")
             } catch (e: Exception) {
                 AppLogger.e("NativeBridge", "解锁屏幕方向失败", e)

--- a/app/src/main/java/com/webtoapp/ui/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/ui/data/model/WebApp.kt
@@ -342,6 +342,7 @@ data class WebViewConfig(
     val downloadEnabled: Boolean = true,
     val openExternalLinks: Boolean = false, // External链接是否在浏览器打开
     val hideToolbar: Boolean = false, // Hide工具栏（全屏模式，无浏览器特征）
+    val hideBrowserToolbar: Boolean = false, // Hide浏览器工具栏（独立于全屏模式）
     val showStatusBarInFullscreen: Boolean = false, // Fullscreen模式下是否显示状态栏
     val showNavigationBarInFullscreen: Boolean = false, // Fullscreen模式下是否显示导航栏
     val showToolbarInFullscreen: Boolean = false, // Fullscreen模式下是否显示顶部导航栏

--- a/app/src/main/java/com/webtoapp/ui/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/ui/data/model/WebApp.kt
@@ -357,6 +357,13 @@ data class WebViewConfig(
     val statusBarBackgroundImage: String? = null, // Cropped image path
     val statusBarBackgroundAlpha: Float = 1.0f, // Alpha 0.0-1.0
     val statusBarHeightDp: Int = 0, // Custom高度dp（0=系统默认）
+    // Status bar深色模式配置
+    val statusBarColorModeDark: StatusBarColorMode = StatusBarColorMode.THEME,
+    val statusBarColorDark: String? = null,
+    val statusBarDarkIconsDark: Boolean? = null,
+    val statusBarBackgroundTypeDark: StatusBarBackgroundType = StatusBarBackgroundType.COLOR,
+    val statusBarBackgroundImageDark: String? = null,
+    val statusBarBackgroundAlphaDark: Float = 1.0f,
     val longPressMenuEnabled: Boolean = true, // Yes否启用长按菜单
     val longPressMenuStyle: LongPressMenuStyle = LongPressMenuStyle.FULL, // Long press menu style
     val adBlockToggleEnabled: Boolean = false, // Allow用户在运行时切换广告拦截开关

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -260,7 +260,6 @@ fun CreateAppScreen(
                 showStatusBar = editState.webViewConfig.showStatusBarInFullscreen,
                 showNavigationBar = editState.webViewConfig.showNavigationBarInFullscreen,
                 showToolbar = editState.webViewConfig.showToolbarInFullscreen,
-                webViewConfig = editState.webViewConfig,
                 onEnabledChange = {
                     viewModel.updateEditState {
                         copy(webViewConfig = webViewConfig.copy(hideToolbar = it))
@@ -281,6 +280,11 @@ fun CreateAppScreen(
                         copy(webViewConfig = webViewConfig.copy(showToolbarInFullscreen = it))
                     }
                 },
+            )
+
+            // Status Bar Style Config (standalone, works without fullscreen)
+            StatusBarStyleCard(
+                webViewConfig = editState.webViewConfig,
                 onWebViewConfigChange = { newConfig ->
                     viewModel.updateEditState {
                         copy(webViewConfig = newConfig)

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1406,6 +1406,42 @@ fun UserAgentCard(
 }
 
 /**
+ * Status Bar Style Config card — standalone, works without fullscreen mode
+ */
+@Composable
+fun StatusBarStyleCard(
+    webViewConfig: WebViewConfig,
+    onWebViewConfigChange: (WebViewConfig) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            CollapsibleCardHeader(
+                icon = Icons.Outlined.Tune,
+                title = Strings.statusBarStyleConfigLabel,
+                checked = expanded,
+                onCheckedChange = { expanded = it }
+            )
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = CardExpandTransition,
+                exit = CardCollapseTransition
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    StatusBarConfigCard(
+                        config = webViewConfig,
+                        onConfigChange = onWebViewConfigChange
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
  * 全屏模式卡片
  */
 @Composable
@@ -1414,15 +1450,11 @@ fun FullscreenModeCard(
     showStatusBar: Boolean = false,
     showNavigationBar: Boolean = false,
     showToolbar: Boolean = false,
-    webViewConfig: WebViewConfig = WebViewConfig(),
     onEnabledChange: (Boolean) -> Unit,
     onShowStatusBarChange: (Boolean) -> Unit = {},
     onShowNavigationBarChange: (Boolean) -> Unit = {},
     onShowToolbarChange: (Boolean) -> Unit = {},
-    onWebViewConfigChange: (WebViewConfig) -> Unit = {}
 ) {
-    var statusBarConfigExpanded by remember { mutableStateOf(false) }
-    
     EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             CollapsibleCardHeader(
@@ -1515,70 +1547,6 @@ fun FullscreenModeCard(
                     )
                 }
                 
-                // Status bar配置（仅在显示状态栏时可用）
-                if (showStatusBar) {
-                    Spacer(modifier = Modifier.height(12.dp))
-                    
-                    // Status bar配置展开/收起
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(8.dp))
-                            .clickable { statusBarConfigExpanded = !statusBarConfigExpanded },
-                        color = MaterialTheme.colorScheme.secondaryContainer
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(12.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Tune,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
-                                    tint = MaterialTheme.colorScheme.onSecondaryContainer
-                                )
-                                Text(
-                                    text = Strings.statusBarStyleConfigLabel,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer
-                                )
-                            }
-                            val statusBarArrowRotation by animateFloatAsState(
-                                targetValue = if (statusBarConfigExpanded) 180f else 0f,
-                                animationSpec = spring(dampingRatio = 0.75f, stiffness = Spring.StiffnessMediumLow),
-                                label = "statusBarArrow"
-                            )
-                            Icon(
-                                Icons.Default.ExpandMore,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                modifier = Modifier.graphicsLayer { rotationZ = statusBarArrowRotation }
-                            )
-                        }
-                    }
-                    
-                    // Status bar配置内容
-                    AnimatedVisibility(
-                        visible = statusBarConfigExpanded,
-                        enter = CardExpandTransition,
-                        exit = CardCollapseTransition
-                    ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(12.dp))
-                            StatusBarConfigCard(
-                                config = webViewConfig,
-                                onConfigChange = onWebViewConfigChange
-                            )
-                        }
-                    }
-                }
               }
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1417,12 +1417,40 @@ fun StatusBarStyleCard(
 
     EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
-            CollapsibleCardHeader(
-                icon = Icons.Outlined.Tune,
-                title = Strings.statusBarStyleConfigLabel,
-                checked = expanded,
-                onCheckedChange = { expanded = it }
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { expanded = !expanded }
+                    .padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        Icons.Outlined.Tune,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = Strings.statusBarStyleConfigLabel,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+                val arrowRotation by animateFloatAsState(
+                    targetValue = if (expanded) 180f else 0f,
+                    animationSpec = spring(dampingRatio = 0.75f, stiffness = Spring.StiffnessMediumLow),
+                    label = "statusBarArrow"
+                )
+                Icon(
+                    Icons.Default.ExpandMore,
+                    contentDescription = null,
+                    modifier = Modifier.graphicsLayer { rotationZ = arrowRotation }
+                )
+            }
 
             AnimatedVisibility(
                 visible = expanded,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -761,6 +761,13 @@ fun WebViewConfigCard(
                             onCheckedChange = { onConfigChange(config.copy(fullscreenEnabled = it)) }
                         )
 
+                        SettingsSwitch(
+                            title = Strings.hideBrowserToolbarLabel,
+                            subtitle = Strings.hideBrowserToolbarHint,
+                            checked = config.hideBrowserToolbar,
+                            onCheckedChange = { onConfigChange(config.copy(hideBrowserToolbar = it)) }
+                        )
+
                         // 视口适配模式 (inline)
                         ViewportModeSelector(config = config, onConfigChange = onConfigChange)
                     }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1459,10 +1459,61 @@ fun StatusBarStyleCard(
             ) {
                 Column {
                     Spacer(modifier = Modifier.height(12.dp))
-                    StatusBarConfigCard(
-                        config = webViewConfig,
-                        onConfigChange = onWebViewConfigChange
-                    )
+
+                    // Light / Dark mode tab selector
+                    var selectedTab by remember { mutableIntStateOf(0) }
+                    TabRow(
+                        selectedTabIndex = selectedTab,
+                        modifier = Modifier.clip(RoundedCornerShape(8.dp)),
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    ) {
+                        Tab(
+                            selected = selectedTab == 0,
+                            onClick = { selectedTab = 0 },
+                            text = { Text(Strings.statusBarLightModeLabel) },
+                            icon = { Icon(Icons.Outlined.LightMode, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                        )
+                        Tab(
+                            selected = selectedTab == 1,
+                            onClick = { selectedTab = 1 },
+                            text = { Text(Strings.statusBarDarkModeLabel) },
+                            icon = { Icon(Icons.Outlined.DarkMode, contentDescription = null, modifier = Modifier.size(18.dp)) }
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    if (selectedTab == 0) {
+                        // Light mode - use standard fields directly
+                        StatusBarConfigCard(
+                            config = webViewConfig,
+                            onConfigChange = onWebViewConfigChange
+                        )
+                    } else {
+                        // Dark mode - map dark fields to standard fields for the component
+                        val darkMappedConfig = webViewConfig.copy(
+                            statusBarColorMode = webViewConfig.statusBarColorModeDark,
+                            statusBarColor = webViewConfig.statusBarColorDark,
+                            statusBarDarkIcons = webViewConfig.statusBarDarkIconsDark,
+                            statusBarBackgroundType = webViewConfig.statusBarBackgroundTypeDark,
+                            statusBarBackgroundImage = webViewConfig.statusBarBackgroundImageDark,
+                            statusBarBackgroundAlpha = webViewConfig.statusBarBackgroundAlphaDark,
+                        )
+                        StatusBarConfigCard(
+                            config = darkMappedConfig,
+                            onConfigChange = { changedConfig ->
+                                // Map changed standard fields back to dark fields
+                                onWebViewConfigChange(webViewConfig.copy(
+                                    statusBarColorModeDark = changedConfig.statusBarColorMode,
+                                    statusBarColorDark = changedConfig.statusBarColor,
+                                    statusBarDarkIconsDark = changedConfig.statusBarDarkIcons,
+                                    statusBarBackgroundTypeDark = changedConfig.statusBarBackgroundType,
+                                    statusBarBackgroundImageDark = changedConfig.statusBarBackgroundImage,
+                                    statusBarBackgroundAlphaDark = changedConfig.statusBarBackgroundAlpha,
+                                ))
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -13,6 +13,7 @@ import android.view.WindowManager
 import android.webkit.*
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.*
 import androidx.lifecycle.lifecycleScope
@@ -68,6 +69,8 @@ class ShellActivity : AppCompatActivity() {
     private var statusBarBackgroundImageDark: String? = null
     private var statusBarBackgroundAlphaDark: Float = 1.0f
     private var forceHideSystemUi: Boolean = false
+    // 当前深色主题状态（从 Compose 同步，用于 onWindowFocusChanged 等 Activity 级别回调）
+    private var currentIsDarkTheme: Boolean = false
     private var keyboardAdjustMode: KeyboardAdjustMode = KeyboardAdjustMode.RESIZE  // 键盘调整模式
     private var forcedRunConfig: ForcedRunConfig? = null
     private val forcedRunManager by lazy { ForcedRunManager.getInstance(this) }
@@ -82,8 +85,13 @@ class ShellActivity : AppCompatActivity() {
         isDarkTheme: Boolean
     ) = WindowHelper.applyStatusBarColor(this, colorMode, customColor, darkIcons, isDarkTheme)
 
-    private fun applyImmersiveFullscreen(enabled: Boolean, hideNavBar: Boolean? = null, isDarkTheme: Boolean = false) {
+    private fun applyImmersiveFullscreen(enabled: Boolean, hideNavBar: Boolean? = null, isDarkTheme: Boolean = currentIsDarkTheme) {
         val shouldHideNavBar = hideNavBar ?: !showNavigationBarInFullscreen
+        // 使用深色/浅色模式对应的状态栏配置
+        val effectiveColorMode = if (isDarkTheme) statusBarColorModeDark else statusBarColorMode
+        val effectiveCustomColor = if (isDarkTheme) statusBarCustomColorDark else statusBarCustomColor
+        val effectiveDarkIcons = if (isDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
+        val effectiveBgType = if (isDarkTheme) statusBarBackgroundTypeDark else statusBarBackgroundType
         WindowHelper.applyImmersiveFullscreen(
             activity = this,
             enabled = enabled,
@@ -91,10 +99,10 @@ class ShellActivity : AppCompatActivity() {
             isDarkTheme = isDarkTheme,
             showStatusBar = showStatusBarInFullscreen,
             forceHideSystemUi = forceHideSystemUi,
-            statusBarColorMode = statusBarColorMode,
-            statusBarCustomColor = statusBarCustomColor,
-            statusBarDarkIcons = statusBarDarkIcons,
-            statusBarBgType = statusBarBackgroundType,
+            statusBarColorMode = effectiveColorMode,
+            statusBarCustomColor = effectiveCustomColor,
+            statusBarDarkIcons = effectiveDarkIcons,
+            statusBarBgType = effectiveBgType,
             keyboardAdjustMode = keyboardAdjustMode,
             tag = "ShellActivity"
         )
@@ -219,17 +227,13 @@ class ShellActivity : AppCompatActivity() {
         // Initialize日志系统（尽早初始化以捕获崩溃）
         ShellActivityInit.initLogger(this)
         
-        // Enable边到边显示（手动配置，不使用 enableEdgeToEdge() 因为它会
-        // 安装一个持续覆盖 isAppearanceLightStatusBars 的监听器，
-        // 阻止我们自定义状态栏图标颜色）
+        // Enable边到边显示（让内容延伸到系统栏区域）
         try {
-            androidx.core.view.WindowCompat.setDecorFitsSystemWindows(window, false)
-            window.statusBarColor = android.graphics.Color.TRANSPARENT
-            window.navigationBarColor = android.graphics.Color.TRANSPARENT
-            com.webtoapp.core.shell.ShellLogger.d("ShellActivity", "edge-to-edge 手动配置成功")
+            enableEdgeToEdge()
+            com.webtoapp.core.shell.ShellLogger.d("ShellActivity", "enableEdgeToEdge 成功")
         } catch (e: Exception) {
-            AppLogger.w("ShellActivity", "edge-to-edge setup failed", e)
-            com.webtoapp.core.shell.ShellLogger.w("ShellActivity", "edge-to-edge 配置失败", e)
+            AppLogger.w("ShellActivity", "enableEdgeToEdge failed", e)
+            com.webtoapp.core.shell.ShellLogger.w("ShellActivity", "enableEdgeToEdge 失败", e)
         }
         
         super.onCreate(savedInstanceState)
@@ -304,12 +308,23 @@ class ShellActivity : AppCompatActivity() {
             KeyboardAdjustMode.RESIZE
         }
 
+        // 计算初始深色主题状态（供 applyImmersiveFullscreen 和 onWindowFocusChanged 使用）
+        currentIsDarkTheme = when (config.darkMode.uppercase()) {
+            "LIGHT" -> false
+            "DARK" -> true
+            else -> {
+                // SYSTEM: 根据系统设置判断
+                val uiMode = resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK
+                uiMode == android.content.res.Configuration.UI_MODE_NIGHT_YES
+            }
+        }
+
         // 根据配置决定是否启用沉浸式全屏模式
         // hideToolbar=true 时启用沉浸式（隐藏状态栏），否则显示状态栏
         immersiveFullscreenEnabled = config.webViewConfig.hideToolbar
         try {
-            applyImmersiveFullscreen(immersiveFullscreenEnabled)
-            com.webtoapp.core.shell.ShellLogger.d("ShellActivity", "沉浸式全屏模式: $immersiveFullscreenEnabled")
+            applyImmersiveFullscreen(immersiveFullscreenEnabled, isDarkTheme = currentIsDarkTheme)
+            com.webtoapp.core.shell.ShellLogger.d("ShellActivity", "沉浸式全屏模式: $immersiveFullscreenEnabled, isDark=$currentIsDarkTheme")
         } catch (e: Exception) {
             com.webtoapp.core.shell.ShellLogger.e("ShellActivity", "应用沉浸式全屏失败", e)
         }
@@ -403,7 +418,12 @@ class ShellActivity : AppCompatActivity() {
             ) {
                 // Get当前主题状态
                 val isDarkTheme = com.webtoapp.ui.theme.LocalIsDarkTheme.current
-                
+
+                // 同步深色主题状态到 Activity 级别（供 onWindowFocusChanged 使用）
+                SideEffect {
+                    currentIsDarkTheme = isDarkTheme
+                }
+
                 // 当主题变化时更新状态栏颜色（根据深色/浅色模式选择对应配置）
                 LaunchedEffect(isDarkTheme, statusBarColorMode, statusBarColorModeDark) {
                     if (!immersiveFullscreenEnabled) {
@@ -493,7 +513,15 @@ class ShellActivity : AppCompatActivity() {
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus) {
-            applyImmersiveFullscreen(customView != null || immersiveFullscreenEnabled || forceHideSystemUi)
+            if (customView != null || immersiveFullscreenEnabled || forceHideSystemUi) {
+                applyImmersiveFullscreen(true, isDarkTheme = currentIsDarkTheme)
+            } else {
+                // 非全屏模式：重新应用状态栏颜色（使用正确的深色/浅色模式值）
+                val effectiveColorMode = if (currentIsDarkTheme) statusBarColorModeDark else statusBarColorMode
+                val effectiveCustomColor = if (currentIsDarkTheme) statusBarCustomColorDark else statusBarCustomColor
+                val effectiveDarkIcons = if (currentIsDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
+                applyStatusBarColor(effectiveColorMode, effectiveCustomColor, effectiveDarkIcons, currentIsDarkTheme)
+            }
         }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -61,6 +61,13 @@ class ShellActivity : AppCompatActivity() {
     private var statusBarBackgroundImage: String? = null
     private var statusBarBackgroundAlpha: Float = 1.0f
     private var statusBarHeightDp: Int = 0
+    // Status bar深色模式配置缓存
+    private var statusBarColorModeDark: String = "THEME"
+    private var statusBarCustomColorDark: String? = null
+    private var statusBarDarkIconsDark: Boolean? = null
+    private var statusBarBackgroundTypeDark: String = "COLOR"
+    private var statusBarBackgroundImageDark: String? = null
+    private var statusBarBackgroundAlphaDark: Float = 1.0f
     private var forceHideSystemUi: Boolean = false
     private var keyboardAdjustMode: KeyboardAdjustMode = KeyboardAdjustMode.RESIZE  // 键盘调整模式
     private var forcedRunConfig: ForcedRunConfig? = null
@@ -277,6 +284,13 @@ class ShellActivity : AppCompatActivity() {
         statusBarBackgroundImage = config.webViewConfig.statusBarBackgroundImage
         statusBarBackgroundAlpha = config.webViewConfig.statusBarBackgroundAlpha
         statusBarHeightDp = config.webViewConfig.statusBarHeightDp
+        // 读取深色模式状态栏配置
+        statusBarColorModeDark = config.webViewConfig.statusBarColorModeDark
+        statusBarCustomColorDark = config.webViewConfig.statusBarColorDark
+        statusBarDarkIconsDark = config.webViewConfig.statusBarDarkIconsDark
+        statusBarBackgroundTypeDark = config.webViewConfig.statusBarBackgroundTypeDark
+        statusBarBackgroundImageDark = config.webViewConfig.statusBarBackgroundImageDark
+        statusBarBackgroundAlphaDark = config.webViewConfig.statusBarBackgroundAlphaDark
         showStatusBarInFullscreen = config.webViewConfig.showStatusBarInFullscreen
         showNavigationBarInFullscreen = config.webViewConfig.showNavigationBarInFullscreen
         // 读取键盘调整模式
@@ -387,13 +401,16 @@ class ShellActivity : AppCompatActivity() {
                 // Get当前主题状态
                 val isDarkTheme = com.webtoapp.ui.theme.LocalIsDarkTheme.current
                 
-                // 当主题变化时更新状态栏颜色
-                LaunchedEffect(isDarkTheme, statusBarColorMode) {
+                // 当主题变化时更新状态栏颜色（根据深色/浅色模式选择对应配置）
+                LaunchedEffect(isDarkTheme, statusBarColorMode, statusBarColorModeDark) {
                     if (!immersiveFullscreenEnabled) {
-                        applyStatusBarColor(statusBarColorMode, statusBarCustomColor, statusBarDarkIcons, isDarkTheme)
+                        val effectiveColorMode = if (isDarkTheme) statusBarColorModeDark else statusBarColorMode
+                        val effectiveCustomColor = if (isDarkTheme) statusBarCustomColorDark else statusBarCustomColor
+                        val effectiveDarkIcons = if (isDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
+                        applyStatusBarColor(effectiveColorMode, effectiveCustomColor, effectiveDarkIcons, isDarkTheme)
                     }
                 }
-                
+
                 ShellScreen(
                     config = config,
                     deepLinkUrl = deepLinkUrl.value,
@@ -435,11 +452,11 @@ class ShellActivity : AppCompatActivity() {
                     onForcedRunStateChanged = { active, forcedConfig ->
                         onForcedRunStateChanged(active, forcedConfig)
                     },
-                    // Status bar配置
-                    statusBarBackgroundType = statusBarBackgroundType,
-                    statusBarBackgroundColor = statusBarCustomColor,
-                    statusBarBackgroundImage = statusBarBackgroundImage,
-                    statusBarBackgroundAlpha = statusBarBackgroundAlpha,
+                    // Status bar配置（根据深色/浅色模式选择对应配置）
+                    statusBarBackgroundType = if (isDarkTheme) statusBarBackgroundTypeDark else statusBarBackgroundType,
+                    statusBarBackgroundColor = if (isDarkTheme) statusBarCustomColorDark else statusBarCustomColor,
+                    statusBarBackgroundImage = if (isDarkTheme) statusBarBackgroundImageDark else statusBarBackgroundImage,
+                    statusBarBackgroundAlpha = if (isDarkTheme) statusBarBackgroundAlphaDark else statusBarBackgroundAlpha,
                     statusBarHeightDp = statusBarHeightDp
                 )
             }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -13,7 +13,6 @@ import android.view.WindowManager
 import android.webkit.*
 import android.widget.Toast
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.*
 import androidx.lifecycle.lifecycleScope
@@ -220,13 +219,17 @@ class ShellActivity : AppCompatActivity() {
         // Initialize日志系统（尽早初始化以捕获崩溃）
         ShellActivityInit.initLogger(this)
         
-        // Enable边到边显示（让内容延伸到系统栏区域）
+        // Enable边到边显示（手动配置，不使用 enableEdgeToEdge() 因为它会
+        // 安装一个持续覆盖 isAppearanceLightStatusBars 的监听器，
+        // 阻止我们自定义状态栏图标颜色）
         try {
-            enableEdgeToEdge()
-            com.webtoapp.core.shell.ShellLogger.d("ShellActivity", "enableEdgeToEdge 成功")
+            androidx.core.view.WindowCompat.setDecorFitsSystemWindows(window, false)
+            window.statusBarColor = android.graphics.Color.TRANSPARENT
+            window.navigationBarColor = android.graphics.Color.TRANSPARENT
+            com.webtoapp.core.shell.ShellLogger.d("ShellActivity", "edge-to-edge 手动配置成功")
         } catch (e: Exception) {
-            AppLogger.w("ShellActivity", "enableEdgeToEdge failed", e)
-            com.webtoapp.core.shell.ShellLogger.w("ShellActivity", "enableEdgeToEdge 失败", e)
+            AppLogger.w("ShellActivity", "edge-to-edge setup failed", e)
+            com.webtoapp.core.shell.ShellLogger.w("ShellActivity", "edge-to-edge 配置失败", e)
         }
         
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -34,6 +34,7 @@ fun BoxScope.ShellScaffoldLayout(
     config: ShellConfig,
     appType: String,
     hideToolbar: Boolean,
+    hideBrowserToolbar: Boolean = false,
     // 状态
     isLoading: Boolean,
     loadProgress: Int,
@@ -72,7 +73,11 @@ fun BoxScope.ShellScaffoldLayout(
     val context = LocalContext.current
 
     // 是否显示顶部导航栏：非全屏模式或全屏模式下用户选择显示
-    val showToolbar = !hideToolbar || config.webViewConfig.showToolbarInFullscreen
+    val showToolbar = when {
+        hideBrowserToolbar -> false
+        hideToolbar -> config.webViewConfig.showToolbarInFullscreen
+        else -> true
+    }
 
     // 读取键盘调整模式
     val keyboardAdjustMode = remember {
@@ -190,7 +195,7 @@ fun BoxScope.ShellScaffoldLayout(
 
             // 悬浮返回按钮（逻辑已提取到 ShellOverlays.kt）
             ShellFloatingBackButton(
-                hideToolbar = hideToolbar,
+                hideToolbar = hideToolbar || hideBrowserToolbar,
                 showToolbar = showToolbar,
                 canGoBack = canGoBack,
                 forcedRunActive = forcedRunActive,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -451,9 +451,7 @@ fun ShellScreen(
     val hasCustomStatusBar = statusBarBackgroundType != "COLOR" || statusBarBackgroundColor != null || statusBarHeightDp > 0
     val showStatusBarOverlay = (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) || (!hideToolbar && hasCustomStatusBar)
     if (showStatusBarOverlay) {
-        // Force status bar icon color to match overlay background on every recomposition
-        // SideEffect (not LaunchedEffect) because enableEdgeToEdge and Material3 DayNight
-        // continuously override isAppearanceLightStatusBars on window focus changes
+        // Force status bar icon color to match overlay background
         val isLightOverlayBackground = remember(statusBarBackgroundColor) {
             if (statusBarBackgroundColor != null) {
                 try {
@@ -464,10 +462,31 @@ fun ShellScreen(
                 } catch (e: Exception) { false }
             } else false
         }
+        // Use native WindowInsetsController API (bypasses compat layer issues)
         SideEffect {
             val activity = context as? android.app.Activity ?: return@SideEffect
-            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-            controller.isAppearanceLightStatusBars = isLightOverlayBackground
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                val controller = activity.window.insetsController
+                if (isLightOverlayBackground) {
+                    controller?.setSystemBarsAppearance(
+                        android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                        android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                    )
+                } else {
+                    controller?.setSystemBarsAppearance(
+                        0,
+                        android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+                    )
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                val flags = activity.window.decorView.systemUiVisibility
+                activity.window.decorView.systemUiVisibility = if (isLightOverlayBackground) {
+                    flags or android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                } else {
+                    flags and android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+                }
+            }
         }
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -451,12 +451,11 @@ fun ShellScreen(
     val hasCustomStatusBar = statusBarBackgroundType != "COLOR" || statusBarBackgroundColor != null || statusBarHeightDp > 0
     val showStatusBarOverlay = (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) || (!hideToolbar && hasCustomStatusBar)
     if (showStatusBarOverlay) {
-        // Force status bar icon color to match overlay background
-        // (enableEdgeToEdge may override our applyStatusBarColor settings)
-        LaunchedEffect(statusBarBackgroundColor, statusBarBackgroundType) {
-            val activity = context as? android.app.Activity ?: return@LaunchedEffect
-            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-            val isLightBackground = if (statusBarBackgroundColor != null) {
+        // Force status bar icon color to match overlay background on every recomposition
+        // SideEffect (not LaunchedEffect) because enableEdgeToEdge and Material3 DayNight
+        // continuously override isAppearanceLightStatusBars on window focus changes
+        val isLightOverlayBackground = remember(statusBarBackgroundColor) {
+            if (statusBarBackgroundColor != null) {
                 try {
                     val color = android.graphics.Color.parseColor(
                         if (statusBarBackgroundColor!!.startsWith("#")) statusBarBackgroundColor else "#$statusBarBackgroundColor"
@@ -464,7 +463,11 @@ fun ShellScreen(
                     com.webtoapp.ui.shared.WindowHelper.isColorLight(color)
                 } catch (e: Exception) { false }
             } else false
-            controller.isAppearanceLightStatusBars = isLightBackground
+        }
+        SideEffect {
+            val activity = context as? android.app.Activity ?: return@SideEffect
+            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+            controller.isAppearanceLightStatusBars = isLightOverlayBackground
         }
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -451,6 +451,21 @@ fun ShellScreen(
     val hasCustomStatusBar = statusBarBackgroundType != "COLOR" || statusBarBackgroundColor != null || statusBarHeightDp > 0
     val showStatusBarOverlay = (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) || (!hideToolbar && hasCustomStatusBar)
     if (showStatusBarOverlay) {
+        // Force status bar icon color to match overlay background
+        // (enableEdgeToEdge may override our applyStatusBarColor settings)
+        LaunchedEffect(statusBarBackgroundColor, statusBarBackgroundType) {
+            val activity = context as? android.app.Activity ?: return@LaunchedEffect
+            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+            val isLightBackground = if (statusBarBackgroundColor != null) {
+                try {
+                    val color = android.graphics.Color.parseColor(
+                        if (statusBarBackgroundColor!!.startsWith("#")) statusBarBackgroundColor else "#$statusBarBackgroundColor"
+                    )
+                    com.webtoapp.ui.shared.WindowHelper.isColorLight(color)
+                } catch (e: Exception) { false }
+            } else false
+            controller.isAppearanceLightStatusBars = isLightBackground
+        }
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -226,8 +226,8 @@ fun ShellScreen(
                 activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             }
             "AUTO" -> {
-                // ★ 自动旋转：跟随重力感应，平板设备友好
-                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                // Auto rotation: respects the system auto-rotate setting
+                activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
             }
             else -> {
                 if (TvUtils.isTv(context)) {
@@ -313,6 +313,7 @@ fun ShellScreen(
 
     // Yes否隐藏工具栏（全屏模式）
     val hideToolbar = config.webViewConfig.hideToolbar
+    val hideBrowserToolbar = config.webViewConfig.hideBrowserToolbar
     // 下拉刷新开关
     val swipeRefreshEnabled = config.webViewConfig.swipeRefreshEnabled
 
@@ -339,6 +340,7 @@ fun ShellScreen(
         config = config,
         appType = appType,
         hideToolbar = hideToolbar,
+        hideBrowserToolbar = hideBrowserToolbar,
         isLoading = isLoading,
         loadProgress = loadProgress,
         pageTitle = pageTitle,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -446,9 +446,11 @@ fun ShellScreen(
         )
     }
     
-    // Status bar背景覆盖层（在全屏模式下显示状态栏时）
-    // 放在 Box 内部最上层，覆盖在所有内容之上，使用 align 固定在顶部
-    if (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) {
+    // Status bar背景覆盖层
+    // Show overlay when: fullscreen with status bar visible, OR non-fullscreen with custom status bar config
+    val hasCustomStatusBar = statusBarBackgroundType != "COLOR" || statusBarBackgroundColor != null || statusBarHeightDp > 0
+    val showStatusBarOverlay = (hideToolbar && config.webViewConfig.showStatusBarInFullscreen) || (!hideToolbar && hasCustomStatusBar)
+    if (showStatusBarOverlay) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -35,6 +35,7 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         openExternalLinks = config.webViewConfig.openExternalLinks,
         downloadEnabled = true, // 确保下载功能始终启用
         hideToolbar = config.webViewConfig.hideToolbar,
+        hideBrowserToolbar = config.webViewConfig.hideBrowserToolbar,
         showStatusBarInFullscreen = config.webViewConfig.showStatusBarInFullscreen,
         showNavigationBarInFullscreen = config.webViewConfig.showNavigationBarInFullscreen,
         showToolbarInFullscreen = config.webViewConfig.showToolbarInFullscreen,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -54,6 +54,13 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         statusBarBackgroundImage = config.webViewConfig.statusBarBackgroundImage,
         statusBarBackgroundAlpha = config.webViewConfig.statusBarBackgroundAlpha,
         statusBarHeightDp = config.webViewConfig.statusBarHeightDp,
+        // 状态栏深色模式配置
+        statusBarColorModeDark = try { com.webtoapp.data.model.StatusBarColorMode.valueOf(config.webViewConfig.statusBarColorModeDark) } catch (e: Exception) { com.webtoapp.data.model.StatusBarColorMode.THEME },
+        statusBarColorDark = config.webViewConfig.statusBarColorDark,
+        statusBarDarkIconsDark = config.webViewConfig.statusBarDarkIconsDark,
+        statusBarBackgroundTypeDark = try { com.webtoapp.data.model.StatusBarBackgroundType.valueOf(config.webViewConfig.statusBarBackgroundTypeDark) } catch (e: Exception) { com.webtoapp.data.model.StatusBarBackgroundType.COLOR },
+        statusBarBackgroundImageDark = config.webViewConfig.statusBarBackgroundImageDark,
+        statusBarBackgroundAlphaDark = config.webViewConfig.statusBarBackgroundAlphaDark,
         // 长按菜单配置
         longPressMenuEnabled = config.webViewConfig.longPressMenuEnabled,
         longPressMenuStyle = try { com.webtoapp.data.model.LongPressMenuStyle.valueOf(config.webViewConfig.longPressMenuStyle) } catch (e: Exception) { com.webtoapp.data.model.LongPressMenuStyle.FULL },

--- a/app/src/main/java/com/webtoapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/webtoapp/ui/theme/Theme.kt
@@ -257,6 +257,7 @@ fun ShellTheme(
     CompositionLocalProvider(
         LocalAppTheme provides currentTheme,
         LocalAnimationSettings provides animationSettings,
+        LocalIsDarkTheme provides useDarkTheme,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2687,6 +2687,20 @@ fun WebViewScreen(
     val hasCustomStatusBar = effectiveStatusBarBgType != "COLOR" || effectiveStatusBarBgColor != null || statusBarHeightDp > 0
     val showStatusBarOverlay = (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) || (!hideToolbar && hasCustomStatusBar)
     if (showStatusBarOverlay) {
+        // Force status bar icon color to match overlay background
+        LaunchedEffect(effectiveStatusBarBgColor, effectiveStatusBarBgType) {
+            val activity = context as? android.app.Activity ?: return@LaunchedEffect
+            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+            val isLightBackground = if (effectiveStatusBarBgColor != null) {
+                try {
+                    val color = android.graphics.Color.parseColor(
+                        if (effectiveStatusBarBgColor!!.startsWith("#")) effectiveStatusBarBgColor else "#$effectiveStatusBarBgColor"
+                    )
+                    com.webtoapp.ui.shared.WindowHelper.isColorLight(color)
+                } catch (e: Exception) { false }
+            } else false
+            controller.isAppearanceLightStatusBars = isLightBackground
+        }
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = effectiveStatusBarBgType,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2687,11 +2687,9 @@ fun WebViewScreen(
     val hasCustomStatusBar = effectiveStatusBarBgType != "COLOR" || effectiveStatusBarBgColor != null || statusBarHeightDp > 0
     val showStatusBarOverlay = (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) || (!hideToolbar && hasCustomStatusBar)
     if (showStatusBarOverlay) {
-        // Force status bar icon color to match overlay background
-        LaunchedEffect(effectiveStatusBarBgColor, effectiveStatusBarBgType) {
-            val activity = context as? android.app.Activity ?: return@LaunchedEffect
-            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-            val isLightBackground = if (effectiveStatusBarBgColor != null) {
+        // Force status bar icon color to match overlay background on every recomposition
+        val isLightOverlayBackground = remember(effectiveStatusBarBgColor) {
+            if (effectiveStatusBarBgColor != null) {
                 try {
                     val color = android.graphics.Color.parseColor(
                         if (effectiveStatusBarBgColor!!.startsWith("#")) effectiveStatusBarBgColor else "#$effectiveStatusBarBgColor"
@@ -2699,7 +2697,11 @@ fun WebViewScreen(
                     com.webtoapp.ui.shared.WindowHelper.isColorLight(color)
                 } catch (e: Exception) { false }
             } else false
-            controller.isAppearanceLightStatusBars = isLightBackground
+        }
+        SideEffect {
+            val activity = context as? android.app.Activity ?: return@SideEffect
+            val controller = androidx.core.view.WindowInsetsControllerCompat(activity.window, activity.window.decorView)
+            controller.isAppearanceLightStatusBars = isLightOverlayBackground
         }
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -147,6 +147,8 @@ class WebViewActivity : AppCompatActivity() {
     private var statusBarDarkIconsDark: Boolean? = null
     private var statusBarBackgroundTypeDark: com.webtoapp.data.model.StatusBarBackgroundType = com.webtoapp.data.model.StatusBarBackgroundType.COLOR
     internal var keyboardAdjustMode: KeyboardAdjustMode = KeyboardAdjustMode.RESIZE  // 键盘调整模式
+    // 当前深色主题状态（从 Compose 同步，用于 onWindowFocusChanged 等 Activity 级别回调）
+    private var currentIsDarkTheme: Boolean = false
 
     private fun applyStatusBarColor(
         colorMode: com.webtoapp.data.model.StatusBarColorMode,
@@ -155,18 +157,23 @@ class WebViewActivity : AppCompatActivity() {
         isDarkTheme: Boolean
     ) = WindowHelper.applyStatusBarColor(this, colorMode.name, customColor, darkIcons, isDarkTheme)
 
-    private fun applyImmersiveFullscreen(enabled: Boolean, hideNavBar: Boolean? = null, isDarkTheme: Boolean = false) {
+    private fun applyImmersiveFullscreen(enabled: Boolean, hideNavBar: Boolean? = null, isDarkTheme: Boolean = currentIsDarkTheme) {
         val shouldHideNavBar = hideNavBar ?: !showNavigationBarInFullscreen
+        // 使用深色/浅色模式对应的状态栏配置
+        val effectiveColorMode = if (isDarkTheme) statusBarColorModeDark else statusBarColorMode
+        val effectiveCustomColor = if (isDarkTheme) statusBarCustomColorDark else statusBarCustomColor
+        val effectiveDarkIcons = if (isDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
+        val effectiveBgType = if (isDarkTheme) statusBarBackgroundTypeDark else statusBarBackgroundType
         WindowHelper.applyImmersiveFullscreen(
             activity = this,
             enabled = enabled,
             hideNavBar = shouldHideNavBar,
             isDarkTheme = isDarkTheme,
             showStatusBar = showStatusBarInFullscreen,
-            statusBarColorMode = statusBarColorMode.name,
-            statusBarCustomColor = statusBarCustomColor,
-            statusBarDarkIcons = statusBarDarkIcons,
-            statusBarBgType = statusBarBackgroundType.name,
+            statusBarColorMode = effectiveColorMode.name,
+            statusBarCustomColor = effectiveCustomColor,
+            statusBarDarkIcons = effectiveDarkIcons,
+            statusBarBgType = effectiveBgType.name,
             keyboardAdjustMode = keyboardAdjustMode,
             tag = "WebViewActivity"
         )
@@ -435,6 +442,11 @@ class WebViewActivity : AppCompatActivity() {
 
         setContent {
             WebToAppTheme { isDarkTheme ->
+                // 同步深色主题状态到 Activity 级别（供 onWindowFocusChanged 使用）
+                SideEffect {
+                    currentIsDarkTheme = isDarkTheme
+                }
+
                 // 当主题变化时更新状态栏颜色（根据深色/浅色模式选择对应配置）
                 LaunchedEffect(isDarkTheme, statusBarColorMode, statusBarColorModeDark) {
                     if (!immersiveFullscreenEnabled) {
@@ -587,7 +599,15 @@ class WebViewActivity : AppCompatActivity() {
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus) {
-            applyImmersiveFullscreen(customView != null || immersiveFullscreenEnabled)
+            if (customView != null || immersiveFullscreenEnabled) {
+                applyImmersiveFullscreen(true, isDarkTheme = currentIsDarkTheme)
+            } else {
+                // 非全屏模式：重新应用状态栏颜色（使用正确的深色/浅色模式值）
+                val effectiveColorMode = if (currentIsDarkTheme) statusBarColorModeDark else statusBarColorMode
+                val effectiveCustomColor = if (currentIsDarkTheme) statusBarCustomColorDark else statusBarCustomColor
+                val effectiveDarkIcons = if (currentIsDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
+                applyStatusBarColor(effectiveColorMode, effectiveCustomColor, effectiveDarkIcons, currentIsDarkTheme)
+            }
         }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -813,7 +813,8 @@ fun WebViewScreen(
                     activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
                 }
                 com.webtoapp.data.model.OrientationMode.AUTO -> {
-                    activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                    // Auto rotation: respects the system auto-rotate setting
+                    activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                 }
                 com.webtoapp.data.model.OrientationMode.PORTRAIT -> {
                     if (!com.webtoapp.util.TvUtils.isTv(context)) {
@@ -919,8 +920,8 @@ fun WebViewScreen(
                         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
                     }
                     com.webtoapp.data.model.OrientationMode.AUTO -> {
-                        // ★ 自动旋转：跟随重力感应，平板设备友好
-                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                        // Auto rotation: respects the system auto-rotate setting
+                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                     }
                     com.webtoapp.data.model.OrientationMode.PORTRAIT -> {
                         if (com.webtoapp.util.TvUtils.isTv(context)) {
@@ -2135,8 +2136,14 @@ fun WebViewScreen(
     
     // Yes否隐藏工具栏（全屏模式）- 测试模式下始终显示工具栏
     val hideToolbar = !isTestMode && webApp?.webViewConfig?.hideToolbar == true
+    val hideBrowserToolbar = !isTestMode && webApp?.webViewConfig?.hideBrowserToolbar == true
     // 是否在全屏模式下显示顶部导航栏
-    val showToolbarInPreview = !hideToolbar || webApp?.webViewConfig?.showToolbarInFullscreen == true
+    val showToolbarInPreview = when {
+        isTestMode -> true
+        hideBrowserToolbar -> false
+        hideToolbar -> webApp?.webViewConfig?.showToolbarInFullscreen == true
+        else -> true
+    }
     
     LaunchedEffect(hideToolbar) {
         onFullscreenModeChanged(hideToolbar)
@@ -2565,7 +2572,7 @@ fun WebViewScreen(
             // 全屏模式下的悬浮返回按钮（当工具栏隐藏且可以后退时显示）
             // 如果用户选择了显示toolbar则不需要悬浮按钮
             // 自动淡出：显示后 3 秒开始淡化，点击时重置透明度
-            if (hideToolbar && !showToolbarInPreview && canGoBack) {
+            if ((hideToolbar || hideBrowserToolbar) && !showToolbarInPreview && canGoBack) {
                 var fabAlpha by remember { mutableFloatStateOf(0.9f) }
                 var fadeKey by remember { mutableIntStateOf(0) }
                 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -141,6 +141,11 @@ class WebViewActivity : AppCompatActivity() {
     private var statusBarCustomColor: String? = null
     private var statusBarDarkIcons: Boolean? = null
     private var statusBarBackgroundType: com.webtoapp.data.model.StatusBarBackgroundType = com.webtoapp.data.model.StatusBarBackgroundType.COLOR
+    // Status bar深色模式配置缓存
+    private var statusBarColorModeDark: com.webtoapp.data.model.StatusBarColorMode = com.webtoapp.data.model.StatusBarColorMode.THEME
+    private var statusBarCustomColorDark: String? = null
+    private var statusBarDarkIconsDark: Boolean? = null
+    private var statusBarBackgroundTypeDark: com.webtoapp.data.model.StatusBarBackgroundType = com.webtoapp.data.model.StatusBarBackgroundType.COLOR
     internal var keyboardAdjustMode: KeyboardAdjustMode = KeyboardAdjustMode.RESIZE  // 键盘调整模式
 
     private fun applyStatusBarColor(
@@ -430,10 +435,13 @@ class WebViewActivity : AppCompatActivity() {
 
         setContent {
             WebToAppTheme { isDarkTheme ->
-                // 当主题变化时更新状态栏颜色
-                LaunchedEffect(isDarkTheme, statusBarColorMode) {
+                // 当主题变化时更新状态栏颜色（根据深色/浅色模式选择对应配置）
+                LaunchedEffect(isDarkTheme, statusBarColorMode, statusBarColorModeDark) {
                     if (!immersiveFullscreenEnabled) {
-                        applyStatusBarColor(statusBarColorMode, statusBarCustomColor, statusBarDarkIcons, isDarkTheme)
+                        val effectiveColorMode = if (isDarkTheme) statusBarColorModeDark else statusBarColorMode
+                        val effectiveCustomColor = if (isDarkTheme) statusBarCustomColorDark else statusBarCustomColor
+                        val effectiveDarkIcons = if (isDarkTheme) statusBarDarkIconsDark else statusBarDarkIcons
+                        applyStatusBarColor(effectiveColorMode, effectiveCustomColor, effectiveDarkIcons, isDarkTheme)
                     }
                 }
                 
@@ -443,13 +451,18 @@ class WebViewActivity : AppCompatActivity() {
                     previewApp = previewApp,
                     testUrl = testUrl,
                     testModuleIds = testModuleIds,
-                    onStatusBarConfigChanged = { colorMode, customColor, darkIcons, showStatusBar, backgroundType ->
+                    onStatusBarConfigChanged = { colorMode, customColor, darkIcons, showStatusBar, backgroundType, colorModeDark, customColorDark, darkIconsDark, backgroundTypeDark ->
                         // Update state栏配置
                         statusBarColorMode = colorMode
                         statusBarCustomColor = customColor
                         statusBarDarkIcons = darkIcons
                         showStatusBarInFullscreen = showStatusBar
                         statusBarBackgroundType = backgroundType
+                        // Update深色模式状态栏配置
+                        statusBarColorModeDark = colorModeDark
+                        statusBarCustomColorDark = customColorDark
+                        statusBarDarkIconsDark = darkIconsDark
+                        statusBarBackgroundTypeDark = backgroundTypeDark
                     },
                     onWebViewCreated = { wv -> 
                         webView = wv
@@ -643,7 +656,7 @@ fun WebViewScreen(
     previewApp: com.webtoapp.data.model.WebApp? = null,
     testUrl: String? = null,
     testModuleIds: List<String>? = null,
-    onStatusBarConfigChanged: ((com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType) -> Unit)? = null,
+    onStatusBarConfigChanged: ((com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType, com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, com.webtoapp.data.model.StatusBarBackgroundType) -> Unit)? = null,
     onWebViewCreated: (WebView) -> Unit,
     onFileChooser: (ValueCallback<Array<Uri>>?, WebChromeClient.FileChooserParams?) -> Boolean,
     onShowCustomView: (View, WebChromeClient.CustomViewCallback?) -> Unit,
@@ -721,6 +734,11 @@ fun WebViewScreen(
     var statusBarBackgroundImage by remember { mutableStateOf<String?>(null) }
     var statusBarBackgroundAlpha by remember { mutableFloatStateOf(1.0f) }
     var statusBarHeightDp by remember { mutableIntStateOf(0) }
+    // Status bar深色模式背景配置
+    var statusBarBackgroundTypeDarkLocal by remember { mutableStateOf("COLOR") }
+    var statusBarBackgroundColorDark by remember { mutableStateOf<String?>(null) }
+    var statusBarBackgroundImageDark by remember { mutableStateOf<String?>(null) }
+    var statusBarBackgroundAlphaDark by remember { mutableFloatStateOf(1.0f) }
     
     // WordPress 预览状态
     var wordPressPreviewState by remember { mutableStateOf<WordPressPreviewState>(WordPressPreviewState.Idle) }
@@ -760,7 +778,11 @@ fun WebViewScreen(
                 app.webViewConfig.statusBarColor,
                 app.webViewConfig.statusBarDarkIcons,
                 app.webViewConfig.showStatusBarInFullscreen,
-                app.webViewConfig.statusBarBackgroundType
+                app.webViewConfig.statusBarBackgroundType,
+                app.webViewConfig.statusBarColorModeDark,
+                app.webViewConfig.statusBarColorDark,
+                app.webViewConfig.statusBarDarkIconsDark,
+                app.webViewConfig.statusBarBackgroundTypeDark
             )
             // Update state栏背景配置
             statusBarBackgroundType = app.webViewConfig.statusBarBackgroundType.name
@@ -768,6 +790,11 @@ fun WebViewScreen(
             statusBarBackgroundImage = app.webViewConfig.statusBarBackgroundImage
             statusBarBackgroundAlpha = app.webViewConfig.statusBarBackgroundAlpha
             statusBarHeightDp = app.webViewConfig.statusBarHeightDp
+            // Update深色模式状态栏背景配置
+            statusBarBackgroundTypeDarkLocal = app.webViewConfig.statusBarBackgroundTypeDark.name
+            statusBarBackgroundColorDark = app.webViewConfig.statusBarColorDark
+            statusBarBackgroundImageDark = app.webViewConfig.statusBarBackgroundImageDark
+            statusBarBackgroundAlphaDark = app.webViewConfig.statusBarBackgroundAlphaDark
             // Update导航栏配置和键盘调整模式
             (context as? WebViewActivity)?.let { activity ->
                 activity.showNavigationBarInFullscreen = app.webViewConfig.showNavigationBarInFullscreen
@@ -2650,17 +2677,22 @@ fun WebViewScreen(
         }
     }
     
-    // Status bar背景覆盖层
+    // Status bar背景覆盖层（根据深色/浅色模式选择对应配置）
     // Show overlay when: fullscreen with status bar visible, OR non-fullscreen with custom status bar config
-    val hasCustomStatusBar = statusBarBackgroundType != "COLOR" || statusBarBackgroundColor != null || statusBarHeightDp > 0
+    val isDarkThemeForOverlay = com.webtoapp.ui.theme.LocalIsDarkTheme.current
+    val effectiveStatusBarBgType = if (isDarkThemeForOverlay) statusBarBackgroundTypeDarkLocal else statusBarBackgroundType
+    val effectiveStatusBarBgColor = if (isDarkThemeForOverlay) statusBarBackgroundColorDark else statusBarBackgroundColor
+    val effectiveStatusBarBgImage = if (isDarkThemeForOverlay) statusBarBackgroundImageDark else statusBarBackgroundImage
+    val effectiveStatusBarBgAlpha = if (isDarkThemeForOverlay) statusBarBackgroundAlphaDark else statusBarBackgroundAlpha
+    val hasCustomStatusBar = effectiveStatusBarBgType != "COLOR" || effectiveStatusBarBgColor != null || statusBarHeightDp > 0
     val showStatusBarOverlay = (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) || (!hideToolbar && hasCustomStatusBar)
     if (showStatusBarOverlay) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
-            backgroundType = statusBarBackgroundType,
-            backgroundColor = statusBarBackgroundColor,
-            backgroundImagePath = statusBarBackgroundImage,
-            alpha = statusBarBackgroundAlpha,
+            backgroundType = effectiveStatusBarBgType,
+            backgroundColor = effectiveStatusBarBgColor,
+            backgroundImagePath = effectiveStatusBarBgImage,
+            alpha = effectiveStatusBarBgAlpha,
             heightDp = statusBarHeightDp,
             modifier = Modifier.align(Alignment.TopStart)
         )

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2650,9 +2650,11 @@ fun WebViewScreen(
         }
     }
     
-    // Status bar背景覆盖层（在全屏模式下显示状态栏时）
-    // 放在 Scaffold 外部，才能正确覆盖在状态栏区域
-    if (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) {
+    // Status bar背景覆盖层
+    // Show overlay when: fullscreen with status bar visible, OR non-fullscreen with custom status bar config
+    val hasCustomStatusBar = statusBarBackgroundType != "COLOR" || statusBarBackgroundColor != null || statusBarHeightDp > 0
+    val showStatusBarOverlay = (hideToolbar && webApp?.webViewConfig?.showStatusBarInFullscreen == true) || (!hideToolbar && hasCustomStatusBar)
+    if (showStatusBarOverlay) {
         com.webtoapp.ui.components.StatusBarOverlay(
             show = true,
             backgroundType = statusBarBackgroundType,


### PR DESCRIPTION
## Summary

This PR combines several bug fixes and feature improvements for exported APKs and preview mode. All changes have been tested on physical devices in both preview and exported APK (Shell) mode.

### New Features

- **Status Bar Style Config independent of Fullscreen Mode**
  - Status bar customization (color, background, icons) is now available as a standalone card in the app creation UI, no longer requires enabling fullscreen mode
  - Collapsible card with expand/collapse arrow for clean UX

- **Separate Light/Dark Mode Status Bar Configuration**
  - New Light/Dark tab selector in Status Bar Style Config
  - Configure different status bar colors, backgrounds, and icon styles for light and dark system themes
  - Runtime switching based on system theme (no app restart needed)

- **"Hide Browser Toolbar" option**
  - New toggle to hide the bottom browser navigation toolbar independently of fullscreen/immersive mode
  - Useful for apps that want a cleaner look without losing the status bar

### Bug Fixes

- **Status bar icons invisible in dark mode (black on black)**
  - Root cause: `onWindowFocusChanged` always called `applyImmersiveFullscreen` with `isDarkTheme` defaulting to `false`, resetting icon appearance to dark (black) icons every time a dialog dismissed or window regained focus
  - Fix: track `currentIsDarkTheme` at Activity level (synced from Compose via `SideEffect`), use dark-mode-aware values in all status bar reapplication paths
  - Fixed in both `ShellActivity` (exported APK) and `WebViewActivity` (preview mode)

- **White screen when toggling system dark/light mode**
  - Added `uiMode` to `android:configChanges` for both `WebViewActivity` and `ShellActivity`
  - Prevents Android from destroying and recreating the Activity (and losing WebView state) on theme change

- **White screen when reopening app from launcher icon**
  - `ShellActivity` had no `launchMode` (defaults to `standard`), so launching from the app icon while already running created a new empty instance
  - Fix: added `android:launchMode="singleTask"` so the existing instance receives `onNewIntent()` instead

- **Auto rotation using wrong constant**
  - Changed `SCREEN_ORIENTATION_SENSOR` to `SCREEN_ORIENTATION_USER` so auto rotation respects the system auto-rotate lock setting

- **`ShellTheme` not providing `LocalIsDarkTheme`**
  - Dark theme detection always returned `false` in exported APKs because `ShellTheme` was missing `LocalIsDarkTheme provides useDarkTheme` in its `CompositionLocalProvider`

- **Status bar overlay not showing without fullscreen**
  - The `StatusBarOverlay` composable was only rendered when `hideToolbar && showStatusBarInFullscreen`. Now also renders in non-fullscreen mode when custom status bar config is set

### Files Changed (15 files, +442 / -125)

| File | Changes |
|------|---------|
| `AndroidManifest.xml` | `uiMode` configChanges, `singleTask` launchMode |
| `ShellActivity.kt` | Dark theme tracking, dark-mode-aware status bar, `onWindowFocusChanged` fix |
| `WebViewActivity.kt` | Same dark theme tracking & `onWindowFocusChanged` fix |
| `ShellScreen.kt` | Hide browser toolbar, StatusBarOverlay condition, native icon color enforcement |
| `ShellScaffoldLayout.kt` | Hide browser toolbar support |
| `Theme.kt` | `LocalIsDarkTheme` in `ShellTheme` |
| `CreateAppWebViewCards.kt` | Standalone StatusBarStyleCard, Light/Dark tabs |
| `CreateAppScreen.kt` | StatusBarStyleCard integration |
| `WebApp.kt` | `hideBrowserToolbar` + dark status bar fields |
| `ShellModeManager.kt` | Dark status bar config fields |
| `ShellWebViewConfig.kt` | Dark status bar field mapping |
| `ApkBuilder.kt` | Dark status bar field export |
| `ApkTemplate.kt` | Dark status bar template fields |
| `Strings.kt` | New i18n strings |
| `NativeBridge.kt` | Minor adjustment |

### Test Plan

- [x] Export APK with custom status bar color → icons visible in both light and dark mode
- [x] Toggle system dark/light mode → no white screen, status bar colors switch correctly
- [x] Open app from launcher icon when already in recents → no white screen
- [x] Auto rotation respects system rotation lock
- [x] Status Bar Style Config works without enabling fullscreen mode
- [x] Light/Dark tab configuration applies correctly per theme
- [x] Hide Browser Toolbar option works independently of fullscreen
- [x] Preview mode status bar icons work correctly

> **Note:** This PR also re-includes the "Hide Browser Toolbar" fix from PR #58, which was previously merged but accidentally lost after a force-push to main. That fix is bundled here along with all the new improvements.
