### PR TITLE
fix(splash): resolve preview media via splashMediaPath fallback

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -675,7 +675,8 @@ data class SplashBlock(
     val videoEndMs: Long = 5000,
     val landscape: Boolean = false,
     val fillScreen: Boolean = true,
-    val enableAudio: Boolean = false
+    val enableAudio: Boolean = false,
+    val mediaPath: String? = null
 )
 
 data class MediaBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -75,6 +75,7 @@ internal object ApkConfigJsonFactory {
         "splashLandscape" to splash.landscape,
         "splashFillScreen" to splash.fillScreen,
         "splashEnableAudio" to splash.enableAudio,
+        "splashMediaPath" to splash.mediaPath,
         "webViewConfig" to webViewConfigPayload(),
         "appType" to meta.appType,
         "siteAssetBase" to when (meta.appType) {

--- a/app/src/main/java/com/webtoapp/core/host/ShellPreviewLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/host/ShellPreviewLauncher.kt
@@ -73,6 +73,10 @@ object ShellPreviewLauncher {
                 )
             )
         }
+        val splashMediaPath = webApp.splashConfig?.mediaPath?.takeIf { it.isNotBlank() }
+        if (config.splashEnabled && splashMediaPath != null && config.splashMediaPath == null) {
+            config = config.copy(splashMediaPath = splashMediaPath)
+        }
         return config
     }
 

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -295,6 +295,9 @@ data class ShellConfig(
     @SerializedName("splashEnableAudio")
     val splashEnableAudio: Boolean = false,
 
+    @SerializedName("splashMediaPath")
+    val splashMediaPath: String? = null,
+
     @SerializedName("appType")
     val appType: String = "WEB",
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -28,6 +28,7 @@ fun ShellSplashOverlay(
     videoEndMs: Long = 5000,
     fillScreen: Boolean = true,
     enableAudio: Boolean = false,
+    mediaPath: String? = null,
     onSkip: (() -> Unit)?,
     onComplete: (() -> Unit)? = null
 ) {
@@ -60,12 +61,17 @@ fun ShellSplashOverlay(
 
                 var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
 
-                LaunchedEffect(assetPath) {
+                LaunchedEffect(assetPath, mediaPath) {
                     bitmap = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                         try {
-                            val decryptor = com.webtoapp.core.crypto.AssetDecryptor(context)
-                            val imageBytes = decryptor.loadAsset(assetPath)
-                            android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+                            val previewFile = mediaPath?.let { java.io.File(it) }
+                            if (previewFile != null && previewFile.exists()) {
+                                android.graphics.BitmapFactory.decodeFile(previewFile.absolutePath)
+                            } else {
+                                val decryptor = com.webtoapp.core.crypto.AssetDecryptor(context)
+                                val imageBytes = decryptor.loadAsset(assetPath)
+                                android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+                            }
                         } catch (e: Exception) {
                             AppLogger.e("ShellSplash", "Failed to load splash image", e)
                             null
@@ -118,6 +124,25 @@ fun ShellSplashOverlay(
                             holder.addCallback(object : android.view.SurfaceHolder.Callback {
                                 override fun surfaceCreated(holder: android.view.SurfaceHolder) {
                                     try {
+
+                                        val previewFile = mediaPath?.let { java.io.File(it) }
+                                        if (previewFile != null && previewFile.exists()) {
+                                            mediaPlayer = android.media.MediaPlayer().apply {
+                                                setDataSource(previewFile.absolutePath)
+                                                setSurface(holder.surface)
+                                                val volume = if (enableAudio) 1f else 0f
+                                                setVolume(volume, volume)
+                                                isLooping = false
+                                                setOnPreparedListener {
+                                                    seekTo(videoStartMs.toInt())
+                                                    start()
+                                                    isPlayerReady = true
+                                                }
+                                                setOnCompletionListener { onComplete?.invoke() }
+                                                prepareAsync()
+                                            }
+                                            return
+                                        }
 
                                         val encryptedPath = "$assetPath.enc"
                                         val hasEncrypted = try {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -3,6 +3,7 @@ package com.webtoapp.ui.shell
 import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.net.Uri
+import java.io.File
 import android.view.View
 import android.webkit.*
 import androidx.compose.animation.AnimatedVisibility
@@ -104,8 +105,10 @@ fun ShellScreen(
                 true
             } catch (e: Exception) { false }
 
-            val exists = hasEncrypted || hasNormal
-            AppLogger.d("ShellActivity", "同步检查: 启动画面媒体 encrypted=$hasEncrypted, normal=$hasNormal, exists=$exists")
+            val hasPreviewPath = config.splashMediaPath?.let { File(it).exists() } ?: false
+
+            val exists = hasEncrypted || hasNormal || hasPreviewPath
+            AppLogger.d("ShellActivity", "同步检查: 启动画面媒体 encrypted=$hasEncrypted, normal=$hasNormal, previewPath=${config.splashMediaPath}, exists=$exists")
             exists
         } else false
     }
@@ -462,6 +465,7 @@ fun ShellScreen(
             videoEndMs = config.splashVideoEndMs,
             fillScreen = config.splashFillScreen,
             enableAudio = config.splashEnableAudio,
+            mediaPath = config.splashMediaPath,
 
             onSkip = if (config.splashClickToSkip) { closeSplash } else null,
 

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/PreviewExportEquivalenceTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/PreviewExportEquivalenceTest.kt
@@ -150,6 +150,90 @@ class PreviewExportEquivalenceTest {
     }
 
     @Test
+    fun `splash preview injects mediaPath so the preview can resolve the splash asset, export leaves it null`() {
+        val app = WebApp(
+            name = "EquivSplash",
+            url = "https://equiv.example.com",
+            appType = AppType.WEB,
+            splashEnabled = true,
+            splashConfig = com.webtoapp.data.model.SplashConfig(
+                type = com.webtoapp.data.model.SplashType.IMAGE,
+                mediaPath = "/preview/splash.png",
+                duration = 5
+            )
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(export.splashMediaPath).isNull()
+        assertThat(preview.splashMediaPath).isEqualTo("/preview/splash.png")
+        assertThat(preview.splashEnabled).isTrue()
+        assertThat(preview.splashType).isEqualTo("IMAGE")
+        assertThat(preview.splashDuration).isEqualTo(5)
+    }
+
+    @Test
+    fun `splash preview without mediaPath stays null and does not break equivalence`() {
+        val app = WebApp(
+            name = "EquivSplashNoMedia",
+            url = "https://equiv.example.com",
+            appType = AppType.WEB,
+            splashEnabled = true,
+            splashConfig = com.webtoapp.data.model.SplashConfig(
+                type = com.webtoapp.data.model.SplashType.IMAGE,
+                mediaPath = null
+            )
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(export.splashMediaPath).isNull()
+        assertThat(preview.splashMediaPath).isNull()
+        assertEquivalentExceptPreviewOnlyFields(export, preview)
+    }
+
+    @Test
+    fun `splash disabled leaves mediaPath null on both paths`() {
+        val app = WebApp(
+            name = "EquivSplashDisabled",
+            url = "https://equiv.example.com",
+            appType = AppType.WEB,
+            splashEnabled = false,
+            splashConfig = com.webtoapp.data.model.SplashConfig(
+                mediaPath = "/should/not/be/injected.png"
+            )
+        )
+        val export = exportEquivalentBase(app)
+        val preview = previewShell(app)
+
+        assertThat(export.splashMediaPath).isNull()
+        assertThat(preview.splashMediaPath).isNull()
+        assertThat(preview.splashEnabled).isFalse()
+    }
+
+    @Test
+    fun `splash preview mediaPath resolves to a real file so the runtime can display it`() {
+        val tmpSplash = java.io.File.createTempFile("equiv_splash", ".png").apply {
+            writeBytes(byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte()))
+            deleteOnExit()
+        }
+        val app = WebApp(
+            name = "EquivSplashResolvable",
+            url = "https://equiv.example.com",
+            appType = AppType.WEB,
+            splashEnabled = true,
+            splashConfig = com.webtoapp.data.model.SplashConfig(
+                type = com.webtoapp.data.model.SplashType.IMAGE,
+                mediaPath = tmpSplash.absolutePath
+            )
+        )
+        val preview = previewShell(app)
+
+        assertThat(preview.splashMediaPath).isEqualTo(tmpSplash.absolutePath)
+        assertThat(java.io.File(preview.splashMediaPath!!).exists()).isTrue()
+    }
+
+    @Test
     fun `multi-web preview and export produce equivalent site shape`() {
         val app = WebApp(
             name = "EquivMultiWeb",
@@ -186,7 +270,8 @@ class PreviewExportEquivalenceTest {
         val normalizedExport = export.copy(
             previewContentDir = preview.previewContentDir,
             siteDirName = preview.siteDirName,
-            siteId = preview.siteId
+            siteId = preview.siteId,
+            splashMediaPath = preview.splashMediaPath
         )
         assertThat(preview).isEqualTo(normalizedExport)
     }

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ResourceDependentFeatureEquivalenceTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ResourceDependentFeatureEquivalenceTest.kt
@@ -1,0 +1,86 @@
+package com.webtoapp.core.apkbuilder
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.WebApp
+import java.io.File
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ResourceDependentFeatureEquivalenceTest {
+
+    private val context get() = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    private fun previewShell(app: WebApp): ShellConfig =
+        com.webtoapp.core.host.ShellPreviewLauncher.buildPreviewConfig(context, app)
+
+    @Test
+    fun `resource-dependent features document their preview resolution path`() {
+        val expectedResolutions = linkedMapOf(
+            "splash" to "ShellPreviewLauncher injects splashMediaPath; ShellScreen splashMediaExists falls back to it when assets/splash_media.* is absent",
+            "gallery" to "ShellPreviewLauncher rewrites items[].assetPath to host file paths; gallery items carry the original path",
+            "media (IMAGE/VIDEO appType)" to "ShellPreviewContent.resolve points previewContentDir at the host media file",
+            "bgm" to "bgmConfig.playlist is serialized with host paths; runtime reads BgmShellItem.assetPath"
+        )
+        assertThat(expectedResolutions.keys)
+            .containsAtLeast("splash", "gallery", "media (IMAGE/VIDEO appType)", "bgm")
+    }
+
+    @Test
+    fun `splash preview config carries a resolvable media path when WebApp has one`() {
+        val tmpPng = File.createTempFile("splash_res", ".png").apply {
+            writeBytes(byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte()))
+            deleteOnExit()
+        }
+        val app = WebApp(
+            name = "ResourceSplash",
+            url = "https://r.example.com",
+            appType = AppType.WEB,
+            splashEnabled = true,
+            splashConfig = com.webtoapp.data.model.SplashConfig(
+                type = com.webtoapp.data.model.SplashType.IMAGE,
+                mediaPath = tmpPng.absolutePath
+            )
+        )
+        val preview = previewShell(app)
+
+        assertThat(preview.splashEnabled).isTrue()
+        assertThat(preview.splashMediaPath).isEqualTo(tmpPng.absolutePath)
+        assertThat(File(preview.splashMediaPath!!).exists()).isTrue()
+    }
+
+    @Test
+    fun `gallery preview items carry resolvable host paths while export uses packaged asset paths`() {
+        val tmpImg = File.createTempFile("gallery_item", ".png").apply {
+            writeBytes(byteArrayOf(0x89.toByte(), 0x50.toByte()))
+            deleteOnExit()
+        }
+        val app = WebApp(
+            name = "ResourceGallery",
+            url = "https://r.example.com",
+            appType = AppType.GALLERY,
+            galleryConfig = com.webtoapp.data.model.GalleryConfig(
+                items = listOf(
+                    com.webtoapp.data.model.GalleryItem(
+                        id = "g1",
+                        path = tmpImg.absolutePath,
+                        type = com.webtoapp.data.model.GalleryItemType.IMAGE,
+                        name = "Preview Item"
+                    )
+                )
+            )
+        )
+        val preview = previewShell(app)
+
+        assertThat(preview.galleryConfig.items).hasSize(1)
+        val previewItem = preview.galleryConfig.items[0]
+        assertThat(previewItem.assetPath).isEqualTo(tmpImg.absolutePath)
+        assertThat(File(previewItem.assetPath).exists()).isTrue()
+    }
+}


### PR DESCRIPTION
## What

Fixes splash animation showing in exported APKs but not in preview, and closes the resource-resolvability test gap that let the bug ship.

## Why

Splash runtime (`ShellScreen.splashMediaExists`, `ShellSplashOverlay`) hardcoded `assets/splash_media.*` as the only media source. Preview runs inside the host app where that asset never exists; the media lives at `SplashConfig.mediaPath` on the host filesystem. Export packages the media into `assets/splash_media.*` at build time, so only the exported APK could resolve it. Issue #240 has the full analysis.

The existing config-consistency gates (#239) did not catch this because they verify config-field equivalence, not resource resolvability. Splash fields round-tripped correctly; the failure was that the preview runtime could not locate the media the fields pointed at.

## Changes

**Field channel (kept symmetric so the static drift gate stays green)**
- `SplashBlock.mediaPath: String? = null` (ApkConfig side).
- `ApkConfigJsonFactory.toShellPayload` emits `splashMediaPath`.
- `ShellConfig.splashMediaPath: String? = null` with `@SerializedName`.

**Preview injection**
- `ShellPreviewLauncher.buildPreviewConfig` injects `WebApp.splashConfig.mediaPath` into the preview `ShellConfig` when splash is enabled, mirroring how gallery already carries host paths.

**Runtime fallback**
- `ShellScreen.splashMediaExists` treats `splashMediaPath` as a third resolution source alongside `assets/splash_media.{png,mp4,.enc}`.
- `ShellSplashOverlay` accepts `mediaPath` and reads the file directly when present (IMAGE: `BitmapFactory.decodeFile`; VIDEO: `MediaPlayer.setDataSource`), falling back to the existing assets path otherwise.

**Export unchanged**
- `buildSplashBlock` does not set `mediaPath`, so exported payloads serialize `splashMediaPath = null` and the runtime keeps using `assets/splash_media.*` exactly as before.

## Tests

- `PreviewExportEquivalenceTest` gains four splash cases: mediaPath injection, no-mediaPath equivalence, splash-disabled, and a temp-file resolvability check.
- New `ResourceDependentFeatureEquivalenceTest` (Robolectric) documents which features are resource-dependent and asserts preview configs carry resolvable host paths for splash and gallery. Verified to fail when the splash injection is removed, so the regression is now gated.

## Issue

Fixes #240

## Verification

```
./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.apkbuilder.*" -x :shell:assembleRelease -x :app:syncShellTemplateApk --no-configuration-cache
python3 scripts/check_config_field_drift.py
```

All green locally:
- `check_config_field_drift: OK (payload=426 shell=457 allowlist=49 shared=418)` — new `splashMediaPath` field tracked automatically.
- Full `apkbuilder` test suite passes.
- Synthetic regression (removing the splash injection) makes `ResourceDependentFeatureEquivalenceTest.splash preview config carries a resolvable media path` fail, confirming the gate works.

## Notes

Only intended files committed; pre-existing uncommitted `shell_i18n/*.pack` / `shell/.../en.pack` changes and `.zcode/` are excluded.