### PR TITLE
fix(shell): stop config-time input validation on stripShellTemplateBloat

### DIFF
--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -544,7 +544,8 @@ tasks.register("stripShellTemplateBloat") {
     dependsOn("packageRelease")
     val apk = layout.buildDirectory.file("outputs/apk/release/shell-release.apk")
     val script = rootProject.layout.projectDirectory.file("scripts/strip_shell_apk_bloat.py").asFile
-    inputs.file(apk)
+    val packageRelease = tasks.named("packageRelease")
+    inputs.files(packageRelease.map { it.outputs.files })
     inputs.file(script)
     outputs.file(apk)
     doLast {


### PR DESCRIPTION
## What

Fixes `:shell:stripShellTemplateBloat` failing at configuration time under AGP 9.2.0 whenever the shell release APK has not been packaged yet.

## Why

The task declared:

```kotlin
val apk = layout.buildDirectory.file("outputs/apk/release/shell-release.apk")
inputs.file(apk)
```

Under AGP 9 / Gradle 9, `inputs.file(provider)` for a literal `layout.buildDirectory.file(...)` triggers a **configuration-time** existence check. Because the provider has no producing-task attribution, Gradle treats it as a literal file that must already exist. `packageRelease` has not run at configuration time, so the file is absent and validation fails before any task executes — breaking any chain that touches the shell template (`:app:syncShellTemplateApk`, IDE import of `:shell`, or `:shell:assembleRelease` from a clean state). Issue #245 has the full analysis.

`packageRelease.finalizedBy(stripShellTemplateBloat)` and the `doLast` existence guard were both correct; the only problem was the eager validation of the literal input.

## Change

Replace the literal input with a provider derived from `packageRelease` outputs:

```kotlin
val packageRelease = tasks.named("packageRelease")
inputs.files(packageRelease.map { it.outputs.files })
```

Gradle now tracks the file as produced by `packageRelease`, skips the configuration-time existence check, and keeps correct up-to-date tracking (the strip task re-runs whenever `packageRelease` outputs change — the intended behavior). Net: +1 line, −1 line. `doLast` logic unchanged.

## Issue

Fixes #245

## Verification

```
./gradlew :shell:assembleRelease --no-configuration-cache
./gradlew :app:syncShellTemplateApk --no-configuration-cache
```

Both run clean from a freshly cleaned state. The strip task still executes after `packageRelease` and reports `strip_apk before=4067801 after=4002478 saved=65323 removed_entries=19`. Up-to-date behavior verified by re-running.

## Notes

Only `shell/build.gradle.kts` is committed; build-generated `shell_i18n/*.pack`, `shell/.../en.pack`, and `template/webview_shell.apk` changes are excluded.
