### PR TITLE
fix: prevent duplicate module IDs causing LazyColumn crash when editing built-in modules

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -220,7 +220,7 @@ fun ExtensionModuleScreen(
         }
     }
 
-    val allModules = builtInModules + modules
+    val allModules = (builtInModules + modules).distinctBy { it.id }
     val extensionModules = allModules.filter { it.sourceType == ModuleSourceType.CUSTOM }
     val userScriptModules = allModules.filter { it.sourceType != ModuleSourceType.CUSTOM }
 
@@ -231,7 +231,7 @@ fun ExtensionModuleScreen(
             module.description.contains(searchQuery, ignoreCase = true) ||
             module.tags.any { it.contains(searchQuery, ignoreCase = true) }
         matchesCategory && matchesSearch
-    }
+    }.distinctBy { it.id }
 
     val filteredUserScripts = userScriptModules.filter { module ->
         searchQuery.isBlank() ||
@@ -247,7 +247,7 @@ fun ExtensionModuleScreen(
                 true
             }
         }
-    }
+    }.distinctBy { it.id }
 
     LaunchedEffect(loadError) {
         val error = loadError ?: return@LaunchedEffect


### PR DESCRIPTION
Fixed crash in ExtensionModuleScreen when scrolling to edited built-in modules.

**Root Cause:** When users edit a built-in module (like Element Blocker), the editor creates a new custom module with the same ID as the original. The previous merge logic allowed duplicates, causing Jetpack Compose's LazyColumn/items() to fail with "Key was already used" error.

**Solution:** Added `distinctBy { it.id }` at three levels to ensure no duplicate IDs ever reach LazyColumn.

**Related:** Fixes #200