### PR TITLE
fix(export): auto-ensure runtimes when opening export dialog

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ExportRuntimeEnsure.kt
@@ -8,6 +8,19 @@ import com.webtoapp.data.model.AppType
 
 object ExportRuntimeEnsure {
 
+    fun needsEnsure(context: Context, appType: AppType): Boolean {
+        return when (appType) {
+            AppType.PYTHON_APP -> !PythonDependencyManager.isPythonReady(context)
+            AppType.NODEJS_APP -> !NodeDependencyManager.isNodeReady(context)
+            AppType.PHP_APP -> !WordPressDependencyManager.isPhpReady(context)
+            AppType.WORDPRESS -> {
+                !WordPressDependencyManager.isPhpReady(context) ||
+                    !WordPressDependencyManager.isWordPressReady(context)
+            }
+            else -> false
+        }
+    }
+
     suspend fun ensure(context: Context, appType: AppType): Boolean {
         return when (appType) {
             AppType.PYTHON_APP -> {

--- a/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
@@ -47,6 +47,7 @@ import coil.decode.VideoFrameDecoder
 import coil.request.ImageRequest
 import com.webtoapp.core.apkbuilder.ApkBuilder
 import com.webtoapp.core.apkbuilder.ApkExportPreflight
+import com.webtoapp.core.apkbuilder.ExportRuntimeEnsure
 import com.webtoapp.core.apkbuilder.ApkExportPreflightReport
 import com.webtoapp.core.apkbuilder.BuildResult
 import com.webtoapp.core.i18n.Strings
@@ -1732,6 +1733,8 @@ fun BuildApkDialog(
     var analysisReport by remember(webApp.id) { mutableStateOf<com.webtoapp.core.apkbuilder.ApkAnalyzer.AnalysisReport?>(null) }
     var buildFailureReport by remember(webApp.id) { mutableStateOf<BuildFailureReport?>(null) }
     var preflightReport by remember(webApp.id) { mutableStateOf<ApkExportPreflightReport?>(null) }
+    var isEnsuringRuntime by remember(webApp.id) { mutableStateOf(false) }
+    var ensureRuntimeText by remember(webApp.id) { mutableStateOf<String?>(null) }
     var forceFullRebuild by remember(webApp.id) { mutableStateOf(false) }
     var lastBuildMode by remember(webApp.id) { mutableStateOf<String?>(null) }
     var lastBuildReason by remember(webApp.id) { mutableStateOf<String?>(null) }
@@ -1818,7 +1821,7 @@ fun BuildApkDialog(
                 com.webtoapp.data.model.AppType.WORDPRESS -> Strings.preparing
                 else -> Strings.preparing
             }
-            val ensureOk = com.webtoapp.core.apkbuilder.ExportRuntimeEnsure.ensure(
+            val ensureOk = ExportRuntimeEnsure.ensure(
                 context,
                 webAppWithConfig.appType
             )
@@ -1874,7 +1877,34 @@ fun BuildApkDialog(
         notificationConfig,
         selectedEngineType
     ) {
-        preflightReport = ApkExportPreflight.check(context, currentBuildConfig())
+        val config = currentBuildConfig()
+        if (ExportRuntimeEnsure.needsEnsure(context, config.appType)) {
+            isEnsuringRuntime = true
+            ensureRuntimeText = when (config.appType) {
+                com.webtoapp.data.model.AppType.PYTHON_APP -> Strings.preparingPythonEnv
+                com.webtoapp.data.model.AppType.NODEJS_APP -> Strings.preparingNodeEnv
+                com.webtoapp.data.model.AppType.PHP_APP,
+                com.webtoapp.data.model.AppType.WORDPRESS -> Strings.preparing
+                else -> Strings.preparing
+            }
+            val ensureOk = ExportRuntimeEnsure.ensure(context, config.appType)
+            if (!ensureOk) {
+                ensureRuntimeText = when (config.appType) {
+                    com.webtoapp.data.model.AppType.PYTHON_APP -> Strings.pythonRuntimeDownloadFailed
+                    com.webtoapp.data.model.AppType.NODEJS_APP -> Strings.njsDownloadFailed
+                    com.webtoapp.data.model.AppType.PHP_APP,
+                    com.webtoapp.data.model.AppType.WORDPRESS -> Strings.wpDownloadFailed
+                    else -> Strings.preparing
+                }
+            } else {
+                ensureRuntimeText = null
+            }
+            isEnsuringRuntime = false
+        } else {
+            ensureRuntimeText = null
+            isEnsuringRuntime = false
+        }
+        preflightReport = ApkExportPreflight.check(context, config)
     }
 
     val dialogScrollState = rememberScrollState()
@@ -2039,8 +2069,41 @@ fun BuildApkDialog(
                     }
                 }
 
-                preflightReport?.let { report ->
-                    ApkExportPreflightPanel(report = report)
+                if (isEnsuringRuntime || ensureRuntimeText != null) {
+                    Surface(
+                        shape = RoundedCornerShape(WtaRadius.Control),
+                        color = if (isEnsuringRuntime) {
+                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
+                        } else {
+                            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.55f)
+                        }
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Text(
+                                text = ensureRuntimeText ?: Strings.preparing,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (isEnsuringRuntime) {
+                                    MaterialTheme.colorScheme.onPrimaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.onErrorContainer
+                                }
+                            )
+                            if (isEnsuringRuntime) {
+                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                            }
+                        }
+                    }
+                }
+
+                if (!isEnsuringRuntime) {
+                    preflightReport?.let { report ->
+                        ApkExportPreflightPanel(report = report)
+                    }
                 }
 
                 if (isBuilding) {
@@ -2227,7 +2290,8 @@ fun BuildApkDialog(
                             } else {
                                 launchBuild()
                             }
-                        }
+                        },
+                        enabled = !isEnsuringRuntime
                     ) {
                         val icon = if (builtApk != null) Icons.Outlined.GetApp else Icons.Outlined.Build
                         Icon(icon, null, Modifier.size(18.dp))


### PR DESCRIPTION
## Summary
#228 still left the export dialog preflight painting Python/musl blockers on open, because ensure only ran on Start Build. Users still saw two blockers for sample Python apps.

## Changes
- `ExportRuntimeEnsure.needsEnsure` for readiness probe
- Export dialog `LaunchedEffect`: ensure missing runtimes with progress UI, then preflight
- Hide blocker panel while ensuring; disable Start Build during ensure

## Issue
Fixes #229

## Test plan
- [ ] Open export on Python app without runtime → progress, then clean or real errors
- [ ] With runtime present → preflight only (no download)
- [ ] Download failure → failure banner + remaining blockers