### PR TITLE
fix(nodejs): enable 16KB app-compat before dlopen of libnode

### DIFF
--- a/app/src/main/cpp/node_bridge.cpp
+++ b/app/src/main/cpp/node_bridge.cpp
@@ -18,6 +18,23 @@
 
 typedef int (*node_start_func)(int argc, char *argv[]);
 
+typedef void (*set_16kb_appcompat_fn)(int enable);
+
+static void enable_16kb_app_compat_if_needed() {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 16384L) {
+        return;
+    }
+    set_16kb_appcompat_fn fn =
+        (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__loader_android_set_16kb_appcompat_mode");
+    if (fn == nullptr) {
+        fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "android_set_16kb_appcompat_mode");
+    }
+    if (fn != nullptr) {
+        fn(1);
+    }
+}
+
 static void *g_node_handle = nullptr;
 static node_start_func g_node_start = nullptr;
 static bool g_node_started = false;
@@ -190,6 +207,7 @@ Java_com_webtoapp_core_nodejs_NodeBridge_nativeLoadNode(
     }
     LOGI("libnode.so size: %lld bytes", (long long)st.st_size);
 
+    enable_16kb_app_compat_if_needed();
     g_node_handle = dlopen(path, RTLD_LAZY);
     env->ReleaseStringUTFChars(nodePath, path);
 

--- a/app/src/main/cpp/node_launcher.c
+++ b/app/src/main/cpp/node_launcher.c
@@ -6,8 +6,24 @@
 #include <unistd.h>
 
 typedef int (*node_start_func)(int argc, char** argv);
+typedef void (*set_16kb_appcompat_fn)(int enable);
 
 static const char* WTA_NODE_LIB = "WTA_NODE_LIB";
+
+static void enable_16kb_app_compat_if_needed(void) {
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 16384L) {
+        return;
+    }
+    set_16kb_appcompat_fn fn =
+        (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__loader_android_set_16kb_appcompat_mode");
+    if (fn == NULL) {
+        fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "android_set_16kb_appcompat_mode");
+    }
+    if (fn != NULL) {
+        fn(1);
+    }
+}
 
 int main(int argc, char* argv[]) {
     const char* node_lib_path = getenv(WTA_NODE_LIB);
@@ -23,6 +39,7 @@ int main(int argc, char* argv[]) {
     }
 
     signal(SIGPIPE, SIG_IGN);
+    enable_16kb_app_compat_if_needed();
 
     void* handle = dlopen(node_lib_path, RTLD_NOW | RTLD_GLOBAL);
     if (handle == NULL) {


### PR DESCRIPTION
## Summary
Fixes host-side Node CLI / `npm install` failures on 16KB page-size devices when loading the stock nodejs-mobile `libnode.so`.

## Problem
On `PAGE_SIZE=16384` devices, forked `libnode_launcher.so` reported:

```text
program alignment (4096) cannot be smaller than system page size (16384)
```

## Root cause
- nodejs-mobile’s ELF still has a 4KB PT_LOAD layout.
- Android’s linker `FixMinAlignFor16KiB` forces effective `min_align=4096` when load segments share a 16KB virtual page with different permissions — **even if `p_align` was rewritten to 16384**.
- `node_launcher` is a standalone native process and does not inherit the host app zygote `pageSizeCompat` flag.

## Fix
Before `dlopen(libnode.so)`:
- `node_launcher.c` and `node_bridge.cpp` call `__loader_android_set_16kb_appcompat_mode(true)` (fallback: `android_set_16kb_appcompat_mode`) when `sysconf(_SC_PAGESIZE) >= 16384`.

## Verification
On `sdk_gphone16k_arm64` with `bionic.linker.16kb.app_compat.enabled=false`:
- patched launcher successfully ran `console.log(777)` against the downloaded cache `libnode.so`.

## Issue
Fixes #221