### PR TITLE
fix(ui): unify setting row titles to titleMedium

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
@@ -205,7 +205,6 @@ private fun DnsHeader(
             Text(
                 text = Strings.dnsConfigTitle,
                 style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface
             )
         }

--- a/app/src/main/java/com/webtoapp/ui/components/EncryptionConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/EncryptionConfigCard.kt
@@ -64,8 +64,7 @@ fun EncryptionConfigCard(
                     Column {
                         Text(
                             text = Strings.resourceEncryption,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Medium
+                            style = MaterialTheme.typography.titleMedium
                         )
                         Text(
                             text = if (config.enabled) Strings.encryptionEnabled else Strings.notEnabled,

--- a/app/src/main/java/com/webtoapp/ui/components/IsolationConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/IsolationConfigCard.kt
@@ -76,8 +76,7 @@ fun IsolationConfigCard(
                     Column {
                         Text(
                             text = Strings.isolatedEnvironment,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Medium
+                            style = MaterialTheme.typography.titleMedium
                         )
                         Text(
                             text = if (config.enabled) Strings.antiDetectionEnabled else Strings.notEnabled,

--- a/app/src/main/java/com/webtoapp/ui/design/WtaDisplay.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaDisplay.kt
@@ -136,7 +136,7 @@ fun WtaIconTitle(
         Column {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                style = MaterialTheme.typography.titleMedium
             )
             if (!subtitle.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(2.dp))
@@ -187,7 +187,7 @@ fun WtaIconTitle(
         Column {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                style = MaterialTheme.typography.titleMedium
             )
             if (!subtitle.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(2.dp))

--- a/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
@@ -383,7 +383,7 @@ fun WtaSettingRow(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.titleMedium,
                     color = contentColor,
                     maxLines = titleMaxLines,
                     overflow = TextOverflow.Ellipsis
@@ -506,7 +506,7 @@ fun WtaTextFieldRow(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface
         )
         if (!subtitle.isNullOrBlank()) {
@@ -546,7 +546,7 @@ fun WtaSliderRow(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Column(modifier = Modifier.weight(1f)) {
-                Text(title, style = MaterialTheme.typography.bodyLarge)
+                Text(title, style = MaterialTheme.typography.titleMedium)
                 if (!subtitle.isNullOrBlank()) {
                     Text(
                         subtitle,


### PR DESCRIPTION
## Summary
- Setting/feature row titles use `titleMedium` instead of mixed `bodyLarge` / SemiBold overlays
- Aligns `WtaSettingRow`, `WtaIconTitle`, DNS/encryption/isolation card headers

## Related Issue
Fixes #208

## Test plan
- [ ] Open edit app and scan toggle row titles for consistent weight/size
- [ ] CI green on this PR
- [x] Issue linked with `Fixes`

## Notes
Visual-only host UI; no export/shell runtime change.