### PR TITLE
fix(ui): restore pull-to-refresh and chrome after fullscreen

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/EdgeSwipeRefreshLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/EdgeSwipeRefreshLayout.kt
@@ -19,7 +19,6 @@ class EdgeSwipeRefreshLayout @JvmOverloads constructor(
 
     private var touchStartedInEdge = false
 
-    private var cachedStableTopInset = 0
 
     private val edgeStartOffsetPx: Float
         get() = edgeStartOffsetDp * resources.displayMetrics.density
@@ -33,11 +32,13 @@ class EdgeSwipeRefreshLayout @JvmOverloads constructor(
     private fun edgeStartPx(): Float {
         val rootInsets = ViewCompat.getRootWindowInsets(this)
         val visibleTop = rootInsets?.getInsets(WindowInsetsCompat.Type.systemBars())?.top ?: 0
-        val stableTop = rootInsets?.getInsetsIgnoringVisibility(WindowInsetsCompat.Type.systemBars())?.top ?: 0
-        if (visibleTop > 0) cachedStableTopInset = visibleTop
-        val systemTopInset = if (visibleTop > 0) visibleTop else maxOf(stableTop, cachedStableTopInset)
         val location = IntArray(2)
         getLocationOnScreen(location)
+        val systemTopInset = if (visibleTop > 0) {
+            visibleTop
+        } else {
+            0
+        }
         val overlapTopInset = (systemTopInset - location[1]).coerceAtLeast(0)
         return overlapTopInset + edgeStartOffsetPx
     }

--- a/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/StatusBarBackground.kt
@@ -64,7 +64,6 @@ fun StatusBarBackground(
         modifier = modifier
             .fillMaxWidth()
             .height(actualHeight)
-            .statusBarsPadding()
     ) {
         when {
             backgroundType == "IMAGE" && imageBitmap != null -> {

--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -164,51 +164,50 @@ object WindowHelper {
                             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     }
                 } else {
+                    decorFitsSystemWindows = false
+                    WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+                    controller.show(WindowInsetsCompat.Type.systemBars())
+                    controller.systemBarsBehavior =
+                        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                    activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
 
-                    val needsCustomBackground = statusBarBgType == "IMAGE" ||
-                        statusBarColorMode == "CUSTOM" ||
-                        statusBarColorMode == "TRANSPARENT"
-
-                    if (needsCustomBackground) {
-
-                        decorFitsSystemWindows = false
-                        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
-                        controller.show(WindowInsetsCompat.Type.systemBars())
-                        activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
-
-                        if (statusBarBgType == "IMAGE") {
-
-                            activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
-
-                            val useDarkIcons = statusBarDarkIcons ?: !isDarkTheme
-                            controller.isAppearanceLightStatusBars = useDarkIcons
-                        } else {
-                            when (statusBarColorMode) {
-                                "CUSTOM" -> {
-                                    val color = try {
-                                        android.graphics.Color.parseColor(statusBarCustomColor ?: "#000000")
-                                    } catch (e: Exception) {
-                                        android.graphics.Color.BLACK
-                                    }
-                                    activity.window.statusBarColor = color
-                                    val useDarkIcons = statusBarDarkIcons ?: isColorLight(color)
-                                    controller.isAppearanceLightStatusBars = useDarkIcons
+                    if (statusBarBgType == "IMAGE") {
+                        activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
+                        val useDarkIcons = statusBarDarkIcons ?: !isDarkTheme
+                        controller.isAppearanceLightStatusBars = useDarkIcons
+                        controller.isAppearanceLightNavigationBars = useDarkIcons
+                    } else {
+                        when (statusBarColorMode) {
+                            "CUSTOM" -> {
+                                val color = try {
+                                    android.graphics.Color.parseColor(statusBarCustomColor ?: "#000000")
+                                } catch (e: Exception) {
+                                    android.graphics.Color.BLACK
                                 }
-                                "TRANSPARENT" -> {
-                                    activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
-                                    val useDarkIcons = statusBarDarkIcons ?: !isDarkTheme
-                                    controller.isAppearanceLightStatusBars = useDarkIcons
-                                }
+                                activity.window.statusBarColor = color
+                                val useDarkIcons = statusBarDarkIcons ?: isColorLight(color)
+                                controller.isAppearanceLightStatusBars = useDarkIcons
+                                controller.isAppearanceLightNavigationBars = useDarkIcons
+                            }
+                            "TRANSPARENT" -> {
+                                activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
+                                val useDarkIcons = statusBarDarkIcons ?: !isDarkTheme
+                                controller.isAppearanceLightStatusBars = useDarkIcons
+                                controller.isAppearanceLightNavigationBars = useDarkIcons
+                            }
+                            else -> {
+                                applyStatusBarColor(
+                                    activity,
+                                    statusBarColorMode,
+                                    statusBarCustomColor,
+                                    statusBarDarkIcons,
+                                    isDarkTheme
+                                )
                             }
                         }
-                        controller.isAppearanceLightNavigationBars = controller.isAppearanceLightStatusBars
-                    } else {
-
-                        decorFitsSystemWindows = true
-                        WindowCompat.setDecorFitsSystemWindows(activity.window, true)
-                        controller.show(WindowInsetsCompat.Type.systemBars())
-                        activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
-                        applyStatusBarColor(activity, statusBarColorMode, statusBarCustomColor, statusBarDarkIcons, isDarkTheme)
+                    }
+                    activity.window.decorView.post {
+                        ViewCompat.requestApplyInsets(activity.window.decorView)
                     }
                 }
                 applyKeyboardMode(activity, keyboardAdjustMode, tag, decorFitsSystemWindows)

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -101,7 +101,11 @@ fun BoxScope.ShellScaffoldLayout(
 
     Scaffold(
 
-        contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
+        contentWindowInsets = if (hideToolbar && !showToolbar) {
+            WindowInsets(0, 0, 0, 0)
+        } else {
+            ScaffoldDefaults.contentWindowInsets
+        },
         modifier = Modifier,
         topBar = {
             if (showToolbar) {
@@ -238,6 +242,7 @@ private fun ShellTopAppBar(
     val context = LocalContext.current
 
     TopAppBar(
+        windowInsets = TopAppBarDefaults.windowInsets,
         title = {
             Column {
                 if (showTitle) {


### PR DESCRIPTION
## Summary
- `EdgeSwipeRefreshLayout`: when system bars are hidden, pull edge starts at the view top (fixes fullscreen pull-to-refresh)
- `WindowHelper`: exit immersive keeps edge-to-edge and requests inset re-apply (avoids blank gray top band)
- `ShellScaffoldLayout`: zero content insets in true fullscreen; TopAppBar uses Material window insets when shown
- `StatusBarBackground`: remove double `statusBarsPadding` on fixed height

## Fixes
Fixes #218

## Test plan
- [ ] Enable immersive fullscreen: pull-to-refresh works from top
- [ ] Disable fullscreen after enable: top chrome/status bar restore without blank gray band
- [ ] CI `check` green
