### PR TITLE
fix(python): ensure runtime before export preflight

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -468,6 +468,16 @@ class ApkBuilder(private val context: Context) {
             logger.section("Build Input Preflight")
             currentStage = BuildStage.INPUT_PRECHECK
 
+            val appTypeEnum = runCatching { com.webtoapp.data.model.AppType.valueOf(config.appType) }.getOrNull()
+            if (appTypeEnum != null) {
+                onProgress(18, "Ensuring runtime dependencies...")
+                val ensured = ExportRuntimeEnsure.ensure(context, appTypeEnum)
+                logger.logKeyValue("exportRuntimeEnsure", ensured)
+                if (!ensured) {
+                    logger.warn("Export runtime ensure failed for ${config.appType}")
+                }
+            }
+
             val phpBinaryPath = if (config.appType in setOf("PHP_APP", "WORDPRESS")) {
                 com.webtoapp.core.wordpress.WordPressDependencyManager.getPhpExecutablePath(context)
             } else null

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/BuildInputPreflight.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/BuildInputPreflight.kt
@@ -128,14 +128,14 @@ object BuildInputPreflight {
                     label = "Python runtime (libpython3.so)",
                     path = request.pythonBinaryPath,
                     minSize = 1024L * 1024L,
-                    hint = "Python runtime not downloaded; open Settings → Runtime Engines and download Python"
+                    hint = "Python runtime not downloaded — go to Settings → Runtime Engines and tap Download for Python. This is required even for built-in sample projects; the sample only provides app code, the Python interpreter is a separate component."
                 )
                 issues.requireNativeBinary(
                     key = "muslLinker",
                     label = "musl linker (libmusl-linker.so)",
                     path = request.muslLinkerPath,
                     minSize = 1024L,
-                    hint = "Python musl linker missing; re-download Python runtime in Settings → Runtime Engines"
+                    hint = "Python musl linker missing — re-download Python in Settings → Runtime Engines (the musl linker is packaged with the Python runtime). Required even for built-in sample projects."
                 )
                 if (request.pythonAppProjectDir.requiresPythonDependencyPrebundle()) {
                     issues.requireNativeBinary(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
@@ -1,0 +1,38 @@
+package com.webtoapp.core.apkbuilder
+
+import android.content.Context
+import com.webtoapp.core.nodejs.NodeDependencyManager
+import com.webtoapp.core.python.PythonDependencyManager
+import com.webtoapp.core.wordpress.WordPressDependencyManager
+import com.webtoapp.data.model.AppType
+
+object ExportRuntimeEnsure {
+
+    suspend fun ensure(context: Context, appType: AppType): Boolean {
+        return when (appType) {
+            AppType.PYTHON_APP -> {
+                if (PythonDependencyManager.isPythonReady(context)) true
+                else PythonDependencyManager.downloadPythonRuntime(context)
+            }
+            AppType.NODEJS_APP -> {
+                if (NodeDependencyManager.isNodeReady(context)) true
+                else NodeDependencyManager.downloadNodeRuntime(context)
+            }
+            AppType.PHP_APP -> {
+                if (WordPressDependencyManager.isPhpReady(context)) true
+                else WordPressDependencyManager.downloadPhpDependency(context)
+            }
+            AppType.WORDPRESS -> {
+                if (
+                    WordPressDependencyManager.isPhpReady(context) &&
+                    WordPressDependencyManager.isWordPressReady(context)
+                ) {
+                    true
+                } else {
+                    WordPressDependencyManager.downloadAllDependencies(context)
+                }
+            }
+            else -> true
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
@@ -8,12 +8,15 @@ import androidx.documentfile.provider.DocumentFile
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.core.python.PythonDependencyManager
 import com.webtoapp.core.python.PythonRuntime
 import com.webtoapp.core.python.PythonSampleManager
 import com.webtoapp.data.model.PythonAppConfig
@@ -90,6 +94,8 @@ fun CreatePythonAppScreen(
     var creationPhase by remember { mutableStateOf("") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var errorThrowable by remember { mutableStateOf<Throwable?>(null) }
+    val downloadState by PythonDependencyManager.downloadState.collectAsStateWithLifecycle()
+    var showDownloadDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(existingAppId) {
         if (existingAppId > 0L) {
@@ -299,6 +305,18 @@ fun CreatePythonAppScreen(
                             }
                         }
 
+                        if (!PythonDependencyManager.isPythonReady(context)) {
+                            showDownloadDialog = true
+                            creationPhase = Strings.preparingPythonEnv
+                            val success = PythonDependencyManager.downloadPythonRuntime(context)
+                            showDownloadDialog = false
+                            if (!success) {
+                                errorMessage = Strings.pythonRuntimeDownloadFailed
+                                isCreating = false
+                                return@withContext
+                            }
+                        }
+
                         creationPhase = Strings.pyProjectReady
                     }
                 } catch (e: Exception) {
@@ -392,6 +410,16 @@ fun CreatePythonAppScreen(
                                         val importedDir = runtime.createProject(newProjectId, projectDir)
                                         projectId = newProjectId
                                         localProjectDir = importedDir.absolutePath
+                                        if (!PythonDependencyManager.isPythonReady(context)) {
+                                            showDownloadDialog = true
+                                            creationPhase = Strings.preparingPythonEnv
+                                            val success = PythonDependencyManager.downloadPythonRuntime(context)
+                                            showDownloadDialog = false
+                                            if (!success) {
+                                                errorMessage = Strings.pythonRuntimeDownloadFailed
+                                                return@withContext
+                                            }
+                                        }
                                         creationPhase = Strings.pyProjectReady
                                     }
                                 } catch (e: Exception) {
@@ -596,6 +624,57 @@ fun CreatePythonAppScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
         }
+    }
+
+    if (showDownloadDialog) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text(Strings.preparingPythonEnv) },
+            text = {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    when (val state = downloadState) {
+                        is PythonDependencyManager.DownloadState.Downloading -> {
+                            Text(Strings.preparingPythonEnv)
+                            Spacer(modifier = Modifier.height(12.dp))
+                            LinearProgressIndicator(
+                                progress = { state.progress },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "${(state.bytesDownloaded / 1024 / 1024)}MB / ${(state.totalBytes / 1024 / 1024)}MB",
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                        is PythonDependencyManager.DownloadState.Extracting -> {
+                            Text(Strings.extracting.format(state.fileName))
+                            Spacer(modifier = Modifier.height(12.dp))
+                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        }
+                        is PythonDependencyManager.DownloadState.Complete -> {
+                            Text(Strings.pyProjectReady)
+                        }
+                        is PythonDependencyManager.DownloadState.Paused -> {
+                            Text(Strings.preparingPythonEnv)
+                            Spacer(modifier = Modifier.height(12.dp))
+                            LinearProgressIndicator(
+                                progress = { state.progress },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                        is PythonDependencyManager.DownloadState.Error -> {
+                            Text(text = state.message, color = MaterialTheme.colorScheme.error)
+                        }
+                        else -> {
+                            Text(Strings.preparingPythonEnv)
+                            Spacer(modifier = Modifier.height(12.dp))
+                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        }
+                    }
+                }
+            },
+            confirmButton = {}
+        )
     }
 }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
@@ -1801,11 +1801,6 @@ fun BuildApkDialog(
     fun launchBuild() {
         if (isBuilding) return
         val webAppWithConfig = currentBuildConfig()
-        val nextPreflight = ApkExportPreflight.check(context, webAppWithConfig)
-        preflightReport = nextPreflight
-        if (nextPreflight.hasErrors) {
-            return
-        }
 
         isBuilding = true
         buildFailureReport = null
@@ -1816,6 +1811,33 @@ fun BuildApkDialog(
         progress = 0
         progressText = Strings.preparing
         scope.launch {
+            progressText = when (webAppWithConfig.appType) {
+                com.webtoapp.data.model.AppType.PYTHON_APP -> Strings.preparingPythonEnv
+                com.webtoapp.data.model.AppType.NODEJS_APP -> Strings.preparingNodeEnv
+                com.webtoapp.data.model.AppType.PHP_APP,
+                com.webtoapp.data.model.AppType.WORDPRESS -> Strings.preparing
+                else -> Strings.preparing
+            }
+            val ensureOk = com.webtoapp.core.apkbuilder.ExportRuntimeEnsure.ensure(
+                context,
+                webAppWithConfig.appType
+            )
+            if (!ensureOk) {
+                progressText = when (webAppWithConfig.appType) {
+                    com.webtoapp.data.model.AppType.PYTHON_APP -> Strings.pythonRuntimeDownloadFailed
+                    com.webtoapp.data.model.AppType.NODEJS_APP -> Strings.njsDownloadFailed
+                    com.webtoapp.data.model.AppType.PHP_APP,
+                    com.webtoapp.data.model.AppType.WORDPRESS -> Strings.wpDownloadFailed
+                    else -> Strings.preparing
+                }
+            }
+            val nextPreflight = ApkExportPreflight.check(context, webAppWithConfig)
+            preflightReport = nextPreflight
+            if (nextPreflight.hasErrors) {
+                isBuilding = false
+                return@launch
+            }
+
             val result = apkBuilder.buildApk(
                 webApp = webAppWithConfig,
                 forceFullRebuild = forceFullRebuild

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/BuildInputPreflightTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/BuildInputPreflightTest.kt
@@ -140,6 +140,8 @@ class BuildInputPreflightTest {
         assertThat(result.issues.map { it.key })
             .containsExactly("pythonBinary", "muslLinker")
             .inOrder()
+        assertThat(result.issues[0].message).contains("sample only provides app code")
+        assertThat(result.issues[1].message).contains("musl linker")
     }
 
     @Test


### PR DESCRIPTION
## Summary
Python sample apps (e.g. first Flask sample) hard-blocked at export preflight with missing `libpython3.so` and musl linker because:
1. Create/sample flow did not auto-download Python (Node/PHP already do).
2. Export preflight ran before any ensure/download path, so `ApkBuilder`'s late auto-download never ran.

## Changes
- `ExportRuntimeEnsure`: download missing Python/Node/PHP/WordPress host runtimes before preflight
- Create Python: auto-download runtime after sample import / folder import
- Export Start Build + `ApkBuilder` input precheck: ensure runtimes first
- Align Python preflight hints with Node/PHP (samples need separate interpreter)

## Issue
Fixes #227

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests com.webtoapp.core.apkbuilder.BuildInputPreflightTest`
- [ ] Create first Python Flask sample without prior runtime → download prompts/completes
- [ ] Export dialog Start Build with missing Python → ensure then preflight passes (or clear download failure)