### PR TITLE
fix(export): embed libc++_shared.so for NODEJS_APP natives

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1628,6 +1628,7 @@ class ApkBuilder(private val context: Context) {
         val requireAligned =
             displayName == com.webtoapp.core.nodejs.NodeDependencyManager.NODE_BINARY_NAME ||
                 displayName == "libnode_bridge.so" ||
+                displayName == "libc++_shared.so" ||
                 displayName == "libgo_exec_loader.so" ||
                 displayName == "libphp.so" ||
                 displayName == "libpython3.so" ||
@@ -1866,10 +1867,18 @@ class ApkBuilder(private val context: Context) {
 
     private fun injectNodeJsNativeLibs(zipOut: ZipOutputStream) {
         val abi = com.webtoapp.core.nodejs.NodeDependencyManager.getDeviceAbi()
-        val bridge = File(context.applicationInfo.nativeLibraryDir, "libnode_bridge.so")
+        val nativeDir = File(context.applicationInfo.nativeLibraryDir)
+        val bridge = File(nativeDir, "libnode_bridge.so")
         if (!bridge.exists() || !bridge.canRead() || bridge.length() <= 0L) {
             val msg =
                 "Node bridge missing at ${bridge.absolutePath}. Rebuild the host app with native node_bridge, then re-export the NODEJS_APP."
+            logger.error(msg)
+            throw IllegalStateException(msg)
+        }
+        val cxxShared = File(nativeDir, "libc++_shared.so")
+        if (!cxxShared.exists() || !cxxShared.canRead() || cxxShared.length() <= 0L) {
+            val msg =
+                "libc++_shared.so missing at ${cxxShared.absolutePath}. libnode_bridge.so and libnode.so require it; rebuild the host app, then re-export the NODEJS_APP."
             logger.error(msg)
             throw IllegalStateException(msg)
         }
@@ -1885,6 +1894,12 @@ class ApkBuilder(private val context: Context) {
             throw IllegalStateException(msg)
         }
         try {
+            val alignedCxx = ensureAligned16kNativeLib(cxxShared, "libc++_shared.so")
+            writeEntryStoredStreaming(zipOut, "lib/$abi/libc++_shared.so", alignedCxx)
+            logger.log(
+                "C++ shared runtime embedded as native lib: lib/$abi/libc++_shared.so (${alignedCxx.length() / 1024} KB)"
+            )
+
             val alignedBridge = ensureAligned16kNativeLib(bridge, "libnode_bridge.so")
             writeEntryStoredStreaming(zipOut, "lib/$abi/libnode_bridge.so", alignedBridge)
             logger.log(

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeBridge.kt
@@ -10,6 +10,10 @@ object NodeBridge {
 
     private var jniLoaded = false
 
+    @Volatile
+    var lastLoadError: String? = null
+        private set
+
     interface OutputCallback {
 
         fun onOutput(line: String, isError: Boolean)
@@ -21,9 +25,11 @@ object NodeBridge {
         return try {
             System.loadLibrary("node_bridge")
             jniLoaded = true
+            lastLoadError = null
             AppLogger.i(TAG, "node_bridge JNI 库加载成功")
             true
         } catch (e: UnsatisfiedLinkError) {
+            lastLoadError = e.message
             AppLogger.e(TAG, "node_bridge JNI 库加载失败", e)
             ShellLogger.e(TAG, "node_bridge JNI 库加载失败: ${e.message}")
             false

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -144,11 +144,12 @@ class NodeService : Service() {
 
             android.util.Log.i(TAG, "调用 NodeBridge.loadNode...")
             if (!NodeBridge.loadJniBridge()) {
-                android.util.Log.e(TAG, "NodeBridge.loadJniBridge 失败")
+                android.util.Log.e(TAG, "NodeBridge.loadJniBridge 失败: ${NodeBridge.lastLoadError}")
+                val detail = NodeBridge.lastLoadError?.takeIf { it.isNotBlank() } ?: "unknown UnsatisfiedLinkError"
                 replyFailed(
                     replyTo,
                     requestId,
-                    "libnode_bridge.so 加载失败。导出的 NODEJS_APP 需包含该库；请用含原生 node_bridge 的构建器重新导出。"
+                    "libnode_bridge.so 加载失败 ($detail)。导出的 NODEJS_APP 需包含 libnode_bridge.so 与 libc++_shared.so；请用最新构建器重新导出。"
                 )
                 return
             }


### PR DESCRIPTION
## Summary
Exported NODEJS_APP failed to load `libnode_bridge.so` because `libc++_shared.so` was not packaged.

## Root cause
- Shell packaging excludes `libc++_shared.so` (LITE size).
- `injectNodeJsNativeLibs` only embedded `libnode_bridge.so` + `libnode.so`.
- Both natives `NEEDED` `libc++_shared.so`, so `System.loadLibrary("node_bridge")` failed with `UnsatisfiedLinkError`.

## Fix
- Inject host `libc++_shared.so` into `lib/<abi>/` during NODEJS export (hard-fail if missing).
- 16KB-align it via the same path as other required natives.
- Surface the underlying load error in `NodeService` failure text.

## Issue
Fixes #223