### PR TITLE
feat(extension): add GreasyFork tab to Extension Modules screen

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionManager.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionManager.kt
@@ -795,7 +795,8 @@ class ExtensionManager private constructor(private val context: Context) {
         val matchingModules = getModulesForUrl(url).filter {
             it.runAt == runAt &&
             it.sourceType != ModuleSourceType.CHROME_EXTENSION &&
-            it.sourceType != ModuleSourceType.USERSCRIPT
+            it.sourceType != ModuleSourceType.USERSCRIPT &&
+            it.sourceType != ModuleSourceType.GREASYFORK
         }
         if (matchingModules.isEmpty()) return ""
 
@@ -824,7 +825,8 @@ class ExtensionManager private constructor(private val context: Context) {
             module.runAt == runAt &&
             module.matchesUrl(url) &&
             module.sourceType != ModuleSourceType.CHROME_EXTENSION &&
-            module.sourceType != ModuleSourceType.USERSCRIPT
+            module.sourceType != ModuleSourceType.USERSCRIPT &&
+            module.sourceType != ModuleSourceType.GREASYFORK
         }
 
         if (targetModules.isEmpty()) return ""

--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
@@ -427,7 +427,8 @@ data class UrlMatchRule(
 enum class ModuleSourceType {
     CUSTOM,
     USERSCRIPT,
-    CHROME_EXTENSION
+    CHROME_EXTENSION,
+    GREASYFORK
 }
 
 enum class ModuleRunMode {
@@ -672,7 +673,7 @@ data class ExtensionModule(
 
     fun shouldRegisterInPanel(): Boolean {
         return !(
-            sourceType == ModuleSourceType.USERSCRIPT &&
+            (sourceType == ModuleSourceType.USERSCRIPT || sourceType == ModuleSourceType.GREASYFORK) &&
                 runMode == ModuleRunMode.AUTO &&
                 configItems.isEmpty()
         )

--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionPanelScript.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionPanelScript.kt
@@ -2122,7 +2122,7 @@ object ExtensionPanelScript {
         getTypeBadge(m) {
             var isChromeExt = m.sourceType === 'CHROME_EXTENSION';
             if (isChromeExt) return '<span class="wta-type-badge chrome">Chrome</span>';
-            if (m.sourceType === 'USERSCRIPT') return '<span class="wta-type-badge userscript">' + T.typeUserScript + '</span>';
+            if (m.sourceType === 'USERSCRIPT' || m.sourceType === 'GREASYFORK') return '<span class="wta-type-badge userscript">' + T.typeUserScript + '</span>';
             return '<span class="wta-type-badge module">' + T.tabModules + '</span>';
         },
 
@@ -2169,8 +2169,8 @@ object ExtensionPanelScript {
 
             var filtered = this.getFilteredModules();
             var chromeExts = filtered.filter(function(m) { return m.sourceType === 'CHROME_EXTENSION'; });
-            var userScripts = filtered.filter(function(m) { return m.sourceType === 'USERSCRIPT'; });
-            var customModules = filtered.filter(function(m) { return m.sourceType !== 'CHROME_EXTENSION' && m.sourceType !== 'USERSCRIPT'; });
+            var userScripts = filtered.filter(function(m) { return m.sourceType === 'USERSCRIPT' || m.sourceType === 'GREASYFORK'; });
+            var customModules = filtered.filter(function(m) { return m.sourceType !== 'CHROME_EXTENSION' && m.sourceType !== 'USERSCRIPT' && m.sourceType !== 'GREASYFORK'; });
 
             // 更新标签页计数
             this.updateTabCounts(customModules.length, chromeExts.length, userScripts.length);

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -561,7 +561,7 @@ data class EmbeddedShellModule(
     @Volatile
     private var _cachedCode: String? = null
 
-    fun isUserscript(): Boolean = sourceType == "USERSCRIPT"
+    fun isUserscript(): Boolean = sourceType == "USERSCRIPT" || sourceType == "GREASYFORK"
 
     fun shouldRegisterInPanel(): Boolean {
         return !(isUserscript() && configItemCount == 0)

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -4781,11 +4781,13 @@ class WebViewManager(
             it.chromeExtId.isNotEmpty()
         }
         val userscriptModules = matching.filter {
-            it.sourceType == com.webtoapp.core.extension.ModuleSourceType.USERSCRIPT
+            it.sourceType == com.webtoapp.core.extension.ModuleSourceType.USERSCRIPT ||
+            it.sourceType == com.webtoapp.core.extension.ModuleSourceType.GREASYFORK
         }
         val customModules = matching.filter {
             it.sourceType != com.webtoapp.core.extension.ModuleSourceType.CHROME_EXTENSION &&
-            it.sourceType != com.webtoapp.core.extension.ModuleSourceType.USERSCRIPT
+            it.sourceType != com.webtoapp.core.extension.ModuleSourceType.USERSCRIPT &&
+            it.sourceType != com.webtoapp.core.extension.ModuleSourceType.GREASYFORK
         }
 
         if (chromeModules.isNotEmpty()) {

--- a/app/src/main/java/com/webtoapp/ui/components/GreasyForkSearchContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/GreasyForkSearchContent.kt
@@ -554,7 +554,8 @@ suspend fun installGreasyForkScript(
         }
 
         val extensionManager = ExtensionManager.getInstance(appContext)
-        val addResult = extensionManager.addModule(parsed.module)
+        val greasyForkModule = parsed.module.copy(sourceType = com.webtoapp.core.extension.ModuleSourceType.GREASYFORK)
+        val addResult = extensionManager.addModule(greasyForkModule)
         addResult.onSuccess {
             Toast.makeText(
                 appContext,

--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -222,7 +222,10 @@ fun ExtensionModuleScreen(
 
     val allModules = (builtInModules + modules).distinctBy { it.id }
     val extensionModules = allModules.filter { it.sourceType == ModuleSourceType.CUSTOM }
-    val userScriptModules = allModules.filter { it.sourceType != ModuleSourceType.CUSTOM }
+    val userScriptModules = allModules.filter {
+        it.sourceType != ModuleSourceType.CUSTOM && it.sourceType != ModuleSourceType.GREASYFORK
+    }
+    val greasyForkModules = allModules.filter { it.sourceType == ModuleSourceType.GREASYFORK }
 
     val filteredModules = extensionModules.filter { module ->
         val matchesCategory = selectedCategory == null || module.category == selectedCategory
@@ -247,6 +250,12 @@ fun ExtensionModuleScreen(
                 true
             }
         }
+    }.distinctBy { it.id }
+
+    val filteredGreasyFork = greasyForkModules.filter { module ->
+        searchQuery.isBlank() ||
+            module.name.contains(searchQuery, ignoreCase = true) ||
+            module.description.contains(searchQuery, ignoreCase = true)
     }.distinctBy { it.id }
 
     LaunchedEffect(loadError) {
@@ -356,11 +365,12 @@ fun ExtensionModuleScreen(
                 shape = RoundedCornerShape(WtaRadius.Button)
             )
 
-            val pagerState = rememberPagerState(pageCount = { 2 })
+            val pagerState = rememberPagerState(pageCount = { 3 })
             WtaTabRow(
                 tabs = listOf(
                     WtaTab(Strings.extensionModulesTab, extensionModules.size),
-                    WtaTab(Strings.userScriptsTab, userScriptModules.size)
+                    WtaTab(Strings.userScriptsTab, userScriptModules.size),
+                    WtaTab(Strings.greasyForkTab, greasyForkModules.size)
                 ),
                 selectedIndex = pagerState.currentPage,
                 onTabSelected = { scope.launch { pagerState.animateScrollToPage(it) } },
@@ -385,6 +395,15 @@ fun ExtensionModuleScreen(
                     )
                     1 -> UserScriptsTabContent(
                         filteredUserScripts = filteredUserScripts,
+                        extensionManager = extensionManager,
+                        searchQuery = searchQuery,
+                        onImportUserScript = {
+                            userScriptPickerLauncher.launch("*/*")
+                        },
+                        onClearSearch = { searchQuery = "" }
+                    )
+                    2 -> UserScriptsTabContent(
+                        filteredUserScripts = filteredGreasyFork,
                         extensionManager = extensionManager,
                         searchQuery = searchQuery,
                         onImportUserScript = {
@@ -1878,8 +1897,17 @@ private fun UserScriptCard(
     var showSourceDialog by remember { mutableStateOf(false) }
 
     val isChromeExt = module.sourceType == ModuleSourceType.CHROME_EXTENSION
-    val typeIcon = if (isChromeExt) "🧩" else "🐵"
-    val typeLabel = if (isChromeExt) "Chrome" else "UserScript"
+    val isGreasyFork = module.sourceType == ModuleSourceType.GREASYFORK
+    val typeIcon = when {
+        isChromeExt -> "🧩"
+        isGreasyFork -> " 🍴"
+        else -> "🐵"
+    }
+    val typeLabel = when {
+        isChromeExt -> "Chrome"
+        isGreasyFork -> "GreasyFork"
+        else -> "UserScript"
+    }
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
@@ -474,7 +474,7 @@ fun ModuleMarketScreen(
                         installProgress = installProgress,
                         favorites = gfFavorites,
                         installedUserScriptNames = installedModules
-                            .filter { it.sourceType == ModuleSourceType.USERSCRIPT }
+                            .filter { it.sourceType == ModuleSourceType.USERSCRIPT || it.sourceType == ModuleSourceType.GREASYFORK }
                             .map { it.name }
                             .toSet(),
                         onInstall = { result ->


### PR DESCRIPTION
## What

Adds a dedicated GreasyFork tab to the Extension Modules management screen, following the same pattern as the existing Extension Modules and Browser Extension tabs.

## Why

GreasyFork scripts installed from the community market were indistinguishable from hand-imported userscripts (both `ModuleSourceType.USERSCRIPT`), so they piled into the mixed Browser Extension tab and users could not filter to "scripts I got from GreasyFork". Issue #247 has the full analysis.

The market screen already has a GreasyFork tab; this brings parity to the local management screen.

## Changes

**New sourceType (peer to CHROME_EXTENSION)**
- `ModuleSourceType.GREASYFORK` added (app + shell enum).
- `installGreasyForkScript` stamps `sourceType = GREASYFORK` before persisting.

**Runtime classification keeps GreasyFork on the userscript path**
- `WebViewManager` (app + shell): GREASYFORK joins `userscriptModules` → `injectUserscriptModules`.
- `ExtensionModule.shouldRegisterInPanel` / `ShellModeManager.isUserscript`: treat GREASYFORK like USERSCRIPT.
- `ExtensionManager` custom-module filters (app + shell): exclude GREASYFORK so it is not misrouted to the custom injection path.
- `ExtensionPanelScript` in-page panel: classifies GREASYFORK as a userscript badge and groups it under userscripts.
- `ModuleMarketScreen` installed-script lookup matches GREASYFORK so re-search shows already-installed state.

**UI**
- `ExtensionModuleScreen` gains a third tab "GreasyFork" (`pageCount` 2 → 3), filtered by `sourceType == GREASYFORK`, reusing `UserScriptsTabContent`.
- Card distinguishes GreasyFork scripts with a dedicated icon/label.

Shell-side files are synced from app via `syncShellRuntimeSources` and not committed (`.gitignore` excludes them).

## Backward compatibility

Existing `USERSCRIPT` modules are unaffected — they stay in the Browser Extension tab. GreasyFork installs from this change forward get the new tag. Previously installed GreasyFork scripts remain `USERSCRIPT` until reinstalled (acceptable; the tab is a view filter, not a data migration).

## Issue

Fixes #247

## Verification

```
./gradlew :app:compileDebugKotlin :shell:compileDebugKotlin --no-configuration-cache
./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.apkbuilder.*" --no-configuration-cache
python3 scripts/check_config_field_drift.py
```

All green locally. The drift gate stays green because `sourceType` is an enum value, not a new field name, so no payload/`@SerializedName` pair is touched.

## Notes

Pattern copied exactly from how `CHROME_EXTENSION` was introduced: distinct sourceType, distinct tab, distinct treatment at each runtime classification point. Only intended source files committed; build-generated `shell_i18n/*.pack`, `shell/.../en.pack`, and `template/webview_shell.apk` changes are excluded.
