### PR TITLE
fix: prevent duplicate module IDs when editing built-in modules causing LazyColumn crash

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -220,7 +220,7 @@ fun ExtensionModuleScreen(
         }
     }
 
-    val allModules = builtInModules + modules
+    val allModules = (builtInModules + modules).distinctBy { it.id }
     val extensionModules = allModules.filter { it.sourceType == ModuleSourceType.CUSTOM }
     val userScriptModules = allModules.filter { it.sourceType != ModuleSourceType.CUSTOM }
 
@@ -231,7 +231,7 @@ fun ExtensionModuleScreen(
             module.description.contains(searchQuery, ignoreCase = true) ||
             module.tags.any { it.contains(searchQuery, ignoreCase = true) }
         matchesCategory && matchesSearch
-    }
+    }.distinctBy { it.id }
 
     val filteredUserScripts = userScriptModules.filter { module ->
         searchQuery.isBlank() ||
@@ -247,7 +247,7 @@ fun ExtensionModuleScreen(
                 true
             }
         }
-    }
+    }.distinctBy { it.id }
 
     LaunchedEffect(loadError) {
         val error = loadError ?: return@LaunchedEffect


### PR DESCRIPTION
## Issue #200

**Problem:** Crash when scrolling to edited built-in modules in extension list.

**Error:** java.lang.IllegalArgumentException: Key "builtin-element-blocker" was already used

## Root Cause

When users edit a built-in module (e.g., Element Blocker), the editor creates a new custom module with the same ID as the original. The previous merge logic allowed duplicate IDs, causing Jetpack Compose's LazyColumn to crash.

## Solution

Added deduplication using distinctBy { it.id } at three levels:
1. Initial merge of builtInModules + modules
2. After filtering filteredModules  
3. User scripts tab filtering

Modified: app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt (+3, -3)

## Testing

- [x] Edit a built-in module (Element Blocker, etc.)
- [ ] Scroll through full module list without crashes
- [ ] Switch between category filters
- [ ] Test both Extension Modules and User Scripts tabs
