### PR TITLE
fix(export): transparent runtime permissions with feature auto-hints

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -24,6 +24,7 @@ import com.webtoapp.data.model.LrcData
 import com.webtoapp.data.model.AnnouncementTemplateType
 import com.webtoapp.data.model.HtmlLoadMode
 import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.withRuntimePermissionsSyncedFromFeatures
 import com.webtoapp.data.model.getActivationCodeStrings
 import com.webtoapp.ui.components.announcement.toUiTemplate
 import com.webtoapp.ui.shell.buildPackagedHtmlShellEntryUrl
@@ -3086,7 +3087,7 @@ builtins.__import__ = _w2a_import
         if (rp.readExternalStorage) {
             permissions += "android.permission.READ_EXTERNAL_STORAGE"
         }
-        if (rp.writeExternalStorage || (config.downloadEnabled && config.downloadLocationMode != "APP_PRIVATE")) {
+        if (rp.writeExternalStorage) {
             permissions += "android.permission.WRITE_EXTERNAL_STORAGE"
         }
         if (rp.readMediaImages) {
@@ -3161,8 +3162,11 @@ builtins.__import__ = _w2a_import
 
         if (rp.foregroundService) {
             permissions += "android.permission.FOREGROUND_SERVICE"
-            permissions += "android.permission.FOREGROUND_SERVICE_DATA_SYNC"
             permissions += "android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+            permissions += "android.permission.FOREGROUND_SERVICE_DATA_SYNC"
+            if (config.bgmEnabled) {
+                permissions += "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+            }
         }
         if (rp.wakeLock) {
             permissions += "android.permission.WAKE_LOCK"
@@ -3185,20 +3189,6 @@ builtins.__import__ = _w2a_import
         if (rp.systemAlertWindow) {
             permissions += "android.permission.SYSTEM_ALERT_WINDOW"
         }
-
-        val needsForegroundService = config.backgroundRunEnabled ||
-            config.notificationEnabled ||
-            config.floatingWindowEnabled ||
-            config.forcedRunConfig?.enabled == true ||
-            config.bgmEnabled
-        if (needsForegroundService || rp.foregroundService) {
-            permissions += "android.permission.FOREGROUND_SERVICE"
-            permissions += "android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
-        }
-        if (config.forcedRunConfig?.enabled == true) {
-
-            permissions += "android.permission.FOREGROUND_SERVICE_DATA_SYNC"
-        }
         if (rp.location) {
             permissions += "android.permission.FOREGROUND_SERVICE_LOCATION"
         }
@@ -3207,24 +3197,6 @@ builtins.__import__ = _w2a_import
         }
         if (rp.microphone) {
             permissions += "android.permission.FOREGROUND_SERVICE_MICROPHONE"
-        }
-        if (config.bgmEnabled) {
-            permissions += "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
-        }
-
-        if (config.backgroundRunEnabled ||
-            config.screenAwakeMode.uppercase() != "OFF" ||
-            config.keepScreenOn ||
-            config.forcedRunConfig?.enabled == true ||
-            rp.wakeLock) {
-            permissions += "android.permission.WAKE_LOCK"
-        }
-        if (config.backgroundRunEnabled || rp.requestIgnoreBatteryOptimizations) {
-            permissions += "android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"
-        }
-
-        if (config.bootStartEnabled || config.autoStartEnabled || rp.bootCompleted) {
-            permissions += "android.permission.RECEIVE_BOOT_COMPLETED"
         }
         if (config.scheduledStartEnabled) {
             permissions += "android.permission.SCHEDULE_EXACT_ALARM"
@@ -3239,11 +3211,6 @@ builtins.__import__ = _w2a_import
         val bt = config.blackTechConfig
         if (bt?.forceFlashlight == true) {
             permissions += "android.permission.FLASHLIGHT"
-
-            permissions += "android.permission.CAMERA"
-        }
-        if (bt?.forceMaxVibration == true || rp.vibration) {
-            permissions += "android.permission.VIBRATE"
         }
         val forcedRun = config.forcedRunConfig
         val needsWriteSettings = bt?.forceScreenAwake == true ||
@@ -3253,16 +3220,10 @@ builtins.__import__ = _w2a_import
         if (needsWriteSettings) {
             permissions += "android.permission.WRITE_SETTINGS"
         }
-        if (bt?.forceWifiHotspot == true ||
-            bt?.forceDisableWifi == true ||
-            rp.wifiState) {
+        if (rp.wifiState) {
             permissions += "android.permission.ACCESS_WIFI_STATE"
             permissions += "android.permission.CHANGE_WIFI_STATE"
             permissions += "android.permission.CHANGE_NETWORK_STATE"
-        }
-
-        if (config.floatingWindowEnabled) {
-            permissions += "android.permission.SYSTEM_ALERT_WINDOW"
         }
 
         if (config.downloadEnabled) {
@@ -3504,37 +3465,8 @@ private fun WebApp.computeHtmlUsesFileScheme(context: android.content.Context?):
     htmlConfig.computeHtmlUsesFileScheme(context)
 
 private fun WebApp.buildEffectiveRuntimePermissions(): ApkRuntimePermissions {
-    var result = apkExportConfig?.runtimePermissions ?: ApkRuntimePermissions()
-    if (apkExportConfig?.backgroundRunEnabled == true) {
-        result = result.copy(
-            foregroundService = true,
-            wakeLock = true,
-            notifications = true,
-            requestIgnoreBatteryOptimizations = true
-        )
-    }
-    if (apkExportConfig?.notificationEnabled == true) {
-        result = result.copy(notifications = true, foregroundService = true)
-    }
-    if (autoStartConfig?.bootStartEnabled == true) {
-        result = result.copy(bootCompleted = true)
-    }
-    if (webViewConfig.floatingWindowConfig.enabled) {
-        result = result.copy(systemAlertWindow = true)
-    }
-    if (forcedRunConfig?.enabled == true) {
-        result = result.copy(foregroundService = true, wakeLock = true)
-    }
-    if (webViewConfig.enableNativeBridge && webViewConfig.nativeBridgeCapabilities.notification) {
-        result = result.copy(notifications = true)
-    }
-    if (webViewConfig.enableNotificationPolyfill) {
-        result = result.copy(notifications = true)
-    }
-    if (webViewConfig.geolocationEnabled) {
-        result = result.copy(location = true)
-    }
-    return result
+    val synced = withRuntimePermissionsSyncedFromFeatures()
+    return synced.apkExportConfig?.runtimePermissions ?: ApkRuntimePermissions()
 }
 
 private fun WebApp.buildMetaBlock(packageName: String, effectiveTargetUrl: String, htmlUsesFileScheme: Boolean, darkMode: String): MetaBlock = MetaBlock(

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4326,6 +4326,8 @@ object Strings {
     val permissionConfigDesc: String get() = StringsE.permissionConfigDesc
     val permissionEnabledCount: String get() = StringsE.permissionEnabledCount
     val permissionClearAll: String get() = StringsE.permissionClearAll
+    val permissionAutoEnabledBy: String get() = StringsE.permissionAutoEnabledBy
+    val permissionAutoEnabledSummary: String get() = StringsE.permissionAutoEnabledSummary
     val permissionConfigButton: String get() = StringsE.permissionConfigButton
     val permissionReadExternalStorage: String get() = StringsE.permissionReadExternalStorage
     val permissionReadExternalStorageDesc: String get() = StringsE.permissionReadExternalStorageDesc
@@ -58693,6 +58695,30 @@ object StringsE {
         AppLanguage.RUSSIAN -> "Очистить все"
         AppLanguage.JAPANESE -> "すべてクリア"
         AppLanguage.KOREAN -> "모두 지우기"
+    }
+    val permissionAutoEnabledBy: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "因以下功能自动启用：%s"
+        AppLanguage.ENGLISH -> "Auto-enabled by: %s"
+        AppLanguage.ARABIC -> "مُفعَّل تلقائياً بواسطة: %s"
+        AppLanguage.PORTUGUESE -> "Ativado automaticamente por: %s"
+        AppLanguage.SPANISH -> "Activado automáticamente por: %s"
+        AppLanguage.FRENCH -> "Activé automatiquement par : %s"
+        AppLanguage.GERMAN -> "Automatisch aktiviert durch: %s"
+        AppLanguage.RUSSIAN -> "Автоматически включено: %s"
+        AppLanguage.JAPANESE -> "次の機能により自動有効：%s"
+        AppLanguage.KOREAN -> "다음 기능으로 자동 활성화: %s"
+    }
+    val permissionAutoEnabledSummary: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "有 %d 项权限因已开启的功能自动勾选，可在下方查看来源。关闭对应功能后可手动取消。"
+        AppLanguage.ENGLISH -> "%d permission(s) were auto-checked by enabled features. See sources below. Turn off the related feature to clear them."
+        AppLanguage.ARABIC -> "تم تحديد %d إذن تلقائياً بواسطة الميزات المفعّلة. انظر المصادر أدناه. أوقف الميزة ذات الصلة لإلغاء التحديد."
+        AppLanguage.PORTUGUESE -> "%d permissão(ões) foram marcadas automaticamente por recursos ativos. Veja as origens abaixo. Desative o recurso relacionado para limpar."
+        AppLanguage.SPANISH -> "%d permiso(s) se marcaron automáticamente por funciones activas. Vea los orígenes abajo. Desactive la función relacionada para quitarlos."
+        AppLanguage.FRENCH -> "%d permission(s) ont été cochées automatiquement par des fonctions activées. Voir les sources ci-dessous. Désactivez la fonction liée pour les retirer."
+        AppLanguage.GERMAN -> "%d Berechtigung(en) wurden durch aktivierte Funktionen automatisch markiert. Quellen siehe unten. Schalten Sie die zugehörige Funktion aus, um sie zu entfernen."
+        AppLanguage.RUSSIAN -> "%d разрешение(й) отмечено автоматически включёнными функциями. Источники ниже. Отключите связанную функцию, чтобы снять отметку."
+        AppLanguage.JAPANESE -> "%d 件の権限が有効な機能により自動チェックされました。下に出典を表示。対応機能をオフにすると解除できます。"
+        AppLanguage.KOREAN -> "활성화된 기능으로 %d개 권한이 자동 선택되었습니다. 아래 출처를 확인하세요. 관련 기능을 끄면 해제할 수 있습니다."
     }
     val permissionConfigButton: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "配置权限"

--- a/app/src/main/java/com/webtoapp/data/model/RuntimePermissionSync.kt
+++ b/app/src/main/java/com/webtoapp/data/model/RuntimePermissionSync.kt
@@ -1,0 +1,260 @@
+package com.webtoapp.data.model
+
+import com.webtoapp.core.actions.DeviceActionsConfig
+import com.webtoapp.core.forcedrun.ForcedRunConfig
+
+fun ApkRuntimePermissions.enableFrom(required: ApkRuntimePermissions): ApkRuntimePermissions {
+    if (required == ApkRuntimePermissions()) return this
+    return copy(
+        camera = camera || required.camera,
+        microphone = microphone || required.microphone,
+        location = location || required.location,
+        notifications = notifications || required.notifications,
+        readExternalStorage = readExternalStorage || required.readExternalStorage,
+        writeExternalStorage = writeExternalStorage || required.writeExternalStorage,
+        readMediaImages = readMediaImages || required.readMediaImages,
+        readMediaVideo = readMediaVideo || required.readMediaVideo,
+        readMediaAudio = readMediaAudio || required.readMediaAudio,
+        bluetooth = bluetooth || required.bluetooth,
+        nfc = nfc || required.nfc,
+        wifiState = wifiState || required.wifiState,
+        bodySensors = bodySensors || required.bodySensors,
+        activityRecognition = activityRecognition || required.activityRecognition,
+        readPhoneState = readPhoneState || required.readPhoneState,
+        callPhone = callPhone || required.callPhone,
+        readContacts = readContacts || required.readContacts,
+        writeContacts = writeContacts || required.writeContacts,
+        readCalendar = readCalendar || required.readCalendar,
+        writeCalendar = writeCalendar || required.writeCalendar,
+        readSms = readSms || required.readSms,
+        sendSms = sendSms || required.sendSms,
+        receiveSms = receiveSms || required.receiveSms,
+        readCallLog = readCallLog || required.readCallLog,
+        writeCallLog = writeCallLog || required.writeCallLog,
+        processOutgoingCalls = processOutgoingCalls || required.processOutgoingCalls,
+        foregroundService = foregroundService || required.foregroundService,
+        wakeLock = wakeLock || required.wakeLock,
+        requestIgnoreBatteryOptimizations = requestIgnoreBatteryOptimizations || required.requestIgnoreBatteryOptimizations,
+        bootCompleted = bootCompleted || required.bootCompleted,
+        vibration = vibration || required.vibration,
+        installPackages = installPackages || required.installPackages,
+        requestDeletePackages = requestDeletePackages || required.requestDeletePackages,
+        systemAlertWindow = systemAlertWindow || required.systemAlertWindow
+    )
+}
+
+fun featureRequiredRuntimePermissions(
+    apkExportConfig: ApkExportConfig? = null,
+    webViewConfig: WebViewConfig = WebViewConfig(),
+    autoStartConfig: AutoStartConfig? = null,
+    forcedRunConfig: ForcedRunConfig? = null,
+    blackTechConfig: DeviceActionsConfig? = null,
+    bgmEnabled: Boolean = false
+): ApkRuntimePermissions {
+    var required = ApkRuntimePermissions()
+    val export = apkExportConfig
+    val webView = webViewConfig
+
+    if (export?.backgroundRunEnabled == true) {
+        required = required.copy(
+            foregroundService = true,
+            wakeLock = true,
+            notifications = true,
+            requestIgnoreBatteryOptimizations = true
+        )
+    }
+    if (export?.notificationEnabled == true) {
+        required = required.copy(
+            notifications = true,
+            foregroundService = true
+        )
+    }
+    if (autoStartConfig?.bootStartEnabled == true) {
+        required = required.copy(bootCompleted = true)
+    }
+    if (webView.floatingWindowConfig.enabled) {
+        required = required.copy(systemAlertWindow = true)
+    }
+    if (forcedRunConfig?.enabled == true) {
+        required = required.copy(
+            foregroundService = true,
+            wakeLock = true
+        )
+    }
+    if (webView.enableNativeBridge && webView.nativeBridgeCapabilities.notification) {
+        required = required.copy(notifications = true)
+    }
+    if (webView.enableNotificationPolyfill) {
+        required = required.copy(notifications = true)
+    }
+    if (webView.geolocationEnabled) {
+        required = required.copy(location = true)
+    }
+    if (bgmEnabled) {
+        required = required.copy(
+            foregroundService = true,
+            notifications = true
+        )
+    }
+    if (webView.downloadEnabled &&
+        webView.downloadLocationMode == DownloadLocationMode.CUSTOM
+    ) {
+        required = required.copy(writeExternalStorage = true)
+    }
+    if (webView.screenAwakeMode != ScreenAwakeMode.OFF || webView.keepScreenOn) {
+        required = required.copy(wakeLock = true)
+    }
+
+    val blackTech = blackTechConfig
+    if (blackTech?.forceFlashlight == true) {
+        required = required.copy(camera = true)
+    }
+    if (blackTech?.forceMaxVibration == true) {
+        required = required.copy(vibration = true)
+    }
+    if (blackTech?.forceWifiHotspot == true || blackTech?.forceDisableWifi == true) {
+        required = required.copy(wifiState = true)
+    }
+
+    return required
+}
+
+fun WebApp.featureRequiredRuntimePermissions(): ApkRuntimePermissions =
+    featureRequiredRuntimePermissions(
+        apkExportConfig = apkExportConfig,
+        webViewConfig = webViewConfig,
+        autoStartConfig = autoStartConfig,
+        forcedRunConfig = forcedRunConfig,
+        blackTechConfig = blackTechConfig,
+        bgmEnabled = bgmEnabled
+    )
+
+fun WebApp.withRuntimePermissionsSyncedFromFeatures(): WebApp {
+    val required = featureRequiredRuntimePermissions()
+    val currentExport = apkExportConfig ?: ApkExportConfig()
+    val merged = currentExport.runtimePermissions.enableFrom(required)
+    if (merged == currentExport.runtimePermissions && apkExportConfig != null) {
+        return this
+    }
+    return copy(apkExportConfig = currentExport.copy(runtimePermissions = merged))
+}
+
+fun ApkExportConfig.withRuntimePermissionsSyncedFromFeatures(
+    webViewConfig: WebViewConfig = WebViewConfig(),
+    autoStartConfig: AutoStartConfig? = null,
+    forcedRunConfig: ForcedRunConfig? = null,
+    blackTechConfig: DeviceActionsConfig? = null,
+    bgmEnabled: Boolean = false
+): ApkExportConfig {
+    val required = featureRequiredRuntimePermissions(
+        apkExportConfig = this,
+        webViewConfig = webViewConfig,
+        autoStartConfig = autoStartConfig,
+        forcedRunConfig = forcedRunConfig,
+        blackTechConfig = blackTechConfig,
+        bgmEnabled = bgmEnabled
+    )
+    val merged = runtimePermissions.enableFrom(required)
+    return if (merged == runtimePermissions) this else copy(runtimePermissions = merged)
+}
+
+enum class PermissionFeatureReason {
+    BACKGROUND_RUN,
+    NOTIFICATION,
+    NATIVE_BRIDGE_NOTIFICATION,
+    NOTIFICATION_POLYFILL,
+    GEOLOCATION,
+    FLOATING_WINDOW,
+    FORCED_RUN,
+    BGM,
+    BOOT_START,
+    SCREEN_AWAKE,
+    CUSTOM_DOWNLOAD,
+    DEVICE_FLASHLIGHT,
+    DEVICE_VIBRATION,
+    DEVICE_WIFI
+}
+
+fun featurePermissionReasons(
+    apkExportConfig: ApkExportConfig? = null,
+    webViewConfig: WebViewConfig = WebViewConfig(),
+    autoStartConfig: AutoStartConfig? = null,
+    forcedRunConfig: ForcedRunConfig? = null,
+    blackTechConfig: DeviceActionsConfig? = null,
+    bgmEnabled: Boolean = false
+): Map<String, List<PermissionFeatureReason>> {
+    val map = linkedMapOf<String, MutableList<PermissionFeatureReason>>()
+
+    fun add(key: String, reason: PermissionFeatureReason) {
+        map.getOrPut(key) { mutableListOf() }.let { list ->
+            if (reason !in list) list += reason
+        }
+    }
+
+    val export = apkExportConfig
+    val webView = webViewConfig
+
+    if (export?.backgroundRunEnabled == true) {
+        add("notifications", PermissionFeatureReason.BACKGROUND_RUN)
+        add("foregroundService", PermissionFeatureReason.BACKGROUND_RUN)
+        add("wakeLock", PermissionFeatureReason.BACKGROUND_RUN)
+        add("requestIgnoreBatteryOptimizations", PermissionFeatureReason.BACKGROUND_RUN)
+    }
+    if (export?.notificationEnabled == true) {
+        add("notifications", PermissionFeatureReason.NOTIFICATION)
+        add("foregroundService", PermissionFeatureReason.NOTIFICATION)
+    }
+    if (autoStartConfig?.bootStartEnabled == true) {
+        add("bootCompleted", PermissionFeatureReason.BOOT_START)
+    }
+    if (webView.floatingWindowConfig.enabled) {
+        add("systemAlertWindow", PermissionFeatureReason.FLOATING_WINDOW)
+    }
+    if (forcedRunConfig?.enabled == true) {
+        add("foregroundService", PermissionFeatureReason.FORCED_RUN)
+        add("wakeLock", PermissionFeatureReason.FORCED_RUN)
+    }
+    if (webView.enableNativeBridge && webView.nativeBridgeCapabilities.notification) {
+        add("notifications", PermissionFeatureReason.NATIVE_BRIDGE_NOTIFICATION)
+    }
+    if (webView.enableNotificationPolyfill) {
+        add("notifications", PermissionFeatureReason.NOTIFICATION_POLYFILL)
+    }
+    if (webView.geolocationEnabled) {
+        add("location", PermissionFeatureReason.GEOLOCATION)
+    }
+    if (bgmEnabled) {
+        add("foregroundService", PermissionFeatureReason.BGM)
+        add("notifications", PermissionFeatureReason.BGM)
+    }
+    if (webView.downloadEnabled && webView.downloadLocationMode == DownloadLocationMode.CUSTOM) {
+        add("writeExternalStorage", PermissionFeatureReason.CUSTOM_DOWNLOAD)
+    }
+    if (webView.screenAwakeMode != ScreenAwakeMode.OFF || webView.keepScreenOn) {
+        add("wakeLock", PermissionFeatureReason.SCREEN_AWAKE)
+    }
+
+    val blackTech = blackTechConfig
+    if (blackTech?.forceFlashlight == true) {
+        add("camera", PermissionFeatureReason.DEVICE_FLASHLIGHT)
+    }
+    if (blackTech?.forceMaxVibration == true) {
+        add("vibration", PermissionFeatureReason.DEVICE_VIBRATION)
+    }
+    if (blackTech?.forceWifiHotspot == true || blackTech?.forceDisableWifi == true) {
+        add("wifiState", PermissionFeatureReason.DEVICE_WIFI)
+    }
+
+    return map.mapValues { (_, v) -> v.toList() }
+}
+
+fun WebApp.featurePermissionReasons(): Map<String, List<PermissionFeatureReason>> =
+    featurePermissionReasons(
+        apkExportConfig = apkExportConfig,
+        webViewConfig = webViewConfig,
+        autoStartConfig = autoStartConfig,
+        forcedRunConfig = forcedRunConfig,
+        blackTechConfig = blackTechConfig,
+        bgmEnabled = bgmEnabled
+    )
+

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -1,4 +1,14 @@
 package com.webtoapp.ui.screens
+
+import com.webtoapp.data.model.featurePermissionReasons
+
+import com.webtoapp.data.model.WebViewConfig
+
+import com.webtoapp.data.model.AutoStartConfig
+
+import com.webtoapp.core.forcedrun.ForcedRunConfig
+
+import com.webtoapp.core.actions.DeviceActionsConfig
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.webtoapp.ui.design.WtaSwitch
 
@@ -538,7 +548,12 @@ fun CreateAppScreen(
             item {
                 ExportAndPermissionDrawer(
                     exportConfig = editState.apkExportConfig,
-                    onExportConfigChange = { viewModel.updateEditState { copy(apkExportConfig = it) } }
+                    onExportConfigChange = { viewModel.updateEditState { copy(apkExportConfig = it) } },
+                    webViewConfig = editState.webViewConfig,
+                    autoStartConfig = editState.autoStartConfig,
+                    forcedRunConfig = editState.forcedRunConfig,
+                    blackTechConfig = editState.blackTechConfig,
+                    bgmEnabled = editState.bgmEnabled
                 )
             }
 
@@ -580,9 +595,31 @@ fun CreateAppScreen(
 @Composable
 private fun ExportAndPermissionDrawer(
     exportConfig: ApkExportConfig,
-    onExportConfigChange: (ApkExportConfig) -> Unit
+    onExportConfigChange: (ApkExportConfig) -> Unit,
+    webViewConfig: WebViewConfig,
+    autoStartConfig: AutoStartConfig?,
+    forcedRunConfig: ForcedRunConfig?,
+    blackTechConfig: DeviceActionsConfig?,
+    bgmEnabled: Boolean
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
+    val featureReasons = remember(
+        exportConfig,
+        webViewConfig,
+        autoStartConfig,
+        forcedRunConfig,
+        blackTechConfig,
+        bgmEnabled
+    ) {
+        featurePermissionReasons(
+            apkExportConfig = exportConfig,
+            webViewConfig = webViewConfig,
+            autoStartConfig = autoStartConfig,
+            forcedRunConfig = forcedRunConfig,
+            blackTechConfig = blackTechConfig,
+            bgmEnabled = bgmEnabled
+        )
+    }
 
     WtaSettingCard {
         Column {
@@ -618,7 +655,8 @@ private fun ExportAndPermissionDrawer(
                         onPermissionsChange = { permissions ->
                             onExportConfigChange(exportConfig.copy(runtimePermissions = permissions))
                         },
-                        showDescription = false
+                        showDescription = false,
+                        featureReasons = featureReasons
                     )
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
@@ -54,6 +54,7 @@ import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.data.dao.WebAppSummary
 import com.webtoapp.data.model.AppCategory
+import com.webtoapp.data.model.withRuntimePermissionsSyncedFromFeatures
 import com.webtoapp.data.model.WebApp
 import com.webtoapp.ui.components.CategoryEditorDialog
 import com.webtoapp.ui.components.CategoryTabRow
@@ -1798,7 +1799,7 @@ fun BuildApkDialog(
                     exportConfig
                 }
             }
-        )
+        ).withRuntimePermissionsSyncedFromFeatures()
     }
 
     fun launchBuild() {

--- a/app/src/main/java/com/webtoapp/ui/screens/PermissionConfigScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/PermissionConfigScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.ApkRuntimePermissions
+import com.webtoapp.data.model.PermissionFeatureReason
 import com.webtoapp.ui.components.EnhancedElevatedCard
 import com.webtoapp.ui.components.IconSwitchCard
 import com.webtoapp.ui.components.PremiumButton
@@ -248,13 +249,17 @@ fun PermissionConfigPanel(
     permissions: ApkRuntimePermissions,
     onPermissionsChange: (ApkRuntimePermissions) -> Unit,
     modifier: Modifier = Modifier,
-    showDescription: Boolean = true
+    showDescription: Boolean = true,
+    featureReasons: Map<String, List<PermissionFeatureReason>> = emptyMap()
 ) {
     val context = LocalContext.current
     var schemeName by remember { mutableStateOf("") }
     var savedPresets by remember { mutableStateOf(PermissionPresetStorage.load(context)) }
     val enabledCount = countEnabledPermissions(permissions)
     val conflicts = detectConflicts(permissions)
+    val autoHintCount = featureReasons.count { (key, reasons) ->
+        reasons.isNotEmpty() && isPermissionKeyEnabled(permissions, key)
+    }
 
     Column(
         modifier = modifier,
@@ -277,6 +282,32 @@ fun PermissionConfigPanel(
                         text = Strings.permissionConfigDesc,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (autoHintCount > 0) {
+            EnhancedElevatedCard(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.55f)
+                )
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Icon(
+                        Icons.Outlined.AutoAwesome,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.secondary,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = Strings.permissionAutoEnabledSummary.format(autoHintCount),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
                     )
                 }
             }
@@ -396,7 +427,8 @@ fun PermissionConfigPanel(
                 PermissionGroupCard(
                     group = group,
                     permissions = permissions,
-                    onPermissionsChange = onPermissionsChange
+                    onPermissionsChange = onPermissionsChange,
+                    featureReasons = featureReasons
                 )
             }
         }
@@ -569,7 +601,8 @@ private fun PermissionSchemeCard(
 private fun PermissionGroupCard(
     group: PermissionGroup,
     permissions: ApkRuntimePermissions,
-    onPermissionsChange: (ApkRuntimePermissions) -> Unit
+    onPermissionsChange: (ApkRuntimePermissions) -> Unit,
+    featureReasons: Map<String, List<PermissionFeatureReason>> = emptyMap()
 ) {
     val enabledInGroup = group.items.count { it.checked(permissions) }
     var expanded by rememberSaveable { mutableStateOf(enabledInGroup > 0) }
@@ -650,12 +683,14 @@ private fun PermissionGroupCard(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     group.items.forEach { item ->
+                        val reasons = featureReasons[item.key].orEmpty()
                         PermissionSwitch(
                             key = item.key,
                             icon = item.icon,
                             title = item.title(),
                             subtitle = item.subtitle(),
                             checked = item.checked(permissions),
+                            featureReasonLabels = reasons.map { it.displayLabel() },
                             onCheckedChange = { checked ->
                                 onPermissionsChange(item.update(permissions, checked))
                             }
@@ -674,9 +709,26 @@ private fun PermissionSwitch(
     title: String,
     subtitle: String,
     checked: Boolean,
+    featureReasonLabels: List<String> = emptyList(),
     onCheckedChange: (Boolean) -> Unit
 ) {
     val isDangerous = key in DANGEROUS_PERMISSION_KEYS
+    val autoHint = if (featureReasonLabels.isNotEmpty()) {
+        Strings.permissionAutoEnabledBy.format(featureReasonLabels.joinToString(" · "))
+    } else {
+        null
+    }
+    val combinedSubtitle = buildString {
+        append(subtitle)
+        if (isDangerous) {
+            append('\n')
+            append(Strings.permissionDangerTag)
+        }
+        if (autoHint != null) {
+            append('\n')
+            append(autoHint)
+        }
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         IconSwitchCard(
@@ -684,7 +736,7 @@ private fun PermissionSwitch(
                 append(title)
                 if (isDangerous) append(" ⚠")
             },
-            subtitle = if (isDangerous) "$subtitle\n${Strings.permissionDangerTag}" else subtitle,
+            subtitle = combinedSubtitle,
             icon = icon,
             checked = checked,
             onCheckedChange = onCheckedChange
@@ -698,6 +750,61 @@ private fun PermissionSwitch(
             )
         }
     }
+}
+
+private fun PermissionFeatureReason.displayLabel(): String = when (this) {
+    PermissionFeatureReason.BACKGROUND_RUN -> Strings.backgroundRunTitle
+    PermissionFeatureReason.NOTIFICATION -> Strings.notificationConfigTitle
+    PermissionFeatureReason.NATIVE_BRIDGE_NOTIFICATION -> Strings.nativeBridgeTitle
+    PermissionFeatureReason.NOTIFICATION_POLYFILL -> Strings.notificationPolyfillTitle
+    PermissionFeatureReason.GEOLOCATION -> Strings.geolocationTitle
+    PermissionFeatureReason.FLOATING_WINDOW -> Strings.floatingWindowTitle
+    PermissionFeatureReason.FORCED_RUN -> Strings.forcedRunSettings
+    PermissionFeatureReason.BGM -> Strings.bgmTitle
+    PermissionFeatureReason.BOOT_START -> Strings.autoStartSettings
+    PermissionFeatureReason.SCREEN_AWAKE -> Strings.screenAwakeModeLabel
+    PermissionFeatureReason.CUSTOM_DOWNLOAD -> Strings.downloadLocationCustom
+    PermissionFeatureReason.DEVICE_FLASHLIGHT -> Strings.enableDeviceActions
+    PermissionFeatureReason.DEVICE_VIBRATION -> Strings.enableDeviceActions
+    PermissionFeatureReason.DEVICE_WIFI -> Strings.enableDeviceActions
+}
+
+private fun isPermissionKeyEnabled(permissions: ApkRuntimePermissions, key: String): Boolean = when (key) {
+    "camera" -> permissions.camera
+    "microphone" -> permissions.microphone
+    "location" -> permissions.location
+    "notifications" -> permissions.notifications
+    "readExternalStorage" -> permissions.readExternalStorage
+    "writeExternalStorage" -> permissions.writeExternalStorage
+    "readMediaImages" -> permissions.readMediaImages
+    "readMediaVideo" -> permissions.readMediaVideo
+    "readMediaAudio" -> permissions.readMediaAudio
+    "bluetooth" -> permissions.bluetooth
+    "nfc" -> permissions.nfc
+    "wifiState" -> permissions.wifiState
+    "bodySensors" -> permissions.bodySensors
+    "activityRecognition" -> permissions.activityRecognition
+    "readPhoneState" -> permissions.readPhoneState
+    "callPhone" -> permissions.callPhone
+    "readContacts" -> permissions.readContacts
+    "writeContacts" -> permissions.writeContacts
+    "readCalendar" -> permissions.readCalendar
+    "writeCalendar" -> permissions.writeCalendar
+    "readSms" -> permissions.readSms
+    "sendSms" -> permissions.sendSms
+    "receiveSms" -> permissions.receiveSms
+    "readCallLog" -> permissions.readCallLog
+    "writeCallLog" -> permissions.writeCallLog
+    "processOutgoingCalls" -> permissions.processOutgoingCalls
+    "foregroundService" -> permissions.foregroundService
+    "wakeLock" -> permissions.wakeLock
+    "requestIgnoreBatteryOptimizations" -> permissions.requestIgnoreBatteryOptimizations
+    "bootCompleted" -> permissions.bootCompleted
+    "vibration" -> permissions.vibration
+    "installPackages" -> permissions.installPackages
+    "requestDeletePackages" -> permissions.requestDeletePackages
+    "systemAlertWindow" -> permissions.systemAlertWindow
+    else -> false
 }
 
 private fun countEnabledPermissions(permissions: ApkRuntimePermissions): Int {

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/EditState.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/EditState.kt
@@ -12,6 +12,7 @@ import com.webtoapp.data.model.ActivationDialogConfig
 import com.webtoapp.data.model.AdConfig
 import com.webtoapp.data.model.Announcement
 import com.webtoapp.data.model.ApkExportConfig
+import com.webtoapp.data.model.withRuntimePermissionsSyncedFromFeatures
 import com.webtoapp.data.model.AppType
 import com.webtoapp.data.model.AutoStartConfig
 import com.webtoapp.data.model.BgmConfig
@@ -65,46 +66,64 @@ data class EditState(
     val deviceDisguiseConfig: DeviceDisguiseConfig = DeviceDisguiseConfig(),
 )
 
-fun WebApp.toEditState(): EditState = EditState(
-    name = name,
-    url = url,
-    iconUri = iconPath?.let(Uri::parse),
-    savedIconPath = iconPath,
-    appType = appType,
-    mediaConfig = mediaConfig,
-    htmlConfig = htmlConfig,
-    activationEnabled = activationEnabled,
-    activationCodeList = activationCodeList,
-    activationRequireEveryTime = activationRequireEveryTime,
-    activationDialogConfig = activationDialogConfig ?: ActivationDialogConfig(),
-    activationRemoteConfig = activationRemoteConfig,
-    adsEnabled = adsEnabled,
-    adConfig = adConfig ?: AdConfig(),
-    announcementEnabled = announcementEnabled,
-    announcement = announcement ?: Announcement(),
-    adBlockEnabled = adBlockEnabled,
-    adBlockRules = adBlockRules,
-    adBlockSubscriptions = adBlockSubscriptions,
-    webViewConfig = webViewConfig,
-    splashEnabled = splashEnabled,
-    splashConfig = splashConfig ?: SplashConfig(),
-    splashMediaUri = splashConfig?.mediaPath?.let(Uri::parse),
-    savedSplashPath = splashConfig?.mediaPath,
-    bgmEnabled = bgmEnabled,
-    bgmConfig = bgmConfig ?: BgmConfig(),
-    apkExportConfig = apkExportConfig ?: ApkExportConfig(),
-    themeType = themeType,
-    translateEnabled = translateEnabled,
-    translateConfig = translateConfig ?: TranslateConfig(),
-    extensionModuleEnabled = extensionEnabled,
-    extensionModuleIds = extensionModuleIds.toSet(),
-    extensionFabIcon = extensionFabIcon ?: "",
-    autoStartConfig = autoStartConfig,
-    forcedRunConfig = forcedRunConfig,
-    blackTechConfig = blackTechConfig,
-    disguiseConfig = disguiseConfig,
-    deviceDisguiseConfig = deviceDisguiseConfig ?: DeviceDisguiseConfig(),
-)
+fun WebApp.toEditState(): EditState {
+    val synced = withRuntimePermissionsSyncedFromFeatures()
+    return EditState(
+        name = synced.name,
+        url = synced.url,
+        iconUri = synced.iconPath?.let(Uri::parse),
+        savedIconPath = synced.iconPath,
+        appType = synced.appType,
+        mediaConfig = synced.mediaConfig,
+        htmlConfig = synced.htmlConfig,
+        activationEnabled = synced.activationEnabled,
+        activationCodeList = synced.activationCodeList,
+        activationRequireEveryTime = synced.activationRequireEveryTime,
+        activationDialogConfig = synced.activationDialogConfig ?: ActivationDialogConfig(),
+        activationRemoteConfig = synced.activationRemoteConfig,
+        adsEnabled = synced.adsEnabled,
+        adConfig = synced.adConfig ?: AdConfig(),
+        announcementEnabled = synced.announcementEnabled,
+        announcement = synced.announcement ?: Announcement(),
+        adBlockEnabled = synced.adBlockEnabled,
+        adBlockRules = synced.adBlockRules,
+        adBlockSubscriptions = synced.adBlockSubscriptions,
+        webViewConfig = synced.webViewConfig,
+        splashEnabled = synced.splashEnabled,
+        splashConfig = synced.splashConfig ?: SplashConfig(),
+        splashMediaUri = synced.splashConfig?.mediaPath?.let(Uri::parse),
+        savedSplashPath = synced.splashConfig?.mediaPath,
+        bgmEnabled = synced.bgmEnabled,
+        bgmConfig = synced.bgmConfig ?: BgmConfig(),
+        apkExportConfig = synced.apkExportConfig ?: ApkExportConfig(),
+        themeType = synced.themeType,
+        translateEnabled = synced.translateEnabled,
+        translateConfig = synced.translateConfig ?: TranslateConfig(),
+        extensionModuleEnabled = synced.extensionEnabled,
+        extensionModuleIds = synced.extensionModuleIds.toSet(),
+        extensionFabIcon = synced.extensionFabIcon ?: "",
+        autoStartConfig = synced.autoStartConfig,
+        forcedRunConfig = synced.forcedRunConfig,
+        blackTechConfig = synced.blackTechConfig,
+        disguiseConfig = synced.disguiseConfig,
+        deviceDisguiseConfig = synced.deviceDisguiseConfig ?: DeviceDisguiseConfig(),
+    )
+}
+
+fun EditState.withRuntimePermissionsSyncedFromFeatures(): EditState {
+    val syncedExport = apkExportConfig.withRuntimePermissionsSyncedFromFeatures(
+        webViewConfig = webViewConfig,
+        autoStartConfig = autoStartConfig,
+        forcedRunConfig = forcedRunConfig,
+        blackTechConfig = blackTechConfig,
+        bgmEnabled = bgmEnabled
+    )
+    return if (syncedExport === apkExportConfig || syncedExport == apkExportConfig) {
+        this
+    } else {
+        copy(apkExportConfig = syncedExport)
+    }
+}
 
 
 fun EditState.hasPreviewableContent(): Boolean = when (appType) {

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
@@ -188,7 +188,7 @@ class MainViewModel(
     }
 
     fun updateEditState(update: EditState.() -> EditState) {
-        _editState.value = _editState.value.update()
+        _editState.value = _editState.value.update().withRuntimePermissionsSyncedFromFeatures()
         _hasUnsavedChanges.value = true
     }
 

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ExportSecurityRegressionTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ExportSecurityRegressionTest.kt
@@ -103,7 +103,60 @@ class ExportSecurityRegressionTest {
     }
 
     @Test
-    fun `plain web export only injects network permissions by default`() {
+    fun `default download does not inject write storage or notifications`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val builder = ApkBuilder(context)
+        val method = ApkBuilder::class.java.getDeclaredMethod(
+            "buildRequiredPermissions",
+            ApkConfig::class.java
+        ).apply { isAccessible = true }
+
+        val config = WebApp(
+            name = "Downloader",
+            url = "https://example.com",
+            appType = AppType.WEB,
+            apkExportConfig = ApkExportConfig()
+        ).toApkConfig("com.example.downloader", context)
+
+        @Suppress("UNCHECKED_CAST")
+        val permissions = method.invoke(builder, config) as List<String>
+
+        assertThat(permissions).doesNotContain("android.permission.POST_NOTIFICATIONS")
+        assertThat(permissions).doesNotContain("android.permission.WRITE_EXTERNAL_STORAGE")
+        assertThat(permissions).doesNotContain("android.permission.CAMERA")
+        assertThat(permissions).contains("android.permission.DOWNLOAD_WITHOUT_NOTIFICATION")
+    }
+
+    @Test
+    fun `background run syncs permissions into visible runtime config before export`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val builder = ApkBuilder(context)
+        val method = ApkBuilder::class.java.getDeclaredMethod(
+            "buildRequiredPermissions",
+            ApkConfig::class.java
+        ).apply { isAccessible = true }
+
+        val config = WebApp(
+            name = "BgApp",
+            url = "https://example.com",
+            appType = AppType.WEB,
+            webViewConfig = WebViewConfig(downloadEnabled = false),
+            apkExportConfig = ApkExportConfig(backgroundRunEnabled = true)
+        ).toApkConfig("com.example.bgapp", context)
+
+        assertThat(config.runtimePermissions.notifications).isTrue()
+        assertThat(config.runtimePermissions.foregroundService).isTrue()
+
+        @Suppress("UNCHECKED_CAST")
+        val permissions = method.invoke(builder, config) as List<String>
+        assertThat(permissions).contains("android.permission.POST_NOTIFICATIONS")
+        assertThat(permissions).contains("android.permission.FOREGROUND_SERVICE")
+        assertThat(permissions).contains("android.permission.WAKE_LOCK")
+        assertThat(permissions).contains("android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS")
+    }
+
+    @Test
+        fun `plain web export only injects network permissions by default`() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val builder = ApkBuilder(context)
         val method = ApkBuilder::class.java.getDeclaredMethod(

--- a/app/src/test/java/com/webtoapp/data/model/RuntimePermissionSyncTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/RuntimePermissionSyncTest.kt
@@ -1,0 +1,112 @@
+package com.webtoapp.data.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RuntimePermissionSyncTest {
+
+    @Test
+    fun `default web app requires no runtime permissions`() {
+        val app = WebApp(name = "Plain", url = "https://example.com")
+        assertThat(app.featureRequiredRuntimePermissions()).isEqualTo(ApkRuntimePermissions())
+    }
+
+    @Test
+    fun `background run auto enables visible notification and service permissions`() {
+        val app = WebApp(
+            name = "Bg",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(backgroundRunEnabled = true)
+        )
+        val required = app.featureRequiredRuntimePermissions()
+        assertThat(required.notifications).isTrue()
+        assertThat(required.foregroundService).isTrue()
+        assertThat(required.wakeLock).isTrue()
+        assertThat(required.requestIgnoreBatteryOptimizations).isTrue()
+
+        val synced = app.withRuntimePermissionsSyncedFromFeatures()
+        assertThat(synced.apkExportConfig?.runtimePermissions?.notifications).isTrue()
+        assertThat(synced.apkExportConfig?.runtimePermissions?.foregroundService).isTrue()
+    }
+
+    @Test
+    fun `notification feature auto enables notifications in export config`() {
+        val app = WebApp(
+            name = "Notify",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(notificationEnabled = true)
+        )
+        val synced = app.withRuntimePermissionsSyncedFromFeatures()
+        assertThat(synced.apkExportConfig?.runtimePermissions?.notifications).isTrue()
+        assertThat(synced.apkExportConfig?.runtimePermissions?.foregroundService).isTrue()
+    }
+
+    @Test
+    fun `native bridge notification auto enables notifications`() {
+        val app = WebApp(
+            name = "Bridge",
+            url = "https://example.com",
+            webViewConfig = WebViewConfig(
+                enableNativeBridge = true,
+                nativeBridgeCapabilities = NativeBridgeCapabilities(notification = true)
+            )
+        )
+        val synced = app.withRuntimePermissionsSyncedFromFeatures()
+        assertThat(synced.apkExportConfig?.runtimePermissions?.notifications).isTrue()
+    }
+
+    @Test
+    fun `sync preserves manually enabled permissions`() {
+        val app = WebApp(
+            name = "Cam",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(
+                backgroundRunEnabled = true,
+                runtimePermissions = ApkRuntimePermissions(camera = true)
+            )
+        )
+        val synced = app.withRuntimePermissionsSyncedFromFeatures()
+        val perms = synced.apkExportConfig!!.runtimePermissions
+        assertThat(perms.camera).isTrue()
+        assertThat(perms.notifications).isTrue()
+    }
+
+    @Test
+    fun `system download default does not force write storage permission`() {
+        val app = WebApp(
+            name = "Dl",
+            url = "https://example.com",
+            webViewConfig = WebViewConfig(
+                downloadEnabled = true,
+                downloadLocationMode = DownloadLocationMode.SYSTEM_DOWNLOAD
+            )
+        )
+        assertThat(app.featureRequiredRuntimePermissions().writeExternalStorage).isFalse()
+    }
+
+    @Test
+    fun `custom download location auto enables write storage`() {
+        val app = WebApp(
+            name = "Dl",
+            url = "https://example.com",
+            webViewConfig = WebViewConfig(
+                downloadEnabled = true,
+                downloadLocationMode = DownloadLocationMode.CUSTOM
+            )
+        )
+        assertThat(app.featureRequiredRuntimePermissions().writeExternalStorage).isTrue()
+    }
+
+    @Test
+    fun `featurePermissionReasons lists sources for background run`() {
+        val app = WebApp(
+            name = "Bg",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(backgroundRunEnabled = true)
+        )
+        val reasons = app.featurePermissionReasons()
+        assertThat(reasons["notifications"]).contains(PermissionFeatureReason.BACKGROUND_RUN)
+        assertThat(reasons["foregroundService"]).contains(PermissionFeatureReason.BACKGROUND_RUN)
+        assertThat(reasons["wakeLock"]).contains(PermissionFeatureReason.BACKGROUND_RUN)
+    }
+}


### PR DESCRIPTION
## Summary
- Make export `runtimePermissions` the visible source of truth instead of black-box build injection.
- Auto-check matching permission toggles when related features are enabled (background run, notifications, native bridge, etc.).
- Keep pure/default WEB free of default `POST_NOTIFICATIONS` / write-storage grants.
- Show permission-panel hints for feature-driven auto-enables (10 languages).

## Issue
Fixes #233

https://github.com/shiaho777/web-to-app/issues/233

## Test plan
- [x] `RuntimePermissionSyncTest` (defaults, feature sync, reason mapping)
- [x] `ExportSecurityRegressionTest` cases for default download / background-run sync / plain web baseline
- [ ] Manual: create plain WEB app → export permission panel empty of notification → build → no notification permission prompt
- [ ] Manual: enable background run → panel auto-checks notifications/FGS and shows “auto-enabled by …” hint

## Notes
Shell template / slim i18n pack rebuild artifacts were intentionally left out of this PR.