### PR TITLE
fix(export): embed node bridge and 16KB-align libnode for NODEJS_APP

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1625,20 +1625,29 @@ class ApkBuilder(private val context: Context) {
     }
 
     private fun ensureAligned16kNativeLib(sourceFile: File, displayName: String): File {
-        if (displayName == com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME) {
-            logger.log("ELF 16KB internal patch skipped for $displayName; APK zip entry will still be 16KB aligned")
-            return sourceFile
-        }
-
+        val requireAligned =
+            displayName == com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME ||
+                displayName == "libnode_bridge.so" ||
+                displayName == "libgo_exec_loader.so" ||
+                displayName == "libphp.so" ||
+                displayName == "libpython3.so" ||
+                displayName == "libmusl-linker.so"
         return try {
             val result = ElfAligner16k.ensureAligned(sourceFile, File(tempDir, "elf16k"))
             when {
                 result.alreadyAligned -> logger.log("ELF 16KB already aligned: $displayName")
-                result.repacked -> logger.log("ELF 16KB repacked: $displayName (${sourceFile.length() / 1024} KB -> ${result.outputFile.length() / 1024} KB)")
+                result.repacked -> logger.log(
+                    "ELF 16KB repacked: $displayName (${sourceFile.length() / 1024} KB -> ${result.outputFile.length() / 1024} KB)"
+                )
                 result.changed -> logger.log("ELF 16KB metadata patched: $displayName")
             }
             result.outputFile
         } catch (e: Exception) {
+            if (requireAligned) {
+                val msg = "ELF 16KB alignment failed for $displayName: ${e.message}"
+                logger.error(msg, e)
+                throw IllegalStateException(msg, e)
+            }
             logger.warn("ELF 16KB alignment failed for $displayName: ${e.message}; using original binary")
             sourceFile
         }
@@ -1832,23 +1841,73 @@ class ApkBuilder(private val context: Context) {
     ) {
 
         RuntimeAssetEmbedder.embedProjectFiles(zipOut, projectDir, RuntimeAssetEmbedder.nodeJsConfig(), logger)
+        injectNodeJsNativeLibs(zipOut)
+    }
 
-        val nodeDir = com.webtoapp.core.nodejs.NodeDependencyManager.getNodeDir(context)
-        val nodeBinary = File(nodeDir, com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME)
-        if (nodeBinary.exists() && nodeBinary.canRead()) {
-            try {
-                val abi = nodeDir.name
+    private fun resolveNodeJsBinary(): File? {
+        val nativeNode = File(
+            context.applicationInfo.nativeLibraryDir,
+            com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME
+        )
+        if (nativeNode.exists() && nativeNode.canRead() && nativeNode.length() > 0L) {
+            AppLogger.d("ApkBuilder", "Using nativeLibraryDir Node: ${nativeNode.absolutePath}")
+            return nativeNode
+        }
+        val downloaded = File(
+            com.webtoapp.core.nodejs.NodeDependencyManager.getNodeDir(context),
+            com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME
+        )
+        if (downloaded.exists() && downloaded.canRead() && downloaded.length() > 0L) {
+            AppLogger.d("ApkBuilder", "Using downloaded Node: ${downloaded.absolutePath}")
+            return downloaded
+        }
+        return null
+    }
 
-                val nodeLibPath = "lib/$abi/${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME}"
-                val alignedNodeBinary = ensureAligned16kNativeLib(nodeBinary, com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME)
+    private fun injectNodeJsNativeLibs(zipOut: ZipOutputStream) {
+        val abi = com.webtoapp.core.nodejs.NodeDependencyManager.getDeviceAbi()
+        val bridge = File(context.applicationInfo.nativeLibraryDir, "libnode_bridge.so")
+        if (!bridge.exists() || !bridge.canRead() || bridge.length() <= 0L) {
+            val msg =
+                "Node bridge missing at ${bridge.absolutePath}. Rebuild the host app with native node_bridge, then re-export the NODEJS_APP."
+            logger.error(msg)
+            throw IllegalStateException(msg)
+        }
+        val nodeBinary = resolveNodeJsBinary()
+        if (nodeBinary == null) {
+            val cachePath = File(
+                com.webtoapp.core.nodejs.NodeDependencyManager.getNodeDir(context),
+                com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME
+            ).absolutePath
+            val msg =
+                "libnode.so missing from host nativeLibraryDir and download cache ($cachePath). Download Node.js runtime in Settings → Runtime Engines, then re-export."
+            logger.error(msg)
+            throw IllegalStateException(msg)
+        }
+        try {
+            val alignedBridge = ensureAligned16kNativeLib(bridge, "libnode_bridge.so")
+            writeEntryStoredStreaming(zipOut, "lib/$abi/libnode_bridge.so", alignedBridge)
+            logger.log(
+                "Node bridge embedded as native lib: lib/$abi/libnode_bridge.so (${alignedBridge.length() / 1024} KB)"
+            )
 
-                writeEntryStoredStreaming(zipOut, nodeLibPath, alignedNodeBinary)
-                logger.log("Node.js binary embedded as native lib: $nodeLibPath (${alignedNodeBinary.length() / 1024} KB)")
-            } catch (e: Exception) {
-                logger.error("Failed to embed Node.js binary", e)
-            }
-        } else {
-            logger.warn("Node.js binary not found in cache: ${nodeBinary.absolutePath}")
+            val alignedNode = ensureAligned16kNativeLib(
+                nodeBinary,
+                com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME
+            )
+            writeEntryStoredStreaming(
+                zipOut,
+                "lib/$abi/${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME}",
+                alignedNode
+            )
+            logger.log(
+                "Node.js binary embedded as native lib: lib/$abi/${com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME} (${alignedNode.length() / 1024} KB)"
+            )
+        } catch (e: IllegalStateException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Failed to embed Node.js native libs", e)
+            throw IllegalStateException("Failed to embed Node.js native libs: ${e.message}", e)
         }
     }
 

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeBridge.kt
@@ -38,15 +38,6 @@ object NodeBridge {
             return true
         }
 
-        try {
-            System.loadLibrary("node")
-            AppLogger.i(TAG, "libnode.so 通过 System.loadLibrary 加载成功")
-            ShellLogger.i(TAG, "libnode.so 通过 System.loadLibrary 加载成功")
-
-        } catch (e: UnsatisfiedLinkError) {
-            AppLogger.d(TAG, "System.loadLibrary(\"node\") 失败: ${e.message}")
-        }
-
         val nodePath = NodeDependencyManager.getNodeLibraryPath(context)
         if (nodePath == null) {
             AppLogger.e(TAG, "libnode.so 未找到")
@@ -62,8 +53,8 @@ object NodeBridge {
             AppLogger.i(TAG, "libnode.so 加载成功")
             ShellLogger.i(TAG, "libnode.so 加载成功")
         } else {
-            AppLogger.e(TAG, "libnode.so 加载失败")
-            ShellLogger.e(TAG, "libnode.so 加载失败")
+            AppLogger.e(TAG, "libnode.so 加载失败 path=$nodePath")
+            ShellLogger.e(TAG, "libnode.so 加载失败 path=$nodePath")
         }
         return result
     }

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
@@ -126,8 +126,32 @@ object NodeDependencyManager {
 
     fun getNodeLibraryPath(context: Context): String? {
         val nativeNode = File(context.applicationInfo.nativeLibraryDir, NODE_BINARY_NAME)
-        if (nativeNode.exists()) {
-            AppLogger.d(TAG, "libnode.so path (nativeLibraryDir): ${nativeNode.absolutePath}")
+        if (nativeNode.exists() && nativeNode.length() > 0L) {
+            if (isElfPageAlignmentCompatible(nativeNode)) {
+                AppLogger.d(TAG, "libnode.so path (nativeLibraryDir, page-aligned): ${nativeNode.absolutePath}")
+                return nativeNode.absolutePath
+            }
+            val staged = File(getNodeDir(context), NODE_BINARY_NAME)
+            try {
+                val needsCopy = !staged.exists() ||
+                    staged.length() != nativeNode.length() ||
+                    staged.lastModified() < nativeNode.lastModified() ||
+                    !isElfPageAlignmentCompatible(staged)
+                if (needsCopy) {
+                    nativeNode.copyTo(staged, overwrite = true)
+                }
+                ensureLibnodePageAligned(staged)
+                if (staged.exists() && staged.length() > 0L) {
+                    AppLogger.d(TAG, "libnode.so path (staged+aligned from nativeLibraryDir): ${staged.absolutePath}")
+                    return staged.absolutePath
+                }
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "Failed to stage/align libnode.so from nativeLibraryDir", e)
+            }
+            AppLogger.w(
+                TAG,
+                "libnode.so in nativeLibraryDir is not page-aligned for ${systemPageSize()}B pages: ${nativeNode.absolutePath}"
+            )
             return nativeNode.absolutePath
         }
         val downloadedNode = File(getNodeDir(context), NODE_BINARY_NAME)

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
@@ -127,8 +127,8 @@ object NodeDependencyManager {
     fun getNodeLibraryPath(context: Context): String? {
         val nativeNode = File(context.applicationInfo.nativeLibraryDir, NODE_BINARY_NAME)
         if (nativeNode.exists() && nativeNode.length() > 0L) {
-            if (isElfPageAlignmentCompatible(nativeNode)) {
-                AppLogger.d(TAG, "libnode.so path (nativeLibraryDir, page-aligned): ${nativeNode.absolutePath}")
+            if (isElfPageAlignmentCompatible(nativeNode) || !isElf64Lsb(nativeNode)) {
+                AppLogger.d(TAG, "libnode.so path (nativeLibraryDir): ${nativeNode.absolutePath}")
                 return nativeNode.absolutePath
             }
             val staged = File(getNodeDir(context), NODE_BINARY_NAME)
@@ -141,7 +141,7 @@ object NodeDependencyManager {
                     nativeNode.copyTo(staged, overwrite = true)
                 }
                 ensureLibnodePageAligned(staged)
-                if (staged.exists() && staged.length() > 0L) {
+                if (staged.exists() && staged.length() > 0L && isElfPageAlignmentCompatible(staged)) {
                     AppLogger.d(TAG, "libnode.so path (staged+aligned from nativeLibraryDir): ${staged.absolutePath}")
                     return staged.absolutePath
                 }
@@ -442,6 +442,23 @@ object NodeDependencyManager {
             v = v or (raf.readUnsignedByte().toLong() shl (8 * i))
         }
         return v
+    }
+
+    private fun isElf64Lsb(lib: File): Boolean {
+        return try {
+            lib.inputStream().use { input ->
+                val hdr = ByteArray(6)
+                if (input.read(hdr) != 6) return false
+                hdr[0] == 0x7f.toByte() &&
+                    hdr[1] == 'E'.code.toByte() &&
+                    hdr[2] == 'L'.code.toByte() &&
+                    hdr[3] == 'F'.code.toByte() &&
+                    hdr[4].toInt() == 2 &&
+                    hdr[5].toInt() == 1
+            }
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun isElfPageAlignmentCompatible(lib: File): Boolean {

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -143,9 +143,23 @@ class NodeService : Service() {
             }
 
             android.util.Log.i(TAG, "调用 NodeBridge.loadNode...")
+            if (!NodeBridge.loadJniBridge()) {
+                android.util.Log.e(TAG, "NodeBridge.loadJniBridge 失败")
+                replyFailed(
+                    replyTo,
+                    requestId,
+                    "libnode_bridge.so 加载失败。导出的 NODEJS_APP 需包含该库；请用含原生 node_bridge 的构建器重新导出。"
+                )
+                return
+            }
             if (!NodeBridge.loadNode(this)) {
                 android.util.Log.e(TAG, "NodeBridge.loadNode 失败")
-                replyFailed(replyTo, requestId, "libnode.so 加载失败")
+                val path = NodeDependencyManager.getNodeLibraryPath(this)
+                replyFailed(
+                    replyTo,
+                    requestId,
+                    "libnode.so 加载失败 ($path)。请确认 APK 含 16KB 对齐的 libnode.so，或在主机下载 Node 运行时后重新导出。"
+                )
                 return
             }
             android.util.Log.i(TAG, "NodeBridge.loadNode 成功, isStarted=${NodeBridge.isStarted()}")


### PR DESCRIPTION
## Summary
- Inject `libnode_bridge.so` and `libnode.so` into NODEJS_APP exports (ABI-aware)
- Resolve `libnode.so` from host `nativeLibraryDir` or download cache; hard-fail export when bridge/node is missing
- Apply ELF 16KB alignment for libnode and other critical native libs (no more skip for libnode)
- Runtime: stage+align nativeLibraryDir libnode when page size is incompatible; clearer NodeService errors

## Fixes
Fixes #217

## Test plan
- [ ] Rebuild host with `node_bridge`, download Node runtime, re-export NODEJS_APP
- [ ] Confirm APK contains `lib/<abi>/libnode_bridge.so` and `lib/<abi>/libnode.so`
- [ ] Install on 16KB-page emulator; Node app starts without libnode load failure
- [ ] CI `check` green
