### PR TITLE
fix(host): restore WebApp separate tasks on Shell preview

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -315,6 +315,18 @@
             android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.WebToApp.Shell" />
+
+        <activity
+            android:name=".ui.shell.ShellDocumentActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
+            android:exported="false"
+            android:hardwareAccelerated="true"
+            android:launchMode="standard"
+            android:documentLaunchMode="always"
+            android:maxRecents="15"
+            android:excludeFromRecents="false"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.WebToApp.Shell" />
         
         
         

--- a/app/src/main/java/com/webtoapp/core/host/ShellPreviewLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/host/ShellPreviewLauncher.kt
@@ -12,6 +12,7 @@ import com.webtoapp.core.shell.ShellPreviewSession
 import com.webtoapp.data.model.AppType
 import com.webtoapp.data.model.WebApp
 import com.webtoapp.ui.shell.ShellActivity
+import com.webtoapp.ui.shell.ShellDocumentActivity
 import java.io.File
 
 object ShellPreviewLauncher {
@@ -27,7 +28,7 @@ object ShellPreviewLauncher {
             true
         } catch (e: Exception) {
             AppLogger.e(TAG, "Failed to start shell preview for appId=${webApp.id} type=${webApp.appType}", e)
-            ShellPreviewSession.end()
+            ShellPreviewSession.end(webApp.id)
             false
         }
     }
@@ -81,7 +82,12 @@ object ShellPreviewLauncher {
         } catch (_: Exception) {
             false
         }
-        return Intent(context, ShellActivity::class.java).apply {
+        val target = if (separateTasks) {
+            ShellDocumentActivity::class.java
+        } else {
+            ShellActivity::class.java
+        }
+        return Intent(context, target).apply {
             putExtra(ShellActivity.EXTRA_PREVIEW, true)
             putExtra(ShellActivity.EXTRA_PREVIEW_APP_ID, appId)
             action = Intent.ACTION_VIEW

--- a/app/src/main/java/com/webtoapp/core/shell/ShellPreviewSession.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellPreviewSession.kt
@@ -1,39 +1,66 @@
 package com.webtoapp.core.shell
 
 object ShellPreviewSession {
-    @Volatile
-    private var activeConfig: ShellConfig? = null
-
-    @Volatile
-    private var activeAppId: Long = -1L
-
-    @Volatile
-    private var active: Boolean = false
+    private val lock = Any()
+    private val sessions = LinkedHashMap<Long, ShellConfig>()
 
     fun begin(config: ShellConfig, appId: Long) {
-        activeConfig = config
-        activeAppId = if (appId > 0L) appId else -1L
-        active = true
-    }
-
-    fun end() {
-        active = false
-        activeConfig = null
-        activeAppId = -1L
-    }
-
-    fun endIfMatches(appId: Long) {
-        if (!active) return
-        if (appId <= 0L || activeAppId == appId || activeAppId == -1L) {
-            end()
+        val key = normalizeAppId(appId)
+        synchronized(lock) {
+            sessions[key] = config
         }
     }
 
-    fun isActive(): Boolean = active && activeConfig != null
+    fun end() {
+        synchronized(lock) {
+            sessions.clear()
+        }
+    }
 
-    fun config(): ShellConfig? = if (active) activeConfig else null
+    fun end(appId: Long) {
+        synchronized(lock) {
+            sessions.remove(normalizeAppId(appId))
+        }
+    }
 
-    fun appId(): Long = if (active) activeAppId else -1L
+    fun endIfMatches(appId: Long) {
+        synchronized(lock) {
+            val key = normalizeAppId(appId)
+            if (key > 0L) {
+                sessions.remove(key)
+            } else {
+                sessions.clear()
+            }
+        }
+    }
 
-    fun activationAppId(): Long = if (active && activeAppId > 0L) activeAppId else -1L
+    fun isActive(): Boolean = synchronized(lock) { sessions.isNotEmpty() }
+
+    fun config(): ShellConfig? = synchronized(lock) {
+        when {
+            sessions.isEmpty() -> null
+            sessions.size == 1 -> sessions.values.first()
+            else -> sessions.values.lastOrNull()
+        }
+    }
+
+    fun config(appId: Long): ShellConfig? = synchronized(lock) {
+        val key = normalizeAppId(appId)
+        if (key > 0L) {
+            sessions[key]
+        } else {
+            config()
+        }
+    }
+
+    fun appId(): Long = synchronized(lock) {
+        sessions.keys.lastOrNull { it > 0L } ?: sessions.keys.lastOrNull() ?: -1L
+    }
+
+    fun activationAppId(): Long {
+        val id = appId()
+        return if (id > 0L) id else -1L
+    }
+
+    private fun normalizeAppId(appId: Long): Long = if (appId > 0L) appId else -1L
 }

--- a/app/src/main/java/com/webtoapp/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AboutScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.webtoapp.R
 import com.webtoapp.core.host.HostRuntimePrefs
+import com.webtoapp.ui.shell.ShellDocumentActivity
 import com.webtoapp.ui.webview.WebViewDocumentActivity
 import com.webtoapp.core.i18n.AppLanguage
 import com.webtoapp.core.i18n.Strings
@@ -124,6 +125,7 @@ fun AboutScreen(onBack: () -> Unit) {
                                 hostPrefs.setSeparateTasksEnabled(enabled)
                                 if (!enabled) {
                                     WebViewDocumentActivity.finishAllDocumentTasks()
+                                    ShellDocumentActivity.finishAllDocumentTasks()
                                 }
                             }
                         },

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -29,7 +29,7 @@ import com.webtoapp.core.forcedrun.ForcedRunManager
 import com.webtoapp.core.floatingwindow.FloatingWindowService
 import com.webtoapp.ui.shared.WindowHelper
 
-class ShellActivity : AppCompatActivity() {
+open class ShellActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_PREVIEW = "shell_preview"
@@ -38,6 +38,9 @@ class ShellActivity : AppCompatActivity() {
 
     private var isPreviewSession: Boolean = false
     private var previewAppId: Long = -1L
+
+    internal fun previewActivationAppId(): Long =
+        if (isPreviewSession && previewAppId > 0L) previewAppId else -1L
 
     private var webView: WebView? = null
     private var browserSurface: BrowserSurface? = null
@@ -312,7 +315,7 @@ class ShellActivity : AppCompatActivity() {
         }
 
         val config = if (isPreviewSession) {
-            com.webtoapp.core.shell.ShellPreviewSession.config()
+            com.webtoapp.core.shell.ShellPreviewSession.config(previewAppId)
         } else {
             WebToAppApplication.shellMode.getConfig()
         }
@@ -321,7 +324,7 @@ class ShellActivity : AppCompatActivity() {
             com.webtoapp.core.shell.ShellLogger.e("ShellActivity", "配置加载失败，无法启动应用")
             Toast.makeText(this, Strings.appConfigLoadFailed, Toast.LENGTH_LONG).show()
             if (isPreviewSession) {
-                com.webtoapp.core.shell.ShellPreviewSession.end()
+                com.webtoapp.core.shell.ShellPreviewSession.endIfMatches(previewAppId)
             }
             finish()
             return
@@ -777,7 +780,7 @@ class ShellActivity : AppCompatActivity() {
             setIntent(intent)
             isPreviewSession = true
             previewAppId = intent.getLongExtra(EXTRA_PREVIEW_APP_ID, -1L)
-            if (com.webtoapp.core.shell.ShellPreviewSession.config() != null) {
+            if (com.webtoapp.core.shell.ShellPreviewSession.config(previewAppId) != null) {
                 recreate()
                 return
             }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -28,13 +28,16 @@ fun ShellActivationDialog(
     onActivated: () -> Unit
 ) {
     val activation = WebToAppApplication.activation
+    val activity = LocalContext.current as? android.app.Activity
+    val activationAppId = (activity as? ShellActivity)?.previewActivationAppId()?.takeIf { it > 0L }
+        ?: ShellPreviewSession.activationAppId()
     var activationStatus by remember {
         mutableStateOf<com.webtoapp.core.activation.ActivationStatus?>(null)
     }
 
     androidx.compose.runtime.LaunchedEffect(Unit) {
         activationStatus = try {
-            activation.getActivationStatus(ShellPreviewSession.activationAppId())
+            activation.getActivationStatus(activationAppId)
         } catch (_: Exception) {
             null
         }
@@ -45,7 +48,7 @@ fun ShellActivationDialog(
         onActivate = { code ->
             val result = if (config.activationRemoteEnabled) {
                 activation.verifyRemoteActivation(
-                    ShellPreviewSession.activationAppId(),
+                    activationAppId,
                     code,
                     activation.buildRemoteRequest(
                         verifyUrl = config.activationRemoteVerifyUrl,
@@ -55,7 +58,7 @@ fun ShellActivationDialog(
                 )
             } else {
                 activation.verifyActivationCode(
-                    ShellPreviewSession.activationAppId(),
+                    activationAppId,
                     code,
                     config.activationCodes
                 )

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDocumentActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDocumentActivity.kt
@@ -1,0 +1,32 @@
+package com.webtoapp.ui.shell
+
+import java.util.Collections
+import java.util.WeakHashMap
+
+class ShellDocumentActivity : ShellActivity() {
+
+    companion object {
+        private val live = Collections.synchronizedSet(
+            Collections.newSetFromMap(WeakHashMap<ShellDocumentActivity, Boolean>())
+        )
+
+        fun finishAllDocumentTasks() {
+            val snapshot = synchronized(live) { live.toList() }
+            snapshot.forEach { activity ->
+                if (!activity.isFinishing) {
+                    activity.finishAndRemoveTask()
+                }
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        live.add(this)
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onDestroy() {
+        live.remove(this)
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -55,6 +55,8 @@ fun ShellScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val activity = context as android.app.Activity
+    val activationAppId = (activity as? ShellActivity)?.previewActivationAppId()?.takeIf { it > 0L }
+        ?: ShellPreviewSession.activationAppId()
     val activation = WebToAppApplication.activation
     val announcement = WebToAppApplication.announcement
     val adBlocker = WebToAppApplication.adBlock
@@ -147,16 +149,16 @@ fun ShellScreen(
         if (config.activationEnabled) {
 
             if (config.activationRequireEveryTime) {
-                activation.resetActivation(ShellPreviewSession.activationAppId())
+                activation.resetActivation(activationAppId)
                 isActivated = false
                 isActivationChecked = true
                 showActivationDialog = true
             } else {
 
                 val activated = if (config.activationRemoteEnabled) {
-                    activation.isActivated(ShellPreviewSession.activationAppId()).first() &&
+                    activation.isActivated(activationAppId).first() &&
                         activation.isRemoteStartupAllowed(
-                            ShellPreviewSession.activationAppId(),
+                            activationAppId,
                             activation.buildRemoteRequest(
                                 verifyUrl = config.activationRemoteVerifyUrl,
                                 publicKeyBase64 = config.activationRemotePublicKey,
@@ -164,7 +166,7 @@ fun ShellScreen(
                             )
                         )
                 } else {
-                    activation.resolveStartupActivation(ShellPreviewSession.activationAppId())
+                    activation.resolveStartupActivation(activationAppId)
                 }
                 isActivated = activated
                 isActivationChecked = true

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -292,6 +292,7 @@ val syncShellRuntimeSources by tasks.registering(Sync::class) {
         "**/core/extension/panel/**",
         "**/core/appearance/BrowserDisguiseJsGenerator.kt",
         "**/ui/shell/TranslateScriptProvider.kt",
+        "**/ui/shell/ShellDocumentActivity.kt",
 
         "**/core/privacy/IsolationManager.kt",
         "**/core/privacy/FingerprintGenerator.kt",


### PR DESCRIPTION
## Summary
- Add host-only `ShellDocumentActivity` (`documentLaunchMode=always`), excluded from LITE shell sync
- `ShellPreviewLauncher` uses Document Activity when separate-tasks pref is enabled
- `ShellPreviewSession` supports concurrent previews keyed by app id
- About toggle off finishes both WebView and Shell document tasks

## Related Issue
Fixes #209

## Test plan
- [ ] About → enable WebApp separate tasks
- [ ] Open two different apps from Home; recents shows two entries
- [ ] Disable toggle; document tasks cleaned up / single-task behavior returns
- [ ] CI green on this PR
- [x] Issue linked with `Fixes`

## Notes
Host-only pref via `HostRuntimePrefs`. Does not flow into ApkConfig/export.