### PR TITLE
fix(export): embed go_exec_loader native lib for GO_APP

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1371,6 +1371,10 @@ class ApkBuilder(private val context: Context) {
             return appType == "NODEJS_APP"
         }
 
+        if (libName == "libgo_exec_loader.so") {
+            return appType == "GO_APP"
+        }
+
         if (libName == "libpython3.so" || libName == "libmusl-linker.so") {
             return appType == "PYTHON_APP"
         }
@@ -2063,6 +2067,30 @@ builtins.__import__ = _w2a_import
         projectDir: File
     ) {
         RuntimeAssetEmbedder.embedProjectFiles(zipOut, projectDir, RuntimeAssetEmbedder.goConfig(), logger)
+        injectGoExecLoaderNativeLib(zipOut)
+    }
+
+    private fun injectGoExecLoaderNativeLib(zipOut: ZipOutputStream) {
+        val loader = File(context.applicationInfo.nativeLibraryDir, "libgo_exec_loader.so")
+        if (!loader.exists() || !loader.canRead()) {
+            val msg =
+                "Go exec loader missing at ${loader.absolutePath}. Rebuild the host app with native go_exec_loader, then re-export the GO_APP."
+            logger.error(msg)
+            throw IllegalStateException(msg)
+        }
+        try {
+            val abi = com.webtoapp.core.golang.GoDependencyManager.getDeviceAbi()
+            val aligned = ensureAligned16kNativeLib(loader, "libgo_exec_loader.so")
+            writeEntryStoredStreaming(zipOut, "lib/$abi/libgo_exec_loader.so", aligned)
+            logger.log(
+                "Go exec loader embedded as native lib: lib/$abi/libgo_exec_loader.so (${aligned.length() / 1024} KB)"
+            )
+        } catch (e: IllegalStateException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to embed Go exec loader", e)
+            throw IllegalStateException("Failed to embed Go exec loader: ${e.message}", e)
+        }
     }
 
     private fun ensureGoProjectBinaryForExport(

--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -108,7 +108,10 @@ class GoRuntime(private val context: Context) {
             currentPort = serverPort
 
             if (!GoDependencyManager.isGoExecLoaderReady(context)) {
-                _serverState.value = ServerState.Error("Go executable loader 未就绪")
+                val path = GoDependencyManager.getGoExecLoaderPath(context)
+                _serverState.value = ServerState.Error(
+                    "Go executable loader 未就绪 ($path)。导出的 GO_APP 需包含 libgo_exec_loader.so；请用含原生 loader 的构建器重新导出。"
+                )
                 return@withContext -1
             }
 


### PR DESCRIPTION
## Summary
- Export injects `libgo_exec_loader.so` into GO_APP APKs from the host native library directory (ABI-aware, 16k aligned)
- Keeps the loader only for `GO_APP` when filtering required native libs
- Hard-fails export if the host build lacks the loader; runtime error includes the expected path

## Fixes
Fixes #214

## Test plan
- [ ] Rebuild host with native `go_exec_loader`, re-export a GO_APP, confirm `lib/<abi>/libgo_exec_loader.so` is present
- [ ] Missing host loader fails export with a clear message
- [ ] CI `check` green