### PR TITLE
fix(nodejs): stable JNI onOutput callback for :nodejs process

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -304,3 +304,8 @@
 -dontwarn com.google.firebase.**
 -dontwarn com.google.android.gms.**
 
+-keep class com.webtoapp.core.nodejs.NodeBridge { *; }
+-keep class com.webtoapp.core.nodejs.NodeJniOutputBridge {
+    <init>(...);
+    public void onOutput(java.lang.String, boolean);
+}

--- a/app/src/main/cpp/node_bridge.cpp
+++ b/app/src/main/cpp/node_bridge.cpp
@@ -112,11 +112,22 @@ static void *log_reader_thread(void *arg) {
                     if (env) {
                         jclass cls = env->GetObjectClass(g_callback_ref);
                         jmethodID mid = env->GetMethodID(cls, "onOutput", "(Ljava/lang/String;Z)V");
+                        if (env->ExceptionCheck()) {
+                            env->ExceptionDescribe();
+                            env->ExceptionClear();
+                            mid = nullptr;
+                        }
                         if (mid) {
                             jstring jline = env->NewStringUTF(line);
                             jboolean isErr = (fd == g_stderr_pipe[0]) ? JNI_TRUE : JNI_FALSE;
                             env->CallVoidMethod(g_callback_ref, mid, jline, isErr);
+                            if (env->ExceptionCheck()) {
+                                env->ExceptionDescribe();
+                                env->ExceptionClear();
+                            }
                             env->DeleteLocalRef(jline);
+                        } else {
+                            LOGE("callback onOutput method not found");
                         }
                         env->DeleteLocalRef(cls);
                         if (attached) {

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeBridge.kt
@@ -4,6 +4,14 @@ import android.content.Context
 import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.core.shell.ShellLogger
 
+class NodeJniOutputBridge(
+    private val callback: NodeBridge.OutputCallback
+) {
+    fun onOutput(line: String, isError: Boolean) {
+        callback.onOutput(line, isError)
+    }
+}
+
 object NodeBridge {
 
     private const val TAG = "NodeBridge"
@@ -78,15 +86,7 @@ object NodeBridge {
         AppLogger.i(TAG, "启动 Node.js: ${args.joinToString(" ")}")
         ShellLogger.i(TAG, "启动 Node.js: ${args.joinToString(" ")}")
 
-        val jniCallback = callback?.let { cb ->
-            object : Any() {
-                @Suppress("unused")
-                fun onOutput(line: String, isError: Boolean) {
-                    cb.onOutput(line, isError)
-                }
-            }
-        }
-
+        val jniCallback = callback?.let { NodeJniOutputBridge(it) }
         return nativeStartNode(args, jniCallback)
     }
 

--- a/shell/proguard-rules.pro
+++ b/shell/proguard-rules.pro
@@ -307,3 +307,8 @@
 -keep class com.webtoapp.core.webview.LocalHttpToSocksBridge$* { *; }
 -keep class com.webtoapp.core.webview.LocalHttpToSocksBridge$Socks5Connector { *; }
 
+-keep class com.webtoapp.core.nodejs.NodeBridge { *; }
+-keep class com.webtoapp.core.nodejs.NodeJniOutputBridge {
+    <init>(...);
+    public void onOutput(java.lang.String, boolean);
+}


### PR DESCRIPTION
## Summary
Exported NODEJS_APP was killing the `:nodejs` process immediately after Node started, with UI message `:nodejs 进程已断开`.

## Root cause
```text
NoSuchMethodError: NodeBridge$startNode$jniCallback$1$1.onOutput(String,Z)
```

`startNode` passed an anonymous object to native `node_bridge`. Shell minify kept the class name but dropped/broke the reflective `onOutput` method. The native log-reader thread then crashed the process on the first stderr line.

## Fix
- Replace anonymous callback with public `NodeJniOutputBridge`.
- Keep the class/method in shell + app ProGuard rules.
- Clear pending JNI exceptions if `GetMethodID` fails so a callback miss cannot kill `:nodejs`.

## Issue
Fixes #225