### PR TITLE
fix(ui): remove double gap between Extension Modules and Ad Blocking cards

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -458,9 +458,6 @@ fun CreateAppScreen(
                 if (hasConfiguredLegacyAds(editState)) {
                     LegacyAdCapabilityWarningCard()
                 }
-            }
-
-            item {
                 AdBlockCard(
                     editState = editState,
                     onEnabledChange = { viewModel.updateEditState { copy(adBlockEnabled = it) } },


### PR DESCRIPTION
## What

Removes the ~2x-tall gap between the Extension Modules card and the Ad Blocking card in the create-app config screen.

## Why

The card list is a `LazyColumn` with `verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)` (16dp). `spacedBy` inserts the gap between every pair of items, including empty ones. Between ExtensionModuleCard and AdBlockCard there was a standalone item that only rendered content conditionally:

```kotlin
item {
    if (hasConfiguredLegacyAds(editState)) {
        LegacyAdCapabilityWarningCard()
    }
}
```

For apps without legacy ads the `if` produced no composable, but the `item { }` still occupied a LazyColumn slot, so `spacedBy` added one SectionGap above and one below the empty item — 2 × 16dp = 32dp between Extension Modules and Ad Blocking, versus 16dp everywhere else. Issue #243 has the analysis.

## Change

Move the legacy-ads warning into the AdBlockCard item so it renders in the same slot when needed and produces no extra item otherwise. Net: -3 lines. The warning still appears above AdBlockCard for apps that configured legacy ads; all card gaps are now uniform.

## Issue

Fixes #243

## Verification

`./gradlew :app:compileDebugKotlin` passes. Pure UI layout change; no logic affected.

## Notes

Only the intended file is committed; build-generated `shell_i18n/*.pack`, `shell/.../en.pack`, and `template/webview_shell.apk` changes are excluded.