### PR TITLE
Bump app version to 2.3.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 48
-        versionName = "2.2.0"
+        versionCode = 49
+        versionName = "2.3.0"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 48
-        versionName = "2.2.0"
+        versionCode = 49
+        versionName = "2.3.0"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## What & why

Bumps the WebToApp version from `2.2.0` to `2.3.0` and raises `versionCode` from `48` to `49` so the new build can overwrite the previous install.

## Changes

- `versionName`: `2.2.0` → `2.3.0`
- `versionCode`: `48` → `49`
- Applied in both `app/build.gradle.kts` and `shell/build.gradle.kts` to keep the builder host and the generated-APK shell template versioned in sync.

No behavior changes.

## Issue

Fixes #249