### PR TITLE
fix(icon): route ARSC foreground icons through safe-zone path

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1134,7 +1134,12 @@ class ApkBuilder(private val context: Context) {
 
                         iconBitmap != null && (isIconEntry(entry.name) || discoveredOldIconPaths.contains(entry.name)) -> {
 
-                            replaceIconEntry(zipOut, entry.name, iconBitmap)
+                            if (discoveredOldIconPaths.contains(entry.name)) {
+                                val iconBytes = template.createAdaptiveForegroundIcon(iconBitmap, 432)
+                                writeEntryDeflated(zipOut, entry.name, iconBytes)
+                            } else {
+                                replaceIconEntry(zipOut, entry.name, iconBitmap)
+                            }
                             replacedIconPaths.add(entry.name)
                         }
 

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -88,32 +88,14 @@ class ApkTemplate(private val context: Context) {
 
     fun loadBitmap(iconPath: String): Bitmap? {
         return try {
-            // Use BitmapFactory.Options to control sampling and get optimal resolution
-            val options = BitmapFactory.Options().apply {
-                inSampleSize = 1
-                inPreferredColor = Bitmap.Config.ARGB_8888
-                inDither = false
-            }
-            
-            val decodedBitmap = if (iconPath.startsWith("/")) {
-                BitmapFactory.decodeFile(iconPath, options)
+            if (iconPath.startsWith("/")) {
+                BitmapFactory.decodeFile(iconPath)
             } else if (iconPath.startsWith("content://")) {
-                context.contentResolver.openInputStream(android.net.Uri.parse(iconPath))?.use { inputStream ->
-                    BitmapFactory.decodeStream(inputStream, null, options)
+                context.contentResolver.openInputStream(android.net.Uri.parse(iconPath))?.use {
+                    BitmapFactory.decodeStream(it)
                 }
             } else {
-                BitmapFactory.decodeFile(iconPath, options)
-            }
-            
-            decodedBitmap ?: return null
-            
-            // Ensure high quality ARGB_8888 format and recycle if needed
-            if (decodedBitmap.config != Bitmap.Config.ARGB_8888) {
-                val argbBitmap = decodedBitmap.copy(Bitmap.Config.ARGB_8888, false)
-                decodedBitmap.recycle()
-                argbBitmap
-            } else {
-                decodedBitmap
+                BitmapFactory.decodeFile(iconPath)
             }
         } catch (e: Exception) {
             AppLogger.e("ApkTemplate", "Failed to load icon from $iconPath", e)
@@ -127,8 +109,8 @@ class ApkTemplate(private val context: Context) {
         val canvas = android.graphics.Canvas(output)
 
         // Calculate the exact center padding for proper icon display
-        // Android adaptive icons use a 72% safe zone with 14% margin on each side
-        val safeZoneSize = (size * 0.72f).toInt()
+        // Android adaptive icons use a 108-unit canvas with a 72-unit safe zone.
+        val safeZoneSize = (size * 72f / 108f).toInt()
         val padding = (size - safeZoneSize) / 2
 
         // Use high-quality scaling with filtering enabled
@@ -137,7 +119,6 @@ class ApkTemplate(private val context: Context) {
         val paint = android.graphics.Paint().apply {
             isAntiAlias = true
             isFilterBitmap = true
-            filterBitmap = true
         }
         canvas.drawBitmap(scaled, padding.toFloat(), padding.toFloat(), paint)
 
@@ -159,7 +140,6 @@ class ApkTemplate(private val context: Context) {
         val paint = android.graphics.Paint().apply {
             isAntiAlias = true
             isFilterBitmap = true
-            filterBitmap = true
         }
 
         val rect = android.graphics.RectF(0f, 0f, size.toFloat(), size.toFloat())

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.webtoapp.core.forcedrun.ForcedRunConfig
+import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.core.shell.BgmShellItem
 import com.webtoapp.core.shell.LrcShellTheme
 import java.io.*
@@ -87,16 +88,35 @@ class ApkTemplate(private val context: Context) {
 
     fun loadBitmap(iconPath: String): Bitmap? {
         return try {
-            if (iconPath.startsWith("/")) {
-                BitmapFactory.decodeFile(iconPath)
+            // Use BitmapFactory.Options to control sampling and get optimal resolution
+            val options = BitmapFactory.Options().apply {
+                inSampleSize = 1
+                inPreferredColor = Bitmap.Config.ARGB_8888
+                inDither = false
+            }
+            
+            val decodedBitmap = if (iconPath.startsWith("/")) {
+                BitmapFactory.decodeFile(iconPath, options)
             } else if (iconPath.startsWith("content://")) {
-                context.contentResolver.openInputStream(android.net.Uri.parse(iconPath))?.use {
-                    BitmapFactory.decodeStream(it)
+                context.contentResolver.openInputStream(android.net.Uri.parse(iconPath))?.use { inputStream ->
+                    BitmapFactory.decodeStream(inputStream, null, options)
                 }
             } else {
-                BitmapFactory.decodeFile(iconPath)
+                BitmapFactory.decodeFile(iconPath, options)
+            }
+            
+            decodedBitmap ?: return null
+            
+            // Ensure high quality ARGB_8888 format and recycle if needed
+            if (decodedBitmap.config != Bitmap.Config.ARGB_8888) {
+                val argbBitmap = decodedBitmap.copy(Bitmap.Config.ARGB_8888, false)
+                decodedBitmap.recycle()
+                argbBitmap
+            } else {
+                decodedBitmap
             }
         } catch (e: Exception) {
+            AppLogger.e("ApkTemplate", "Failed to load icon from $iconPath", e)
             null
         }
     }
@@ -106,14 +126,18 @@ class ApkTemplate(private val context: Context) {
         val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
         val canvas = android.graphics.Canvas(output)
 
-        val safeZoneSize = (size * 72f / 108f).toInt()
+        // Calculate the exact center padding for proper icon display
+        // Android adaptive icons use a 72% safe zone with 14% margin on each side
+        val safeZoneSize = (size * 0.72f).toInt()
         val padding = (size - safeZoneSize) / 2
 
+        // Use high-quality scaling with filtering enabled
         val scaled = Bitmap.createScaledBitmap(bitmap, safeZoneSize, safeZoneSize, true)
 
         val paint = android.graphics.Paint().apply {
             isAntiAlias = true
             isFilterBitmap = true
+            filterBitmap = true
         }
         canvas.drawBitmap(scaled, padding.toFloat(), padding.toFloat(), paint)
 
@@ -127,6 +151,7 @@ class ApkTemplate(private val context: Context) {
     }
 
     fun createRoundIcon(bitmap: Bitmap, size: Int): ByteArray {
+        // Scale with high quality
         val scaled = Bitmap.createScaledBitmap(bitmap, size, size, true)
         val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
 
@@ -134,6 +159,7 @@ class ApkTemplate(private val context: Context) {
         val paint = android.graphics.Paint().apply {
             isAntiAlias = true
             isFilterBitmap = true
+            filterBitmap = true
         }
 
         val rect = android.graphics.RectF(0f, 0f, size.toFloat(), size.toFloat())


### PR DESCRIPTION
## What & why

Icons in exported APKs became **blurry and upscaled/overflowing** after the black-border fix in `f2242261`. This PR restores correct adaptive-foreground rendering.

Root cause: `f2242261` routed every icon entry through `replaceIconEntry`, which dispatches by readable-name substrings (`contains("foreground")`, `contains("xxxhdpi")`, …). The shell template ships **R8-shrunk resource names**, so the adaptive foregrounds referenced by `resources.arsc` — collected into `discoveredOldIconPaths` — matched no branch and fell into the generic `else`: rendered as **96px full-bleed with no safe-zone padding**, then stretched across the 108-unit adaptive grid by the launcher. That single regression explains both symptoms (blurry: 96px source upscaled; upscaled: full-bleed, no 72/108 safe zone).

It also explains why the follow-up `4b5eab8b` had no visible effect: it edited `createAdaptiveForegroundIcon`, which the affected entries never reached (they took the `scaleBitmapToPng` path).

## Changes

- `ApkBuilder.kt` — icon loop now routes `discoveredOldIconPaths` entries (always ARSC-referenced adaptive foregrounds) through `createAdaptiveForegroundIcon(432)` with the safe zone; readable-name regular icons keep the existing `replaceIconEntry` dispatch.
- `ApkTemplate.kt` — restore the spec-correct safe-zone formula `size * 72f / 108f` (the `0.72f` value only became reachable again after the dispatch fix); drop the `4b5eab8b` placeholders that do not compile on the host `compileSdk` (`inPreferredColor`, `Paint.filterBitmap`).

No shell template / feature-pack changes are needed: the transparent adaptive background already landed in `f2242261`.

## Verification

- `:app:compileDebugKotlin` passes.
- Host-only `apkbuilder` change; no shell sync / pack / Planner changes, so `liteOnly` planning for pure WEB is unaffected.

## Issue

Fixes #255