### PR TITLE
fix(go): handle in-app build ENOSPC and relocate GOTMPDIR

### DIFF
--- a/app/src/main/java/com/webtoapp/core/golang/GoBuildEnvironment.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoBuildEnvironment.kt
@@ -118,7 +118,9 @@ object GoBuildEnvironment {
         processEnv["GOCACHE"] = buildCache.absolutePath
         processEnv["GOMODCACHE"] = GoToolchainManager.getModCacheDir(context).absolutePath
         processEnv["HOME"] = context.filesDir.absolutePath
-        processEnv["TMPDIR"] = context.cacheDir.absolutePath
+        val tempDir = GoToolchainManager.selectTempDir(context)
+        processEnv["TMPDIR"] = tempDir.absolutePath
+        processEnv["GOTMPDIR"] = tempDir.absolutePath
 
         processEnv["GOOS"] = processEnv["GOOS"] ?: "android"
         processEnv["GOARCH"] = processEnv["GOARCH"] ?: "arm64"
@@ -143,6 +145,14 @@ object GoBuildEnvironment {
         ).filter { it.isNotBlank() }.joinToString(File.pathSeparator)
     }
 
+    fun looksLikeNoSpace(stderr: String, stdout: String = ""): Boolean {
+        val blob = (stderr + "\n" + stdout).lowercase()
+        return "no space left on device" in blob ||
+            "enospc" in blob ||
+            "not enough space" in blob ||
+            "disk quota exceeded" in blob
+    }
+
     suspend fun buildProject(
         context: Context,
         projectDir: File,
@@ -152,6 +162,46 @@ object GoBuildEnvironment {
     ): File? = withContext(Dispatchers.IO) {
         val name = binaryName.ifBlank { projectDir.name }
 
+        val tempDir = GoToolchainManager.prepareForBuild(context)
+        onOutput("[env] TMPDIR=${tempDir.absolutePath} free≈${GoToolchainManager.usableBytes(tempDir) / 1024 / 1024}MB")
+        if (GoToolchainManager.usableBytes(tempDir) < 64L * 1024 * 1024) {
+            onOutput("[go] ${Strings.goBuildNoSpace}")
+            AppLogger.e(TAG, "insufficient free space for Go build under ${tempDir.absolutePath}")
+            return@withContext null
+        }
+
+        val lastStderr = StringBuilder()
+        val wrapOutput: (String) -> Unit = { line ->
+            lastStderr.appendLine(line)
+            onOutput(line)
+        }
+
+        val first = buildProjectOnce(context, projectDir, name, env, wrapOutput)
+        if (first != null) return@withContext first
+
+        if (!looksLikeNoSpace(lastStderr.toString())) {
+            return@withContext null
+        }
+
+        onOutput("[go] ${Strings.goBuildNoSpace}")
+        val freed = GoToolchainManager.clearBuildArtifactCaches(context)
+        onOutput("[go] ${Strings.goBuildStreamCleaningCache.format((freed / 1024 / 1024).coerceAtLeast(0).toInt())}")
+        onOutput("[go] ${Strings.goBuildStreamRetryAfterClean}")
+        lastStderr.clear()
+        val second = buildProjectOnce(context, projectDir, name, env, wrapOutput)
+        if (second == null && looksLikeNoSpace(lastStderr.toString())) {
+            onOutput("[go] ${Strings.goBuildNoSpace}")
+        }
+        second
+    }
+
+    private suspend fun buildProjectOnce(
+        context: Context,
+        projectDir: File,
+        name: String,
+        env: Map<String, String>,
+        onOutput: (String) -> Unit,
+    ): File? {
         val envProbe = executeGo(
             context = context,
             arguments = listOf("env", "GOPROXY", "GOSUMDB", "GO111MODULE", "GOFLAGS"),
@@ -191,7 +241,7 @@ object GoBuildEnvironment {
                     .forEach { onOutput("[stderr] $it") }
 
                 onOutput("[hint] 网络受限时可在电脑上跑 `go mod vendor`，把生成的 vendor/ 一并导入项目即可离线构建")
-                return@withContext null
+                return null
             }
             onOutput("[go] 2/3 预下载依赖 (go mod download)")
             val downloadResult = executeGo(
@@ -231,14 +281,17 @@ object GoBuildEnvironment {
         if (buildResult.exitCode != 0 || !output.exists()) {
             AppLogger.e(TAG, "go build failed: exit=${buildResult.exitCode}\n${buildResult.stderr}")
 
+            if (looksLikeNoSpace(buildResult.stderr, buildResult.stdout)) {
+                onOutput("[go] ${Strings.goBuildNoSpace}")
+            }
             onOutput("[go] ${Strings.goBuildStreamFailedExit.format(buildResult.exitCode)}")
             buildResult.stderr.lineSequence()
                 .filter { it.isNotBlank() }
                 .forEach { onOutput("[stderr] $it") }
-            return@withContext null
+            return null
         }
         output.setExecutable(true, false)
         AppLogger.i(TAG, "Go 项目构建成功: ${output.absolutePath} (${output.length() / 1024} KB)")
-        output
+        return output
     }
 }

--- a/app/src/main/java/com/webtoapp/core/golang/GoToolchainManager.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoToolchainManager.kt
@@ -84,6 +84,86 @@ object GoToolchainManager {
     fun getBuildCacheDir(context: Context): File =
         File(getToolchainRoot(context), "build-cache").also { it.mkdirs() }
 
+    fun getTempWorkDir(context: Context): File =
+        File(getToolchainRoot(context), "tmp").also { it.mkdirs() }
+
+    fun usableBytes(dir: File): Long {
+        return runCatching {
+            if (!dir.exists()) dir.mkdirs()
+            dir.usableSpace
+        }.getOrDefault(0L)
+    }
+
+    fun clearBuildArtifactCaches(context: Context): Long {
+        var freed = 0L
+        fun wipe(file: File) {
+            if (!file.exists()) return
+            val size = if (file.isFile) file.length() else directorySize(file)
+            if (file.deleteRecursively()) freed += size
+        }
+
+        wipe(getBuildCacheDir(context))
+        wipe(getTempWorkDir(context))
+        context.cacheDir.listFiles()?.forEach { child ->
+            if (child.name.startsWith("go-build") ||
+                child.name.startsWith("go-link-") ||
+                child.name == "go_tmp"
+            ) {
+                wipe(child)
+            }
+        }
+        context.externalCacheDir?.listFiles()?.forEach { child ->
+            if (child.name.startsWith("go-build") ||
+                child.name.startsWith("go-link-") ||
+                child.name == "go_tmp"
+            ) {
+                wipe(child)
+            }
+        }
+
+        getBuildCacheDir(context).mkdirs()
+        getTempWorkDir(context).mkdirs()
+        AppLogger.i(TAG, "cleared Go build caches, freed≈${freed / 1024}KB")
+        return freed
+    }
+
+    fun selectTempDir(context: Context): File {
+        val candidates = buildList {
+            add(getTempWorkDir(context))
+            context.externalCacheDir?.let { add(File(it, "go_tmp").also { d -> d.mkdirs() }) }
+            add(File(context.cacheDir, "go_tmp").also { it.mkdirs() })
+        }
+        return candidates.maxByOrNull { usableBytes(it) } ?: getTempWorkDir(context)
+    }
+
+    fun prepareForBuild(context: Context): File {
+        context.cacheDir.listFiles()?.forEach { child ->
+            if (child.name.startsWith("go-build") || child.name.startsWith("go-link-")) {
+                child.deleteRecursively()
+            }
+        }
+        val tmp = selectTempDir(context)
+        val free = usableBytes(tmp)
+        val buildCache = getBuildCacheDir(context)
+        if (free < 200L * 1024 * 1024) {
+            clearBuildArtifactCaches(context)
+        } else if (directorySize(buildCache) > 800L * 1024 * 1024) {
+            val size = directorySize(buildCache)
+            if (buildCache.deleteRecursively()) {
+                AppLogger.i(TAG, "pruned large GOCACHE ≈${size / 1024 / 1024}MB")
+            }
+            buildCache.mkdirs()
+        }
+        return selectTempDir(context)
+    }
+
+    private fun directorySize(dir: File): Long {
+        if (!dir.exists()) return 0L
+        return runCatching {
+            dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+        }.getOrDefault(0L)
+    }
+
     fun isGoReady(context: Context): Boolean {
         val goBin = getGoBinary(context)
         if (!goBin.exists() || !goBin.canExecute()) return false

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -3586,6 +3586,9 @@ object Strings {
     val goBuildInProgress: String get() = StringsD.goBuildInProgress
     val goBuildSuccess: String get() = StringsD.goBuildSuccess
     val goBuildFailed: String get() = StringsD.goBuildFailed
+    val goBuildNoSpace: String get() = StringsD.goBuildNoSpace
+    val goBuildStreamCleaningCache: String get() = StringsD.goBuildStreamCleaningCache
+    val goBuildStreamRetryAfterClean: String get() = StringsD.goBuildStreamRetryAfterClean
     val goBuildStreamNoGoMod: String get() = StringsD.goBuildStreamNoGoMod
     val goBuildStreamFailedExit: String get() = StringsD.goBuildStreamFailedExit
     val goBuildStreamToolchainNotReady: String get() = StringsD.goBuildStreamToolchainNotReady
@@ -49619,6 +49622,45 @@ object StringsD {
         AppLanguage.RUSSIAN -> "Сборка не удалась"
         AppLanguage.JAPANESE -> "ビルド失敗"
         AppLanguage.KOREAN -> "빌드 실패"
+    }
+
+    val goBuildNoSpace: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "设备存储空间不足，无法完成 Go 应用内构建。已尝试清理构建缓存；请释放存储空间后重试。"
+        AppLanguage.ENGLISH -> "Not enough storage for in-app Go build. Build caches were cleaned; free up space and try again."
+        AppLanguage.ARABIC -> "لا توجد مساحة تخزين كافية لبناء Go داخل التطبيق. تم تنظيف ذاكرة البناء؛ حرّر مساحة ثم أعد المحاولة."
+        AppLanguage.PORTUGUESE -> "Armazenamento insuficiente para o build Go no app. Caches de build foram limpos; libere espaço e tente de novo."
+        AppLanguage.SPANISH -> "Almacenamiento insuficiente para el build de Go en la app. Se limpiaron caches; libera espacio e inténtalo de nuevo."
+        AppLanguage.FRENCH -> "Espace de stockage insuffisant pour le build Go intégré. Caches nettoyés ; libérez de l'espace puis réessayez."
+        AppLanguage.GERMAN -> "Nicht genug Speicher für den In-App-Go-Build. Build-Caches wurden geleert; Speicher freigeben und erneut versuchen."
+        AppLanguage.RUSSIAN -> "Недостаточно места для in-app сборки Go. Кэш сборки очищен; освободите место и повторите."
+        AppLanguage.JAPANESE -> "アプリ内 Go ビルドに十分な空き容量がありません。ビルドキャッシュを削除しました。容量を確保して再試行してください。"
+        AppLanguage.KOREAN -> "인앱 Go 빌드에 저장 공간이 부족합니다. 빌드 캐시를 정리했습니다. 공간을 확보한 뒤 다시 시도하세요."
+    }
+
+    val goBuildStreamCleaningCache: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "已清理约 %d MB 的 Go 构建缓存"
+        AppLanguage.ENGLISH -> "Cleared about %d MB of Go build cache"
+        AppLanguage.ARABIC -> "تم مسح حوالي %d ميغابايت من ذاكرة بناء Go"
+        AppLanguage.PORTUGUESE -> "Limpou cerca de %d MB do cache de build Go"
+        AppLanguage.SPANISH -> "Se limpiaron unos %d MB de caché de build de Go"
+        AppLanguage.FRENCH -> "Environ %d Mo de cache de build Go nettoyés"
+        AppLanguage.GERMAN -> "Etwa %d MB Go-Build-Cache freigegeben"
+        AppLanguage.RUSSIAN -> "Очищено около %d МБ кэша сборки Go"
+        AppLanguage.JAPANESE -> "Go ビルドキャッシュを約 %d MB 削除しました"
+        AppLanguage.KOREAN -> "Go 빌드 캐시 약 %d MB를 정리했습니다"
+    }
+
+    val goBuildStreamRetryAfterClean: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "清理后自动重试构建…"
+        AppLanguage.ENGLISH -> "Retrying build after cache cleanup…"
+        AppLanguage.ARABIC -> "إعادة محاولة البناء بعد تنظيف الذاكرة…"
+        AppLanguage.PORTUGUESE -> "Tentando o build novamente após limpar o cache…"
+        AppLanguage.SPANISH -> "Reintentando el build tras limpiar la caché…"
+        AppLanguage.FRENCH -> "Nouvelle tentative de build après nettoyage du cache…"
+        AppLanguage.GERMAN -> "Build wird nach Cache-Bereinigung erneut versucht…"
+        AppLanguage.RUSSIAN -> "Повторная сборка после очистки кэша…"
+        AppLanguage.JAPANESE -> "キャッシュ削除後にビルドを再試行します…"
+        AppLanguage.KOREAN -> "캐시 정리 후 빌드를 다시 시도합니다…"
     }
 
     val goBuildStreamNoGoMod: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
@@ -975,11 +975,14 @@ private fun GoBuildInAppCard(
                                 lastResult = true to null
                                 onBuildComplete(produced.name, produced.length())
                             } else {
-
-                                val errLine = buildLog.lastOrNull { it.startsWith("[stderr]") }
-                                    ?: buildLog.lastOrNull { !it.startsWith("[go]") }
+                                val errLine = buildLog.asReversed().firstOrNull {
+                                    it.contains("no space left on device", ignoreCase = true) ||
+                                        it.contains(Strings.goBuildNoSpace.take(12))
+                                } ?: buildLog.asReversed().firstOrNull {
+                                    it.startsWith("[go]") && !it.contains("exit=")
+                                } ?: buildLog.lastOrNull { it.startsWith("[stderr]") }
                                     ?: buildLog.lastOrNull()
-                                lastResult = false to (errLine ?: "go build failed")
+                                lastResult = false to (errLine?.removePrefix("[go] ")?.removePrefix("[stderr] ") ?: "go build failed")
                             }
                         }
                     },

--- a/app/src/test/java/com/webtoapp/core/golang/GoBuildEnvironmentTest.kt
+++ b/app/src/test/java/com/webtoapp/core/golang/GoBuildEnvironmentTest.kt
@@ -1,0 +1,18 @@
+package com.webtoapp.core.golang
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class GoBuildEnvironmentTest {
+
+    @Test
+    fun `looksLikeNoSpace detects device full errors`() {
+        assertThat(
+            GoBuildEnvironment.looksLikeNoSpace(
+                "golang.org/x/text/unicode/bidi: mkdir /data/user/0/com.webtoapp/cache/go-build1/b254/: no space left on device"
+            )
+        ).isTrue()
+        assertThat(GoBuildEnvironment.looksLikeNoSpace("ENOSPC")).isTrue()
+        assertThat(GoBuildEnvironment.looksLikeNoSpace("compile error: undefined: Foo")).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
In-app Go build failed with `mkdir …/cache/go-build…: no space left on device` because compile temps use `TMPDIR`, which pointed at the small internal `cacheDir`.

## Changes
- `TMPDIR`/`GOTMPDIR` → best of toolchain tmp / external cache / cache go_tmp
- Pre-build cleanup of stale `go-build*` and oversized GOCACHE when free space is low
- ENOSPC detection, cache wipe, one automatic retry, localized user message
- Prefer clear storage error in Create Go UI

## Issue
Fixes #231

## Test plan
- [x] `GoBuildEnvironmentTest` (ENOSPC detection)
- [ ] Reproduce on low-space emulator: clean/retry messaging; build succeeds after free space available