### PR TITLE
test(config): add preview/export consistency gates, fix hideUrlPreview and SSR targetUrl drift

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -63,7 +63,8 @@ jobs:
             -PallowDebugSignedRelease=true \
             :app:compileDebugKotlin \
             :shell:compileDebugKotlin \
-            :app:testDebugUnitTest
+            :app:testDebugUnitTest \
+            :app:checkConfigFieldDrift
 
       - name: Delivery summary
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -571,3 +571,27 @@ tasks.register("checkCapabilityChain") {
     }
 }
 
+tasks.register("checkConfigFieldDrift") {
+    group = "verification"
+    description = "Detect field-name drift between ApkConfig payload keys and ShellConfig @SerializedName (static guard for preview/export config consistency)"
+    val script = rootProject.file("scripts/check_config_field_drift.py")
+    val payloadFile = file("src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt")
+    val apkConfigFile = file("src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt")
+    val shellConfigFile = file("src/main/java/com/webtoapp/core/shell/ShellModeManager.kt")
+    val allowlist = rootProject.file("scripts/config_field_drift_allowlist.json")
+    inputs.files(script, payloadFile, apkConfigFile, shellConfigFile, allowlist)
+    outputs.upToDateWhen { false }
+    doLast {
+        val pb = ProcessBuilder("python3", script.absolutePath)
+        pb.directory(rootProject.projectDir)
+        pb.redirectErrorStream(true)
+        val proc = pb.start()
+        val log = proc.inputStream.bufferedReader().readText()
+        val code = proc.waitFor()
+        logger.lifecycle(log.trim())
+        if (code != 0) {
+            throw GradleException("checkConfigFieldDrift failed ($code)")
+        }
+    }
+}
+

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3468,7 +3468,8 @@ private fun WebApp.computeEffectiveTargetUrl(packageName: String): String = when
         com.webtoapp.data.model.NodeJsBuildMode.STATIC ->
             "nodejs://localhost"
         com.webtoapp.data.model.NodeJsBuildMode.API_BACKEND,
-        com.webtoapp.data.model.NodeJsBuildMode.FULLSTACK ->
+        com.webtoapp.data.model.NodeJsBuildMode.FULLSTACK,
+        com.webtoapp.data.model.NodeJsBuildMode.SSR ->
             "nodejs://localhost"
         else -> "file:///android_asset/nodejs_app/index.html"
     }
@@ -3703,6 +3704,7 @@ private fun WebApp.buildWebViewBehaviorBlock(): WebViewBehaviorBlock = WebViewBe
     enableShareBridge = webViewConfig.enableShareBridge,
     enableZoomPolyfill = webViewConfig.enableZoomPolyfill,
     enableCrossOriginIsolation = webViewConfig.enableCrossOriginIsolation,
+    hideUrlPreview = webViewConfig.hideUrlPreview,
     decodeBase64DeepLinks = webViewConfig.decodeBase64DeepLinks,
     decodeBase64Mode = webViewConfig.decodeBase64Mode.name,
     mediaAutoplayEnabled = webViewConfig.mediaAutoplayEnabled,

--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -220,7 +220,7 @@ fun ExtensionModuleScreen(
         }
     }
 
-    val allModules = builtInModules + modules
+    val allModules = (builtInModules + modules).distinctBy { it.id }
     val extensionModules = allModules.filter { it.sourceType == ModuleSourceType.CUSTOM }
     val userScriptModules = allModules.filter { it.sourceType != ModuleSourceType.CUSTOM }
 
@@ -231,7 +231,7 @@ fun ExtensionModuleScreen(
             module.description.contains(searchQuery, ignoreCase = true) ||
             module.tags.any { it.contains(searchQuery, ignoreCase = true) }
         matchesCategory && matchesSearch
-    }
+    }.distinctBy { it.id }
 
     val filteredUserScripts = userScriptModules.filter { module ->
         searchQuery.isBlank() ||
@@ -247,7 +247,7 @@ fun ExtensionModuleScreen(
                 true
             }
         }
-    }
+    }.distinctBy { it.id }
 
     LaunchedEffect(loadError) {
         val error = loadError ?: return@LaunchedEffect

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ConfigRoundTripSentinelTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ConfigRoundTripSentinelTest.kt
@@ -1,0 +1,440 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.activation.ActivationCode
+import com.webtoapp.core.activation.ActivationCodeType
+import com.webtoapp.core.appearance.BrowserDisguiseConfig
+import com.webtoapp.core.appearance.DeviceDisguiseConfig
+import com.webtoapp.core.appearance.DisguiseConfig
+import com.webtoapp.core.actions.DeviceActionsConfig
+import com.webtoapp.core.forcedrun.ForcedRunConfig
+import com.webtoapp.core.privacy.IsolationConfig
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.AdConfig
+import com.webtoapp.data.model.Announcement
+import com.webtoapp.data.model.AnnouncementTemplateType
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.ApkExportConfig
+import com.webtoapp.data.model.ApkRuntimePermissions
+import com.webtoapp.data.model.AutoStartConfig
+import com.webtoapp.data.model.BgmConfig
+import com.webtoapp.data.model.BgmItem
+import com.webtoapp.data.model.BgmPlayMode
+import com.webtoapp.data.model.ActivationDialogConfig
+import com.webtoapp.data.model.LrcTheme
+import com.webtoapp.data.model.RemoteActivationConfig
+import com.webtoapp.data.model.RemoteActivationOfflinePolicy
+import com.webtoapp.data.model.SplashConfig
+import com.webtoapp.data.model.SplashType
+import com.webtoapp.data.model.TranslateConfig
+import com.webtoapp.data.model.TranslateEngine
+import com.webtoapp.data.model.TranslateLanguage
+import com.webtoapp.data.model.UserAgentMode
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.util.GsonProvider
+import org.junit.Test
+
+class ConfigRoundTripSentinelTest {
+
+    private fun roundTrip(app: WebApp, packageName: String = "com.example.test"): ShellConfig {
+        val apk = app.toApkConfig(packageName)
+        val json = ApkConfigJsonFactory.toShellConfigJson(apk)
+        return GsonProvider.gson.fromJson(json, ShellConfig::class.java)
+            ?: error("round-trip produced null ShellConfig")
+    }
+
+    private fun baseApp(appType: AppType = AppType.WEB): WebApp = WebApp(
+        name = "Sentinel",
+        url = "https://sentinel.example.com",
+        appType = appType
+    )
+
+    @Test
+    fun `meta fields appName targetUrl packageName versionCode versionName round-trip`() {
+        val app = baseApp().copy(
+            name = "MySentinelApp",
+            apkExportConfig = ApkExportConfig(
+                customVersionCode = 42,
+                customVersionName = "9.9.9-sentinel"
+            )
+        )
+        val shell = roundTrip(app, packageName = "com.sentinel.pkg")
+        assertThat(shell.appName).isEqualTo("MySentinelApp")
+        assertThat(shell.packageName).isEqualTo("com.sentinel.pkg")
+        assertThat(shell.versionCode).isEqualTo(42)
+        assertThat(shell.versionName).isEqualTo("9.9.9-sentinel")
+        assertThat(shell.targetUrl).isEqualTo("https://sentinel.example.com")
+    }
+
+    @Test
+    fun `activation local fields round-trip through flatten and type-change`() {
+        val code1 = ActivationCode(code = "SEN-111", type = ActivationCodeType.PERMANENT)
+        val code2 = ActivationCode(code = "SEN-222", type = ActivationCodeType.USAGE_LIMITED)
+        val app = baseApp().copy(
+            activationEnabled = true,
+            activationRequireEveryTime = true,
+            activationCodeList = listOf(code1, code2),
+            activationDialogConfig = ActivationDialogConfig(
+                title = "SEN-TITLE",
+                subtitle = "SEN-SUB",
+                inputLabel = "SEN-LABEL",
+                buttonText = "SEN-BUTTON"
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.activationEnabled).isTrue()
+        assertThat(shell.activationRequireEveryTime).isTrue()
+        assertThat(shell.activationCodes).containsExactly(code1.toJson(), code2.toJson()).inOrder()
+        assertThat(shell.activationCodes[0]).contains("SEN-111")
+        assertThat(shell.activationDialogTitle).isEqualTo("SEN-TITLE")
+        assertThat(shell.activationDialogSubtitle).isEqualTo("SEN-SUB")
+        assertThat(shell.activationDialogInputLabel).isEqualTo("SEN-LABEL")
+        assertThat(shell.activationDialogButtonText).isEqualTo("SEN-BUTTON")
+    }
+
+    @Test
+    fun `activation remote config round-trip through flatten`() {
+        val app = baseApp().copy(
+            activationRemoteConfig = RemoteActivationConfig(
+                enabled = true,
+                verifyUrl = "https://verify.sentinel.example/api",
+                publicKeyBase64 = "SEN-PUBKEY-BASE64",
+                offlinePolicy = RemoteActivationOfflinePolicy.DENY
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.activationRemoteEnabled).isTrue()
+        assertThat(shell.activationRemoteVerifyUrl).isEqualTo("https://verify.sentinel.example/api")
+        assertThat(shell.activationRemotePublicKey).isEqualTo("SEN-PUBKEY-BASE64")
+        assertThat(shell.activationRemoteOfflinePolicy).isEqualTo("DENY")
+    }
+
+    @Test
+    fun `ad block fields round-trip`() {
+        val app = baseApp().copy(
+            adBlockEnabled = true,
+            adBlockRules = listOf("||ads.sentinel.example^", "||track.sentinel.example^"),
+            adBlockSubscriptions = listOf("https://list.sentinel.example/block.txt")
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.adBlockEnabled).isTrue()
+        assertThat(shell.adBlockRules).containsExactly("||ads.sentinel.example^", "||track.sentinel.example^").inOrder()
+        assertThat(shell.adBlockSubscriptions).containsExactly("https://list.sentinel.example/block.txt")
+    }
+
+    @Test
+    fun `ads block round-trip through nullable flatten`() {
+        val app = baseApp().copy(
+            adsEnabled = true,
+            adConfig = AdConfig(
+                bannerEnabled = true,
+                bannerId = "SEN-BANNER",
+                interstitialEnabled = true,
+                interstitialId = "SEN-INTER",
+                splashEnabled = true,
+                splashId = "SEN-SPLASH"
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.adsEnabled).isTrue()
+        assertThat(shell.adBannerEnabled).isTrue()
+        assertThat(shell.adBannerId).isEqualTo("SEN-BANNER")
+        assertThat(shell.adInterstitialEnabled).isTrue()
+        assertThat(shell.adInterstitialId).isEqualTo("SEN-INTER")
+        assertThat(shell.adSplashEnabled).isTrue()
+        assertThat(shell.adSplashId).isEqualTo("SEN-SPLASH")
+    }
+
+    @Test
+    fun `announcement fields round-trip through nullable flatten and enum-to-string`() {
+        val app = baseApp().copy(
+            announcementEnabled = true,
+            announcement = Announcement(
+                title = "SEN-ANN-TITLE",
+                content = "SEN-ANN-BODY",
+                contentIsHtml = true,
+                linkUrl = "https://link.sentinel.example",
+                linkText = "SEN-ANN-LINK",
+                showOnce = false,
+                requireConfirmation = true,
+                allowNeverShow = true,
+                triggerOnLaunch = false,
+                triggerOnNoNetwork = true,
+                triggerIntervalMinutes = 77,
+                version = 5,
+                triggerIntervalIncludeLaunch = true,
+                template = AnnouncementTemplateType.NEON
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.announcementEnabled).isTrue()
+        assertThat(shell.announcementTitle).isEqualTo("SEN-ANN-TITLE")
+        assertThat(shell.announcementContent).isEqualTo("SEN-ANN-BODY")
+        assertThat(shell.announcementContentIsHtml).isTrue()
+        assertThat(shell.announcementLink).isEqualTo("https://link.sentinel.example")
+        assertThat(shell.announcementLinkText).isEqualTo("SEN-ANN-LINK")
+        assertThat(shell.announcementShowOnce).isFalse()
+        assertThat(shell.announcementRequireConfirmation).isTrue()
+        assertThat(shell.announcementAllowNeverShow).isTrue()
+        assertThat(shell.announcementTriggerOnLaunch).isFalse()
+        assertThat(shell.announcementTriggerOnNoNetwork).isTrue()
+        assertThat(shell.announcementTriggerIntervalMinutes).isEqualTo(77)
+        assertThat(shell.announcementVersion).isEqualTo(5)
+        assertThat(shell.announcementTriggerIntervalIncludeLaunch).isTrue()
+        assertThat(shell.announcementTemplate).isEqualTo("DARK")
+    }
+
+    @Test
+    fun `splash fields round-trip through nullable flatten and camelCase rename`() {
+        val app = baseApp().copy(
+            splashEnabled = true,
+            splashConfig = SplashConfig(
+                type = SplashType.VIDEO,
+                mediaPath = "/sentinel/splash.mp4",
+                duration = 9,
+                clickToSkip = false,
+                fillScreen = false,
+                enableAudio = true,
+                videoStartMs = 1000L,
+                videoEndMs = 9000L
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.splashEnabled).isTrue()
+        assertThat(shell.splashType).isEqualTo("VIDEO")
+        assertThat(shell.splashDuration).isEqualTo(9)
+        assertThat(shell.splashClickToSkip).isFalse()
+        assertThat(shell.splashFillScreen).isFalse()
+        assertThat(shell.splashEnableAudio).isTrue()
+        assertThat(shell.splashVideoStartMs).isEqualTo(1000L)
+        assertThat(shell.splashVideoEndMs).isEqualTo(9000L)
+        assertThat(shell.splashLandscape).isFalse()
+    }
+
+    @Test
+    fun `bgm scalar fields round-trip`() {
+        val app = baseApp().copy(
+            bgmEnabled = true,
+            bgmConfig = BgmConfig(
+                playMode = BgmPlayMode.SHUFFLE,
+                volume = 0.25f,
+                autoPlay = false,
+                showLyrics = false
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.bgmEnabled).isTrue()
+        assertThat(shell.bgmPlayMode).isEqualTo("SHUFFLE")
+        assertThat(shell.bgmVolume).isEqualTo(0.25f)
+        assertThat(shell.bgmAutoPlay).isFalse()
+        assertThat(shell.bgmShowLyrics).isFalse()
+    }
+
+    @Test
+    fun `bgm nested playlist and lrcTheme round-trip via object serialization`() {
+        val app = baseApp().copy(
+            bgmEnabled = true,
+            bgmConfig = BgmConfig(
+                playlist = listOf(
+                    BgmItem(name = "SEN-TRACK-A", path = "/sentinel/a.mp3"),
+                    BgmItem(name = "SEN-TRACK-B", path = "/sentinel/b.mp3")
+                ),
+                lrcTheme = LrcTheme(
+                    id = "sen-lrc",
+                    name = "SEN-LRC-THEME",
+                    textColor = "#SENTEXT",
+                    highlightColor = "#SENHIGH",
+                    fontSize = 24f
+                )
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.bgmPlaylist).hasSize(2)
+        assertThat(shell.bgmPlaylist[0].name).isEqualTo("SEN-TRACK-A")
+        assertThat(shell.bgmPlaylist[1].name).isEqualTo("SEN-TRACK-B")
+        assertThat(shell.bgmLrcTheme?.textColor).isEqualTo("#SENTEXT")
+        assertThat(shell.bgmLrcTheme?.highlightColor).isEqualTo("#SENHIGH")
+        assertThat(shell.bgmLrcTheme?.fontSize).isEqualTo(24f)
+    }
+
+    @Test
+    fun `translate fields round-trip through nullable flatten and enum-to-string`() {
+        val app = baseApp().copy(
+            translateEnabled = true,
+            translateConfig = TranslateConfig(
+                targetLanguage = TranslateLanguage.JAPANESE,
+                showFloatingButton = false
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.translateEnabled).isTrue()
+        assertThat(shell.translateTargetLanguage).isEqualTo("ja")
+        assertThat(shell.translateShowButton).isFalse()
+    }
+
+    @Test
+    fun `extension fields round-trip`() {
+        val app = baseApp().copy(
+            extensionEnabled = true,
+            extensionModuleIds = listOf("sen-mod-1", "sen-mod-2")
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.extensionEnabled).isTrue()
+        assertThat(shell.extensionModuleIds).containsExactly("sen-mod-1", "sen-mod-2").inOrder()
+    }
+
+    @Test
+    fun `webview core toggles round-trip`() {
+        val app = baseApp().copy(
+            webViewConfig = WebViewConfig(
+                javaScriptEnabled = false,
+                domStorageEnabled = false,
+                zoomEnabled = false,
+                desktopMode = true,
+                cacheEnabled = false,
+                clearBrowsingDataOnLaunch = true,
+                swipeRefreshEnabled = false,
+                fullscreenEnabled = false,
+                hideToolbar = true,
+                landscapeMode = true,
+                userAgentMode = UserAgentMode.CHROME_MOBILE
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.webViewConfig.javaScriptEnabled).isFalse()
+        assertThat(shell.webViewConfig.domStorageEnabled).isFalse()
+        assertThat(shell.webViewConfig.zoomEnabled).isFalse()
+        assertThat(shell.webViewConfig.desktopMode).isTrue()
+        assertThat(shell.webViewConfig.cacheEnabled).isFalse()
+        assertThat(shell.webViewConfig.clearBrowsingDataOnLaunch).isTrue()
+        assertThat(shell.webViewConfig.swipeRefreshEnabled).isFalse()
+        assertThat(shell.webViewConfig.fullscreenEnabled).isFalse()
+        assertThat(shell.webViewConfig.hideToolbar).isTrue()
+        assertThat(shell.webViewConfig.landscapeMode).isTrue()
+        assertThat(shell.webViewConfig.userAgentMode).isEqualTo("CHROME_MOBILE")
+    }
+
+    @Test
+    fun `autostart config round-trip as whole-object serialization`() {
+        val app = baseApp().copy(
+            autoStartConfig = AutoStartConfig(
+                bootStartEnabled = true,
+                scheduledStartEnabled = true,
+                scheduledTime = "12:34",
+                scheduledDays = listOf(2, 4, 6),
+                scheduledRepeat = false,
+                bootDelay = 12345L
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.autoStartConfig).isNotNull()
+        assertThat(shell.autoStartConfig?.bootStartEnabled).isTrue()
+        assertThat(shell.autoStartConfig?.scheduledStartEnabled).isTrue()
+        assertThat(shell.autoStartConfig?.scheduledTime).isEqualTo("12:34")
+        assertThat(shell.autoStartConfig?.scheduledDays).containsExactly(2, 4, 6).inOrder()
+        assertThat(shell.autoStartConfig?.scheduledRepeat).isFalse()
+        assertThat(shell.autoStartConfig?.bootDelay).isEqualTo(12345L)
+    }
+
+    @Test
+    fun `disguise-family whole-object configs round-trip non-null`() {
+        val app = baseApp().copy(
+            disguiseConfig = DisguiseConfig(enabled = true),
+            browserDisguiseConfig = BrowserDisguiseConfig(),
+            deviceDisguiseConfig = DeviceDisguiseConfig(),
+            blackTechConfig = DeviceActionsConfig(),
+            forcedRunConfig = ForcedRunConfig()
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.disguiseConfig).isNotNull()
+        assertThat(shell.browserDisguiseConfig).isNotNull()
+        assertThat(shell.deviceDisguiseConfig).isNotNull()
+        assertThat(shell.blackTechConfig).isNotNull()
+        assertThat(shell.forcedRunConfig).isNotNull()
+    }
+
+    @Test
+    fun `apkExportConfig engineType and isolation flag round-trip`() {
+        val app = baseApp().copy(
+            apkExportConfig = ApkExportConfig(
+                engineType = "GECKOVIEW",
+                isolationConfig = IsolationConfig(enabled = true)
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.engineType).isEqualTo("GECKOVIEW")
+        assertThat(shell.isolationEnabled).isTrue()
+    }
+
+    @Test
+    fun `runtimePermissions are derived from backgroundRun and notification`() {
+        val app = baseApp().copy(
+            apkExportConfig = ApkExportConfig(
+                backgroundRunEnabled = true,
+                runtimePermissions = ApkRuntimePermissions(
+                    camera = true,
+                    location = true,
+                    microphone = false
+                )
+            )
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.backgroundRunEnabled).isTrue()
+    }
+
+    @Test
+    fun `derived targetUrl is rewritten per appType for non-WEB types`() {
+        val gallery = baseApp(appType = AppType.GALLERY).copy(
+            galleryConfig = com.webtoapp.data.model.GalleryConfig()
+        )
+        val shellGallery = roundTrip(gallery)
+        assertThat(shellGallery.targetUrl).isEqualTo("gallery://content")
+        assertThat(shellGallery.appType).isEqualTo("GALLERY")
+
+        val wordpress = baseApp(appType = AppType.WORDPRESS)
+        val shellWp = roundTrip(wordpress)
+        assertThat(shellWp.targetUrl).isEqualTo("wordpress://localhost")
+        assertThat(shellWp.appType).isEqualTo("WORDPRESS")
+
+        val nodejs = baseApp(appType = AppType.NODEJS_APP)
+        val shellNode = roundTrip(nodejs)
+        assertThat(shellNode.targetUrl).isEqualTo("file:///android_asset/nodejs_app/index.html")
+    }
+
+    @Test
+    fun `preview-only fields default empty on export payload`() {
+        val shell = roundTrip(baseApp())
+        assertThat(shell.previewContentDir).isEmpty()
+        assertThat(shell.siteDirName).isEmpty()
+        assertThat(shell.siteId).isEmpty()
+    }
+
+    @Test
+    fun `injectScripts receives build-time kernel and perf sentinels`() {
+        val app = baseApp().copy(
+            webViewConfig = WebViewConfig(enableKernelDisguise = true)
+        )
+        val shell = roundTrip(app)
+        val names = shell.webViewConfig.injectScripts.map { it.name }
+        assertThat(names).contains("__kernel__")
+        assertThat(names).contains("__perf_start__")
+        assertThat(names).contains("__perf_end__")
+    }
+
+    @Test
+    fun `darkMode defaults to SYSTEM when context is null`() {
+        val shell = roundTrip(baseApp())
+        assertThat(shell.darkMode).isEqualTo("SYSTEM")
+    }
+
+    @Test
+    fun `web app type preserves original url as targetUrl`() {
+        val app = baseApp(appType = AppType.WEB).copy(
+            url = "https://web.sentinel.example/path?q=1"
+        )
+        val shell = roundTrip(app)
+        assertThat(shell.targetUrl).isEqualTo("https://web.sentinel.example/path?q=1")
+        assertThat(shell.appType).isEqualTo("WEB")
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/NodeJsBuildModeTargetUrlTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/NodeJsBuildModeTargetUrlTest.kt
@@ -1,0 +1,53 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.NodeJsBuildMode
+import com.webtoapp.data.model.NodeJsConfig
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.util.GsonProvider
+import org.junit.Test
+
+class NodeJsBuildModeTargetUrlTest {
+
+    private fun roundTrip(app: WebApp): ShellConfig {
+        val apk = app.toApkConfig("com.example.test")
+        return GsonProvider.gson.fromJson(ApkConfigJsonFactory.toShellConfigJson(apk), ShellConfig::class.java)!!
+    }
+
+    private fun nodeApp(buildMode: NodeJsBuildMode): WebApp = WebApp(
+        name = "n",
+        url = "https://n.example.com",
+        appType = AppType.NODEJS_APP,
+        nodejsConfig = NodeJsConfig(buildMode = buildMode, entryFile = "server.js", serverPort = 3000)
+    )
+
+    @Test
+    fun `STATIC build mode rewrites targetUrl to nodejs scheme`() {
+        val shell = roundTrip(nodeApp(NodeJsBuildMode.STATIC))
+        assertThat(shell.targetUrl).isEqualTo("nodejs://localhost")
+        assertThat(shell.nodejsConfig.mode).isEqualTo("STATIC")
+    }
+
+    @Test
+    fun `API_BACKEND build mode rewrites targetUrl to nodejs scheme`() {
+        val shell = roundTrip(nodeApp(NodeJsBuildMode.API_BACKEND))
+        assertThat(shell.targetUrl).isEqualTo("nodejs://localhost")
+        assertThat(shell.nodejsConfig.mode).isEqualTo("API_BACKEND")
+    }
+
+    @Test
+    fun `FULLSTACK build mode rewrites targetUrl to nodejs scheme`() {
+        val shell = roundTrip(nodeApp(NodeJsBuildMode.FULLSTACK))
+        assertThat(shell.targetUrl).isEqualTo("nodejs://localhost")
+        assertThat(shell.nodejsConfig.mode).isEqualTo("FULLSTACK")
+    }
+
+    @Test
+    fun `SSR build mode rewrites targetUrl to nodejs scheme`() {
+        val shell = roundTrip(nodeApp(NodeJsBuildMode.SSR))
+        assertThat(shell.targetUrl).isEqualTo("nodejs://localhost")
+        assertThat(shell.nodejsConfig.mode).isEqualTo("SSR")
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/PreviewExportEquivalenceTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/PreviewExportEquivalenceTest.kt
@@ -1,0 +1,193 @@
+package com.webtoapp.core.apkbuilder
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.GalleryConfig
+import com.webtoapp.data.model.GalleryItem
+import com.webtoapp.data.model.GalleryItemType
+import com.webtoapp.data.model.HtmlConfig
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.util.GsonProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PreviewExportEquivalenceTest {
+
+    private val context get() = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    private fun exportEquivalentBase(app: WebApp): ShellConfig =
+        app.toPreviewShellConfig(context)
+
+    private fun previewShell(app: WebApp): ShellConfig =
+        com.webtoapp.core.host.ShellPreviewLauncher.buildPreviewConfig(context, app)
+
+    @Test
+    fun `web app preview and export produce identical shell config`() {
+        val app = WebApp(
+            name = "EquivWeb",
+            url = "https://equiv.example.com",
+            appType = AppType.WEB
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertEquivalentExceptPreviewOnlyFields(export, preview)
+    }
+
+    @Test
+    fun `html app preview entryFile fallback does not diverge from export path`() {
+        val app = WebApp(
+            name = "EquivHtml",
+            url = "https://equiv.example.com",
+            appType = AppType.HTML,
+            htmlConfig = HtmlConfig(projectDir = null)
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(export.htmlConfig.entryFile).isNotEmpty()
+        assertEquivalentExceptPreviewOnlyFields(export, preview)
+        assertThat(preview.htmlConfig.entryFile).isEqualTo(export.htmlConfig.entryFile)
+    }
+
+    @Test
+    fun `gallery preview only rewrites asset paths, all other item fields match export`() {
+        val app = WebApp(
+            name = "EquivGallery",
+            url = "https://equiv.example.com",
+            appType = AppType.GALLERY,
+            galleryConfig = GalleryConfig(
+                items = listOf(
+                    GalleryItem(
+                        id = "g1",
+                        path = "/original/img1.png",
+                        type = GalleryItemType.IMAGE,
+                        name = "Item One",
+                        duration = 0,
+                        thumbnailPath = "/original/thumb1.jpg"
+                    ),
+                    GalleryItem(
+                        id = "g2",
+                        path = "/original/vid2.mp4",
+                        type = GalleryItemType.VIDEO,
+                        name = "Item Two",
+                        duration = 5000L,
+                        thumbnailPath = null
+                    )
+                )
+            )
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(preview.galleryConfig.items).hasSize(2)
+        assertThat(export.galleryConfig.items).hasSize(2)
+
+        for ((idx, pair) in (preview.galleryConfig.items zip export.galleryConfig.items).withIndex()) {
+            val (previewItem, exportItem) = pair
+            assertThat(previewItem.id).isEqualTo(exportItem.id)
+            assertThat(previewItem.name).isEqualTo(exportItem.name)
+            assertThat(previewItem.duration).isEqualTo(exportItem.duration)
+            assertThat(previewItem.type).isEqualTo(exportItem.type)
+        }
+
+        val previewPaths = preview.galleryConfig.items.map { it.assetPath }
+        val exportPaths = export.galleryConfig.items.map { it.assetPath }
+        assertThat(exportPaths).containsExactly("gallery/item_0.png", "gallery/item_1.mp4").inOrder()
+        assertThat(previewPaths).containsExactly("/original/img1.png", "/original/vid2.mp4").inOrder()
+
+        assertThat(preview.galleryConfig.items[0].thumbnailPath).isEqualTo("/original/thumb1.jpg")
+        assertThat(export.galleryConfig.items[0].thumbnailPath).isEqualTo("gallery/thumb_0.jpg")
+        assertThat(preview.galleryConfig.items[1].thumbnailPath).isNull()
+        assertThat(export.galleryConfig.items[1].thumbnailPath).isNull()
+    }
+
+    @Test
+    fun `gallery scalar config fields are identical between preview and export`() {
+        val app = WebApp(
+            name = "EquivGalleryScalar",
+            url = "https://equiv.example.com",
+            appType = AppType.GALLERY,
+            galleryConfig = GalleryConfig(
+                imageInterval = 7,
+                loop = false,
+                autoPlay = true,
+                showThumbnailBar = false,
+                gridColumns = 4
+            )
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(preview.galleryConfig.imageInterval).isEqualTo(export.galleryConfig.imageInterval)
+        assertThat(preview.galleryConfig.loop).isEqualTo(export.galleryConfig.loop)
+        assertThat(preview.galleryConfig.autoPlay).isEqualTo(export.galleryConfig.autoPlay)
+        assertThat(preview.galleryConfig.showThumbnailBar).isEqualTo(export.galleryConfig.showThumbnailBar)
+        assertThat(preview.galleryConfig.gridColumns).isEqualTo(export.galleryConfig.gridColumns)
+    }
+
+    @Test
+    fun `preview-only fields are populated on preview but empty on export`() {
+        val app = WebApp(
+            name = "EquivPreviewFields",
+            url = "https://equiv.example.com",
+            appType = AppType.WEB
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(export.previewContentDir).isEmpty()
+        assertThat(export.siteDirName).isEmpty()
+        assertThat(export.siteId).isEmpty()
+
+        assertThat(preview.siteId).isEqualTo("preview_${app.id}")
+    }
+
+    @Test
+    fun `multi-web preview and export produce equivalent site shape`() {
+        val app = WebApp(
+            name = "EquivMultiWeb",
+            url = "https://equiv.example.com",
+            appType = AppType.MULTI_WEB,
+            multiWebConfig = com.webtoapp.data.model.MultiWebConfig(
+                sites = listOf(
+                    com.webtoapp.data.model.MultiWebSite(
+                        id = "site-1",
+                        name = "Site One",
+                        url = "https://site1.example.com",
+                        iconEmoji = "SEN-ICON",
+                        themeColor = "#SEN-COLOR"
+                    )
+                )
+            )
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(preview.multiWebConfig.sites).hasSize(1)
+        assertThat(export.multiWebConfig.sites).hasSize(1)
+
+        val previewSite = preview.multiWebConfig.sites[0]
+        val exportSite = export.multiWebConfig.sites[0]
+        assertThat(previewSite.id).isEqualTo(exportSite.id)
+        assertThat(previewSite.name).isEqualTo(exportSite.name)
+        assertThat(previewSite.url).isEqualTo(exportSite.url)
+        assertThat(previewSite.iconEmoji).isEqualTo(exportSite.iconEmoji)
+        assertThat(previewSite.themeColor).isEqualTo(exportSite.themeColor)
+    }
+
+    private fun assertEquivalentExceptPreviewOnlyFields(export: ShellConfig, preview: ShellConfig) {
+        val normalizedExport = export.copy(
+            previewContentDir = preview.previewContentDir,
+            siteDirName = preview.siteDirName,
+            siteId = preview.siteId
+        )
+        assertThat(preview).isEqualTo(normalizedExport)
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
@@ -1,0 +1,178 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.util.GsonProvider
+import java.lang.reflect.Field
+import org.junit.Test
+
+class WebViewConfigBooleanCoverageTest {
+
+    @Test
+    fun `every WebViewConfig Boolean field flips its WebViewShellConfig counterpart on export`() {
+        val defaultApp = WebApp(name = "t", url = "https://t.example.com")
+        val defaultShell = roundTrip(defaultApp)
+        val defaultWv = defaultApp.webViewConfig
+        val defaultShellWv = shellWvOf(defaultShell)
+
+        val flippedWv = flipAllBooleans(defaultWv)
+        val flippedApp = defaultApp.copy(webViewConfig = flippedWv)
+        val flippedShell = roundTrip(flippedApp)
+        val flippedShellWv = shellWvOf(flippedShell)
+
+        val shellWvFields = flippedShellWv.javaClass.declaredFields.associateBy { it.name }
+
+        val wvBooleanFields = WebViewConfig::class.java.declaredFields
+            .filter { it.type == java.lang.Boolean.TYPE }
+
+        val knownDerivedOrIntentional = setOf(
+            "allowFileAccess",
+            "allowFileAccessFromFileURLs",
+            "allowUniversalAccessFromFileURLs",
+            "cacheEnabled",
+            "pwaOfflineEnabled"
+        )
+
+        val knownBroken: Set<String> = emptySet()
+
+        val exempt = knownDerivedOrIntentional + knownBroken
+
+        val notFlipped = mutableListOf<String>()
+        val notPresent = mutableListOf<String>()
+
+        for (field in wvBooleanFields) {
+            val name = field.name
+            val shellField = shellWvFields[name]
+            if (shellField == null) {
+                if (name !in exempt) notPresent.add(name)
+                continue
+            }
+            shellField.isAccessible = true
+            val flippedValue = readBoolean(shellField, flippedShellWv)
+            val defaultValue = readBoolean(shellField, defaultShellWv)
+            if (flippedValue == defaultValue && name !in exempt) {
+                notFlipped.add(name)
+            }
+        }
+
+        if (notFlipped.isNotEmpty()) {
+            throw AssertionError(
+                "WebViewConfig Boolean fields whose flip did NOT propagate to WebViewShellConfig " +
+                    "(missing in toWebViewBlock/toWebViewBehaviorBlock): $notFlipped"
+            )
+        }
+        if (notPresent.isNotEmpty()) {
+            throw AssertionError(
+                "WebViewConfig Boolean fields with no same-named WebViewShellConfig field " +
+                    "(add to knownDerivedOrIntentional if by design): $notPresent"
+            )
+        }
+
+        assertThat(knownBroken).isEmpty()
+    }
+
+    private fun roundTrip(app: WebApp): ShellConfig {
+        val apk = app.toApkConfig("com.example.test")
+        val json = ApkConfigJsonFactory.toShellConfigJson(apk)
+        return GsonProvider.gson.fromJson(json, ShellConfig::class.java)!!
+    }
+
+    private fun shellWvOf(shell: ShellConfig): Any {
+        val field = ShellConfig::class.java.getDeclaredField("webViewConfig")
+        field.isAccessible = true
+        return field.get(shell)!!
+    }
+
+    private fun readBoolean(field: Field, target: Any): Boolean? {
+        field.isAccessible = true
+        return if (field.type == java.lang.Boolean.TYPE) {
+            field.getBoolean(target)
+        } else {
+            field.get(target) as? Boolean
+        }
+    }
+
+    private fun flipAllBooleans(source: WebViewConfig): WebViewConfig {
+        val sourceFields = WebViewConfig::class.java.declaredFields
+            .filter { it.type == java.lang.Boolean.TYPE }
+            .associateBy { it.name }
+        fun bool(name: String): Boolean {
+            val f = sourceFields[name]!!
+            f.isAccessible = true
+            return !f.getBoolean(source)
+        }
+        return WebViewConfig(
+            javaScriptEnabled = bool("javaScriptEnabled"),
+            domStorageEnabled = bool("domStorageEnabled"),
+            allowFileAccess = bool("allowFileAccess"),
+            allowContentAccess = bool("allowContentAccess"),
+            cacheEnabled = bool("cacheEnabled"),
+            clearBrowsingDataOnLaunch = bool("clearBrowsingDataOnLaunch"),
+            zoomEnabled = bool("zoomEnabled"),
+            desktopMode = bool("desktopMode"),
+            hideToolbar = bool("hideToolbar"),
+            hideBrowserToolbar = bool("hideBrowserToolbar"),
+            toolbarShowTitle = bool("toolbarShowTitle"),
+            toolbarShowUrl = bool("toolbarShowUrl"),
+            toolbarShowBack = bool("toolbarShowBack"),
+            toolbarShowForward = bool("toolbarShowForward"),
+            toolbarShowRefresh = bool("toolbarShowRefresh"),
+            browserToolbarCustomized = bool("browserToolbarCustomized"),
+            showStatusBarInFullscreen = bool("showStatusBarInFullscreen"),
+            showNavigationBarInFullscreen = bool("showNavigationBarInFullscreen"),
+            showToolbarInFullscreen = bool("showToolbarInFullscreen"),
+            landscapeMode = bool("landscapeMode"),
+            longPressMenuEnabled = bool("longPressMenuEnabled"),
+            popupBlockerEnabled = bool("popupBlockerEnabled"),
+            popupBlockerToggleEnabled = bool("popupBlockerToggleEnabled"),
+            openExternalLinks = bool("openExternalLinks"),
+            showFloatingBackButton = bool("showFloatingBackButton"),
+            swipeRefreshEnabled = bool("swipeRefreshEnabled"),
+            fullscreenEnabled = bool("fullscreenEnabled"),
+            performanceOptimization = bool("performanceOptimization"),
+            pwaOfflineEnabled = bool("pwaOfflineEnabled"),
+            downloadEnabled = bool("downloadEnabled"),
+            antiCapture = bool("antiCapture"),
+            enableKernelDisguise = bool("enableKernelDisguise"),
+            enableImageRepair = bool("enableImageRepair"),
+            enableScrollMemory = bool("enableScrollMemory"),
+            enableBackStatePreservation = bool("enableBackStatePreservation"),
+            followSystemDarkMode = bool("followSystemDarkMode"),
+            enableClipboardPolyfill = bool("enableClipboardPolyfill"),
+            enableNotificationPolyfill = bool("enableNotificationPolyfill"),
+            enableOrientationPolyfill = bool("enableOrientationPolyfill"),
+            enableCompatPolyfills = bool("enableCompatPolyfills"),
+            enableCorsBypass = bool("enableCorsBypass"),
+            allowMixedContent = bool("allowMixedContent"),
+            enableBlobDownloadInterception = bool("enableBlobDownloadInterception"),
+            enablePrintBridge = bool("enablePrintBridge"),
+            enableCloudflareCompat = bool("enableCloudflareCompat"),
+            enableCookiePersistence = bool("enableCookiePersistence"),
+            enablePrivateNetworkBridge = bool("enablePrivateNetworkBridge"),
+            enableNativeBridge = bool("enableNativeBridge"),
+            enablePaymentSchemes = bool("enablePaymentSchemes"),
+            enableShareBridge = bool("enableShareBridge"),
+            enableZoomPolyfill = bool("enableZoomPolyfill"),
+            enableCrossOriginIsolation = bool("enableCrossOriginIsolation"),
+            hideUrlPreview = bool("hideUrlPreview"),
+            decodeBase64DeepLinks = bool("decodeBase64DeepLinks"),
+            javaScriptCanOpenWindows = bool("javaScriptCanOpenWindows"),
+            mediaAutoplayEnabled = bool("mediaAutoplayEnabled"),
+            acceptThirdPartyCookies = bool("acceptThirdPartyCookies"),
+            geolocationEnabled = bool("geolocationEnabled"),
+            keepScreenOn = bool("keepScreenOn"),
+            databaseEnabled = bool("databaseEnabled"),
+            primeUserActivation = bool("primeUserActivation"),
+            failoverEnabled = bool("failoverEnabled"),
+            hostsMappingEnabled = bool("hostsMappingEnabled"),
+            autoRefreshEnabled = bool("autoRefreshEnabled"),
+            autoRefreshShowCountdown = bool("autoRefreshShowCountdown"),
+            allowFileAccessFromFileURLs = bool("allowFileAccessFromFileURLs"),
+            allowUniversalAccessFromFileURLs = bool("allowUniversalAccessFromFileURLs"),
+            tlsFingerprintEnabled = bool("tlsFingerprintEnabled"),
+            statusBarDarkIconsDark = bool("statusBarDarkIconsDark")
+        )
+    }
+}

--- a/scripts/check_config_field_drift.py
+++ b/scripts/check_config_field_drift.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PAYLOAD_FILE = ROOT / "app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt"
+APKCONFIG_FILE = ROOT / "app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt"
+SHELLCONFIG_FILE = ROOT / "app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt"
+ALLOWLIST_FILE = ROOT / "scripts/config_field_drift_allowlist.json"
+
+OBJECT_RETURN_PAYLOAD_CLASSES = ("BackgroundRunConfig", "NotificationConfig")
+
+PAYLOAD_FUNCS = [
+    "toShellPayload",
+    "webViewConfigPayload",
+    "floatingWindowConfigPayload",
+    "errorPageConfigPayload",
+    "mediaConfigPayload",
+    "htmlConfigPayload",
+    "galleryConfigPayload",
+    "autoStartConfigPayload",
+    "isolationConfigPayload",
+    "backgroundRunConfigPayload",
+    "notificationConfigPayload",
+    "networkTrustConfigPayload",
+    "wordpressConfigPayload",
+    "nodejsConfigPayload",
+    "phpAppConfigPayload",
+    "pythonAppConfigPayload",
+    "goAppConfigPayload",
+    "multiWebConfigPayload",
+]
+
+PAIR_KEY = re.compile(r'"([A-Za-z][A-Za-z0-9_]*)"\s+to\b')
+SERIAL_NAME = re.compile(r'@SerializedName\(\s*"([A-Za-z][A-Za-z0-9_]*)"\s*\)')
+FUN_HEADER = re.compile(r"fun\s+ApkConfig\.(\w+)\s*\(\s*\)\s*:\s*([A-Za-z<>?,\s]+)\s*[={]")
+
+
+def extract_payload_keys(text: str) -> set[str]:
+    lines = text.splitlines()
+    func_ranges: list[tuple[str, int, int]] = []
+    headers: list[tuple[int, str, str]] = []
+    for idx, line in enumerate(lines):
+        m = FUN_HEADER.search(line)
+        if not m:
+            continue
+        name = m.group(1)
+        if not name.endswith("Payload"):
+            continue
+        headers.append((idx, name, m.group(2)))
+
+    for i, (idx, name, _ret) in enumerate(headers):
+        end = headers[i + 1][0] if i + 1 < len(headers) else len(lines)
+        func_ranges.append((name, idx, end))
+
+    keys: set[str] = set()
+    for name, start, end in func_ranges:
+        if name not in PAYLOAD_FUNCS:
+            continue
+        body = "\n".join(lines[start:end])
+        keys.update(PAIR_KEY.findall(body))
+    return keys
+
+
+def extract_object_returned_keys(text: str) -> set[str]:
+    keys: set[str] = set()
+    for cls in OBJECT_RETURN_PAYLOAD_CLASSES:
+        pattern = re.compile(rf"data class {cls}\s*\((.*?)\n\)", re.DOTALL)
+        m = pattern.search(text)
+        if not m:
+            continue
+        body = m.group(1)
+        for prop in re.finditer(r"^\s*val\s+(\w+)\s*:", body, re.MULTILINE):
+            keys.add(prop.group(1))
+    return keys
+
+
+def extract_shell_keys(text: str) -> set[str]:
+    return set(SERIAL_NAME.findall(text))
+
+
+def load_allowlist() -> tuple[set[str], dict[str, str]]:
+    if not ALLOWLIST_FILE.is_file():
+        return set(), {}
+    data = json.loads(ALLOWLIST_FILE.read_text(encoding="utf-8"))
+    entries = data.get("allowlist", [])
+    keys: set[str] = set()
+    reasons: dict[str, str] = {}
+    for entry in entries:
+        key = entry.get("key")
+        reason = (entry.get("reason") or "").strip()
+        if not key:
+            continue
+        keys.add(key)
+        reasons[key] = reason
+    return keys, reasons
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect field-name drift between ApkConfig payload and ShellConfig @SerializedName")
+    parser.add_argument("--payload-file", type=Path, default=PAYLOAD_FILE)
+    parser.add_argument("--apkconfig-file", type=Path, default=APKCONFIG_FILE)
+    parser.add_argument("--shellconfig-file", type=Path, default=SHELLCONFIG_FILE)
+    parser.add_argument("--allowlist-file", type=Path, default=ALLOWLIST_FILE)
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    for f in (args.payload_file, args.apkconfig_file, args.shellconfig_file):
+        if not f.is_file():
+            errors.append(f"source file missing: {f}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}")
+        return 1
+
+    payload_text = args.payload_file.read_text(encoding="utf-8")
+    apkconfig_text = args.apkconfig_file.read_text(encoding="utf-8")
+    shell_text = args.shellconfig_file.read_text(encoding="utf-8")
+
+    payload_keys = extract_payload_keys(payload_text)
+    payload_keys |= extract_object_returned_keys(apkconfig_text)
+    shell_keys = extract_shell_keys(shell_text)
+
+    allow_keys, allow_reasons = load_allowlist()
+
+    allow_no_reason = sorted(k for k in allow_keys if not allow_reasons.get(k))
+    if allow_no_reason:
+        errors.append(
+            "allowlist entries missing 'reason' (every entry must document why it is exempt): "
+            + ", ".join(allow_no_reason)
+        )
+
+    stale_allow = sorted(k for k in allow_keys if k not in payload_keys and k not in shell_keys)
+    if stale_allow:
+        warnings.append(
+            "allowlist contains keys present in neither side (stale, remove them): "
+            + ", ".join(stale_allow)
+        )
+
+    only_payload = sorted((payload_keys - shell_keys) - allow_keys)
+    only_shell = sorted((shell_keys - payload_keys) - allow_keys)
+
+    for k in only_payload:
+        errors.append(
+            f"payload writes key '{k}' but ShellConfig has no matching @SerializedName "
+            "(serialized but runtime never receives)"
+        )
+    for k in only_shell:
+        errors.append(
+            f"ShellConfig declares @SerializedName('{k}') but no payload writes it "
+            "(runtime field exists but export never emits)"
+        )
+
+    if warnings:
+        for w in warnings:
+            print(f"WARN: {w}")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}")
+        print(
+            f"check_config_field_drift: FAILED "
+            f"(payload_only={len(only_payload)} shell_only={len(only_shell)} "
+            f"allowlist={len(allow_keys)})"
+        )
+        return 1
+
+    print(
+        f"check_config_field_drift: OK "
+        f"(payload={len(payload_keys)} shell={len(shell_keys)} "
+        f"allowlist={len(allow_keys)} shared={len(payload_keys & shell_keys)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/config_field_drift_allowlist.json
+++ b/scripts/config_field_drift_allowlist.json
@@ -1,0 +1,64 @@
+{
+  "_doc": "Drift allowlist for scripts/check_config_field_drift.py. Every entry MUST have a non-empty 'reason'. Two valid exemption categories: (1) nested-object serialization — payload assigns a data class instance as a value, Gson recursively serializes its property names as JSON keys, so the field name only appears in the source class definition, not in ApkConfigJsonFactory.kt; (2) legitimately dead payload — written by payload but runtime path uses a different channel (e.g. networkSecurityConfig.xml) so ShellConfig intentionally does not declare it; (3) preview-only fields injected by ShellPreviewLauncher that exported APKs never populate. If a key here becomes stale (neither side references it) the script warns.",
+  "allowlist": [
+    {"key": "schemaVersion", "reason": "Payload metadata written by toShellPayload header; ShellConfig does not version-track, runtime ignores it."},
+    {"key": "networkTrustConfig", "reason": "Dead payload subtree — network trust config is embedded as networkSecurityConfig.xml by NetworkSecurityConfigBuilder at export, ShellConfig never reads it."},
+    {"key": "trustSystemCa", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
+    {"key": "trustUserCa", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
+    {"key": "customCaCertificates", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
+    {"key": "cleartextTrafficPermitted", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
+    {"key": "displayName", "reason": "Nested object field of CustomCaCertificate, serialized via customCaCertificates.map{...} in networkTrustConfigPayload. Dead payload subtree (see networkTrustConfig)."},
+    {"key": "sha256", "reason": "Nested object field of CustomCaCertificate, serialized via customCaCertificates.map{...} in networkTrustConfigPayload. Dead payload subtree (see networkTrustConfig)."},
+
+    {"key": "previewContentDir", "reason": "Preview-only field injected by ShellPreviewLauncher.buildPreviewConfig; exported APKs derive content dir from app type at runtime."},
+    {"key": "siteDirName", "reason": "Preview-only field injected by ShellPreviewLauncher.buildPreviewConfig for preview session isolation."},
+    {"key": "siteId", "reason": "Preview-only field injected by ShellPreviewLauncher.buildPreviewConfig for preview session isolation."},
+
+    {"key": "textColor", "reason": "Nested object field of LrcTheme; serialized via bgm.lrcTheme in BgmBlock → ShellConfig.bgmLrcTheme: LrcShellTheme."},
+    {"key": "highlightColor", "reason": "Nested object field of LrcTheme; see textColor."},
+    {"key": "fontSize", "reason": "Nested object field of LrcTheme; see textColor."},
+    {"key": "animationType", "reason": "Nested object field of LrcTheme; see textColor."},
+    {"key": "position", "reason": "Nested object field of LrcTheme; see textColor."},
+    {"key": "backgroundColor", "reason": "Nested object field of LrcTheme; see textColor. (Note: also collides with GalleryBlock.backgroundColor which IS in payload — collision is harmless.)"},
+
+    {"key": "coverAssetPath", "reason": "Nested object field of BgmItem; serialized via bgm.playlist: List<BgmItem> → ShellConfig.bgmPlaylist: List<BgmShellItem>."},
+    {"key": "lrcAssetPath", "reason": "Nested object field of BgmItem; see coverAssetPath."},
+
+    {"key": "assetPath", "reason": "Nested object field of GalleryItem; serialized via gallery.items: List<GalleryItem> → ShellConfig.galleryConfig.items: List<GalleryShellItem>."},
+    {"key": "duration", "reason": "Nested object field of GalleryItem; see assetPath."},
+    {"key": "thumbnailPath", "reason": "Nested object field of GalleryItem; see assetPath."},
+
+    {"key": "autoHide", "reason": "Nested object field of EmbeddedExtensionModuleUiConfig; serialized via embeddedExtensionModules[].uiConfig in EmbeddedExtensionModule.toPayload."},
+    {"key": "autoHideDelay", "reason": "Nested object field of EmbeddedExtensionModuleUiConfig; see autoHide."},
+    {"key": "initiallyHidden", "reason": "Nested object field of EmbeddedExtensionModuleUiConfig; see autoHide."},
+    {"key": "showOnlyOnMatch", "reason": "Nested object field of EmbeddedExtensionModuleUiConfig; see autoHide."},
+
+    {"key": "pattern", "reason": "Nested object field of EmbeddedUrlMatchRule; serialized via embeddedExtensionModules[].urlMatches in EmbeddedExtensionModule.toPayload."},
+    {"key": "isRegex", "reason": "Nested object field of EmbeddedUrlMatchRule; see pattern."},
+    {"key": "exclude", "reason": "Nested object field of EmbeddedUrlMatchRule; see pattern."},
+
+    {"key": "keepCpuAwake", "reason": "Nested object field of BackgroundRunConfig; payload returns the whole object via backgroundRunConfigPayload(): BackgroundRunConfig? → ShellConfig.backgroundRunConfig: BackgroundRunShellConfig?."},
+
+    {"key": "provider", "reason": "Nested object field of DnsApkConfig; payload assigns the whole object via \"dnsConfig\" to dns.config, Gson serializes DnsApkConfig.provider as JSON key → ShellConfig.dnsConfig: DnsShellConfig.provider."},
+    {"key": "customDohUrl", "reason": "Nested object field of DnsApkConfig; see provider."},
+    {"key": "dohMode", "reason": "Nested object field of DnsApkConfig; see provider."},
+    {"key": "bypassSystemDns", "reason": "Nested object field of DnsApkConfig; see provider."},
+    {"key": "echEnabled", "reason": "Nested object field of DnsApkConfig; see provider."},
+
+    {"key": "announcementAnimationEnabled", "reason": "Shell-internal default (true) for announcement dialog animation; no editor surface in WebApp/AnnouncementBlock, intentionally never flows from export."},
+    {"key": "announcementShowEmoji", "reason": "Shell-internal default (true) for announcement dialog emoji display; no editor surface in WebApp/AnnouncementBlock, intentionally never flows from export."},
+
+    {"key": "url", "reason": "Nested object field of MultiWebSiteShellConfig; serialized via multiWeb.sites: List<MultiWebSiteShellConfig> → ShellConfig.multiWebConfig.sites. Collides with top-level targetUrl but lives at different JSON path."},
+    {"key": "faviconUrl", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "iconEmoji", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "themeColor", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "cssSelector", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "linkSelector", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "localFilePath", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "siteProjectId", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "siteShellConfig", "reason": "Nested object field of MultiWebSiteShellConfig (recursive ShellConfig?); see url."},
+    {"key": "sortIndex", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "sourceAppId", "reason": "Nested object field of MultiWebSiteShellConfig; see url."},
+    {"key": "sourceProjectId", "reason": "Nested object field of MultiWebSiteShellConfig; see url."}
+  ]
+}


### PR DESCRIPTION
## What

Adds three complementary config-consistency gates and fixes the two real drift bugs the gates surfaced on first run.

## Why

Preview and exported-APK runtime share `WebApp -> ApkConfig -> JSON -> ShellConfig` as their contract, but the mapping is hand-maintained across three large layers with a 405-key payload and no drift detection. Gson silently drops unknown fields, so the recurring "works in preview, broken after export" symptom has had no stable remediation. Issue #238 tracks the problem in detail.

## Changes

**Gates**
- `scripts/check_config_field_drift.py` + `:app:checkConfigFieldDrift` Gradle task, wired into the CI `check` job. Compares payload keys against `ShellConfig` `@SerializedName`. Allowlist (`scripts/config_field_drift_allowlist.json`) documents every legitimate asymmetry with a mandatory `reason`.
- `ConfigRoundTripSentinelTest` — per-domain sentinel round-trip across `WebApp -> toApkConfig -> toShellConfigJson -> ShellConfig`.
- `PreviewExportEquivalenceTest` (Robolectric) — compares `ShellPreviewLauncher.buildPreviewConfig` against the export payload round-trip per app type, catching non-preview-only field divergence from `ShellPreviewLauncher` `.copy()` patches.
- `WebViewConfigBooleanCoverageTest` — reflects over every `WebViewConfig` Boolean, flips it, verifies propagation to the same-named `WebViewShellConfig` field. `knownBroken` set is asserted empty so any future drift must be fixed or explicitly registered.
- `NodeJsBuildModeTargetUrlTest` — covers all four `NodeJsBuildMode` values for `computeEffectiveTargetUrl`.

**Bug fixes (each one line, surfaced by the gates above)**
- `buildWebViewBehaviorBlock` now maps `hideUrlPreview = webViewConfig.hideUrlPreview`. Previously the editor toggle was dropped and `WebViewManager` always read the default `false`.
- `computeEffectiveTargetUrl` now lists `NodeJsBuildMode.SSR` alongside `API_BACKEND`/`FULLSTACK` for `nodejs://localhost`. Previously SSR fell through to `file://`, so the Node server never started and SSR silently degraded to static-file loading.

## Issue

Fixes #238

## Verification

```
./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.apkbuilder.*" -x :shell:assembleRelease -x :app:syncShellTemplateApk --no-configuration-cache
python3 scripts/check_config_field_drift.py
./gradlew :app:checkConfigFieldDrift --no-configuration-cache
```

All green locally:
- `check_config_field_drift: OK (payload=425 shell=456 allowlist=49 shared=417)`
- All `apkbuilder` tests pass, including the four new test classes.
- `hideUrlPreview` flip propagates end-to-end (verified via the boolean coverage test after removing it from `knownBroken`).
- All four `NodeJsBuildMode` cases produce `nodejs://localhost` (or the documented file:// fallback only for the `null` config case).

## Notes

- Only intended files are committed; pre-existing uncommitted `shell_i18n/*.pack` / `shell/.../en.pack` changes and `.zcode/` are left out of this PR.
- The static drift gate alone is insufficient — the two bugs fixed here are value/round-trip level, not key-name level, which is why the round-trip and equivalence gates are necessary.