### PR TITLE
fix(build): make custom Gradle tasks configuration-cache safe

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -210,7 +210,8 @@ tasks.matching { it.name == "preBuild" }.configureEach {
     }
 }
 
-val cloneHostAar = project(":clone-host").layout.buildDirectory.file("outputs/aar/clone-host-release.aar")
+val cloneHostAar = rootProject.layout.projectDirectory.file("clone-host/build/outputs/aar/clone-host-release.aar")
+val androidSdkDir = android.sdkDirectory
 
 tasks.register<Copy>("syncCloneHostDex") {
     description = "Extracts classes.jar from clone-host AAR and converts it to a DEX asset for APK cloning."
@@ -219,8 +220,9 @@ tasks.register<Copy>("syncCloneHostDex") {
 
     enabled = false
 
-    val dexOutputDir = file("src/main/assets/clone_host")
+    val dexOutputDir = layout.projectDirectory.dir("src/main/assets/clone_host").asFile
     val intermediateDir = layout.buildDirectory.dir("intermediates/clone-host-extract")
+    val sdkDir = androidSdkDir
 
     doFirst {
         intermediateDir.get().asFile.mkdirs()
@@ -246,18 +248,17 @@ tasks.register<Copy>("syncCloneHostDex") {
             }
         }
 
-        val androidJar = android.sdkDirectory.resolve("platforms/android-36/android.jar")
+        val androidJar = sdkDir.resolve("platforms/android-36/android.jar")
         if (!androidJar.exists()) {
             throw GradleException("android.jar not found at ${androidJar.absolutePath}")
         }
 
-        val d8 = android.sdkDirectory.resolve("build-tools")
+        val d8 = sdkDir.resolve("build-tools")
             .listFiles()?.maxByOrNull { it.name }
             ?.resolve("d8")
             ?: throw GradleException("d8 not found in build-tools")
 
-        val dexFile = file("src/main/assets/clone_host/clone_host.dex")
-        dexFile.parentFile.mkdirs()
+        dexOutputDir.mkdirs()
 
         val process = ProcessBuilder(
             d8.absolutePath,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -172,13 +172,13 @@ android {
 val slimShellStrings by tasks.registering {
     group = "build"
     description = "Split shell i18n into per-language packs (all 10 languages)"
-    val input = rootProject.file("app/src/main/java/com/webtoapp/core/i18n/Strings.kt")
-    val slimRoot = layout.buildDirectory.dir("generated/slim-i18n")
+    val input = rootProject.layout.projectDirectory.file("app/src/main/java/com/webtoapp/core/i18n/Strings.kt").asFile
+    val script = rootProject.layout.projectDirectory.file("scripts/slim_shell_strings.py").asFile
     val output = layout.buildDirectory.file("generated/slim-i18n/com/webtoapp/core/i18n/Strings.kt")
     val tableOut = layout.buildDirectory.file("generated/slim-i18n/com/webtoapp/core/i18n/ShellStringTable.kt")
     val assetsOut = layout.buildDirectory.dir("generated/slim-i18n/assets/i18n")
     inputs.file(input)
-    inputs.file(rootProject.file("scripts/slim_shell_strings.py"))
+    inputs.file(script)
     outputs.file(output)
     outputs.file(tableOut)
     outputs.dir(assetsOut)
@@ -187,7 +187,7 @@ val slimShellStrings by tasks.registering {
         outFile.parentFile.mkdirs()
         val cmd = listOf(
             "python3",
-            rootProject.file("scripts/slim_shell_strings.py").absolutePath,
+            script.absolutePath,
             input.absolutePath,
             outFile.absolutePath
         )
@@ -209,7 +209,7 @@ val syncShellRuntimeSources by tasks.registering(Sync::class) {
     description = "Sync runtime-only Kotlin sources from app module to shell"
     group = "build"
 
-    from("../app/src/main/java")
+    from(rootProject.layout.projectDirectory.dir("app/src/main/java"))
 
     include(
         "**/ui/shell/**",
@@ -364,18 +364,19 @@ val syncShellRuntimeSources by tasks.registering(Sync::class) {
         "**/ui/components/PermissionRationale.kt"
     )
 
-    into("src/main/java")
+    into(layout.projectDirectory.dir("src/main/java"))
 }
 
 tasks.named("syncShellRuntimeSources").configure {
     dependsOn(slimShellStrings)
+    val slim = layout.buildDirectory.file("generated/slim-i18n/com/webtoapp/core/i18n/Strings.kt")
+    val table = layout.buildDirectory.file("generated/slim-i18n/com/webtoapp/core/i18n/ShellStringTable.kt")
+    val destDir = layout.projectDirectory.dir("src/main/java/com/webtoapp/core/i18n")
     doLast {
-        val slim = layout.buildDirectory.file("generated/slim-i18n/com/webtoapp/core/i18n/Strings.kt").get().asFile
-        val table = layout.buildDirectory.file("generated/slim-i18n/com/webtoapp/core/i18n/ShellStringTable.kt").get().asFile
-        val destDir = file("src/main/java/com/webtoapp/core/i18n")
-        destDir.mkdirs()
-        slim.copyTo(destDir.resolve("Strings.kt"), overwrite = true)
-        table.copyTo(destDir.resolve("ShellStringTable.kt"), overwrite = true)
+        val dest = destDir.asFile
+        dest.mkdirs()
+        slim.get().asFile.copyTo(dest.resolve("Strings.kt"), overwrite = true)
+        table.get().asFile.copyTo(dest.resolve("ShellStringTable.kt"), overwrite = true)
     }
 }
 
@@ -387,14 +388,15 @@ val syncShellRuntimeAssets by tasks.registering {
     description = "Mirror runtime-only asset files from app module to shell template (single source of truth: app/src/main/assets)."
     group = "build"
     dependsOn(slimShellStrings)
-    val phpSrc = rootProject.file("app/src/main/assets/php_router_server.php")
+    val phpSrc = rootProject.layout.projectDirectory.file("app/src/main/assets/php_router_server.php").asFile
+    val hostI18n = rootProject.layout.projectDirectory.dir("app/src/main/assets/shell_i18n").asFile
+    val assetsDir = layout.projectDirectory.dir("src/main/assets").asFile
     val i18nSrc = layout.buildDirectory.dir("generated/slim-i18n/assets/i18n")
     inputs.file(phpSrc)
     inputs.dir(i18nSrc)
-    outputs.file(file("src/main/assets/php_router_server.php"))
-    outputs.dir(file("src/main/assets/i18n"))
+    outputs.file(assetsDir.resolve("php_router_server.php"))
+    outputs.dir(assetsDir.resolve("i18n"))
     doLast {
-        val assetsDir = file("src/main/assets")
         assetsDir.mkdirs()
         val phpOut = assetsDir.resolve("php_router_server.php")
         if (phpOut.exists()) {
@@ -413,7 +415,6 @@ val syncShellRuntimeAssets by tasks.registering {
                 }
             }
         }
-        val hostI18n = rootProject.file("app/src/main/assets/shell_i18n")
         hostI18n.mkdirs()
         hostI18n.listFiles()?.forEach { it.delete() }
         i18nSrc.get().asFile.listFiles()?.forEach { src ->
@@ -541,13 +542,14 @@ tasks.register("stripShellTemplateBloat") {
     description = "Remove non-runtime bloat entries from shell release APK"
     dependsOn("packageRelease")
     val apk = layout.buildDirectory.file("outputs/apk/release/shell-release.apk")
+    val script = rootProject.layout.projectDirectory.file("scripts/strip_shell_apk_bloat.py").asFile
     inputs.file(apk)
+    inputs.file(script)
     outputs.file(apk)
     doLast {
-        val file = apk.get().asFile
-        if (!file.isFile) return@doLast
-        val script = rootProject.file("scripts/strip_shell_apk_bloat.py")
-        val pb = ProcessBuilder("python3", script.absolutePath, file.absolutePath)
+        val apkFile = apk.get().asFile
+        if (!apkFile.isFile) return@doLast
+        val pb = ProcessBuilder("python3", script.absolutePath, apkFile.absolutePath)
         pb.redirectErrorStream(true)
         val proc = pb.start()
         val log = proc.inputStream.bufferedReader().readText()


### PR DESCRIPTION
## Summary
- Capture plain `File` / layout providers at configuration time for shell packaging tasks and the disabled clone-host DEX helper
- Remove `project` / `rootProject` / `android` captures from task actions so Gradle configuration cache can store and reuse entries

## Fixes
Fixes #213

## Test plan
- [x] `./gradlew :shell:slimShellStrings :shell:syncShellRuntimeSources :shell:syncShellRuntimeAssets :shell:stripShellTemplateBloat :app:syncCloneHostDex --configuration-cache` — store with 0 problems
- [x] Second run reuses configuration cache entry
- [ ] CI `check` green