### PR TITLE
fix(icon): replace legacy mipmap fallbacks and render foreground full-bleed

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1135,7 +1135,10 @@ class ApkBuilder(private val context: Context) {
                         iconBitmap != null && (isIconEntry(entry.name) || discoveredOldIconPaths.contains(entry.name)) -> {
 
                             if (discoveredOldIconPaths.contains(entry.name)) {
-                                val iconBytes = template.createAdaptiveForegroundIcon(iconBitmap, 432)
+                                val iconBytes = when {
+                                    entry.name.contains("round") -> template.createRoundIcon(iconBitmap, 432)
+                                    else -> template.scaleBitmapToPng(iconBitmap, 432)
+                                }
                                 writeEntryDeflated(zipOut, entry.name, iconBytes)
                             } else {
                                 replaceIconEntry(zipOut, entry.name, iconBitmap)

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -104,31 +104,7 @@ class ApkTemplate(private val context: Context) {
     }
 
     fun createAdaptiveForegroundIcon(bitmap: Bitmap, size: Int): ByteArray {
-
-        val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-        val canvas = android.graphics.Canvas(output)
-
-        // Calculate the exact center padding for proper icon display
-        // Android adaptive icons use a 108-unit canvas with a 72-unit safe zone.
-        val safeZoneSize = (size * 72f / 108f).toInt()
-        val padding = (size - safeZoneSize) / 2
-
-        // Use high-quality scaling with filtering enabled
-        val scaled = Bitmap.createScaledBitmap(bitmap, safeZoneSize, safeZoneSize, true)
-
-        val paint = android.graphics.Paint().apply {
-            isAntiAlias = true
-            isFilterBitmap = true
-        }
-        canvas.drawBitmap(scaled, padding.toFloat(), padding.toFloat(), paint)
-
-        val baos = ByteArrayOutputStream()
-        output.compress(Bitmap.CompressFormat.PNG, 100, baos)
-
-        if (scaled != bitmap) scaled.recycle()
-        output.recycle()
-
-        return baos.toByteArray()
+        return scaleBitmapToPng(bitmap, size)
     }
 
     fun createRoundIcon(bitmap: Bitmap, size: Int): ByteArray {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ArscRebuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ArscRebuilder.kt
@@ -293,7 +293,12 @@ class ArscRebuilder {
                             if (entryKeyIndex == icLauncherKeyIdx || entryKeyIndex == icLauncherRoundKeyIdx) {
                                 val oldPath = globalStrings[globalStrIdx]
                                 val keyName = if (entryKeyIndex >= 0 && entryKeyIndex < keyStrings.size) keyStrings[entryKeyIndex] else "?"
-                                AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' (adaptive icon XML, KEEPING)")
+                                if (oldPath.endsWith(".png")) {
+                                    result.add(globalStrIdx to oldPath)
+                                    AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' (raster PNG, REPLACING)")
+                                } else {
+                                    AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' (adaptive icon XML, KEEPING)")
+                                }
                             }
                         }
 


### PR DESCRIPTION
## What & why

Exported APK icons still render wrong on **OEM / third-party launchers** even after the earlier sharpness/scaling fix (#256): on some ROMs the icon shows the default **WebToApp grid icon** (user icon ignored), on others it looks **undersized** ("a ring smaller"), and only stock Google/AOSP launchers look correct. This is an adaptive-icon shape + legacy-fallback problem, with two independent causes:

**A. Legacy raster fallbacks never replaced.** The shell template ships R8-shrunk resource names. `resources.arsc` references `mipmap/ic_launcher` and `ic_launcher_round` legacy PNGs under mangled names (`res/o-.png`, `res/Gc.png`), but `ArscRebuilder.findIconPathIndices()` only logged those entries as `KEEPING` without collecting them. The export loop therefore never matched/replaced them, so they shipped as the original WebToApp icon. Android < 8 and OEM "classic icon" modes / third-party launchers select these legacy PNGs instead of the adaptive XML → grid icon.

**B. Adaptive foreground padded + transparent background.** The earlier fix restored 72/108 safe-zone padding on `createAdaptiveForegroundIcon` (icon shrunk to central ~67%, transparent surround) while `f2242261` made the adaptive background transparent. Non-cropping OEM launchers show the full 108-unit grid, so the icon looks undersized vs. neighbors. Stock launchers crop to circle/squircle and look fine.

## Changes

- `ArscRebuilder.kt` — collect `mipmap/ic_launcher` + `ic_launcher_round` **PNG** configs (`.png` suffix) into the discovered set; adaptive XML configs still skipped.
- `ApkBuilder.kt` — export loop dispatches discovered paths by name: `round` → `createRoundIcon(432)` (circle), everything else (foreground drawable + legacy square fallback) → full-bleed `scaleBitmapToPng(432)`.
- `ApkTemplate.kt` — `createAdaptiveForegroundIcon` now renders full-bleed (delegates to `scaleBitmapToPng`); cropping launchers still never reveal a dark fringe thanks to the transparent background.

No shell template / feature-pack / Planner changes (transparent background already in template via `f2242261`).

## Verification

- `:app:compileDebugKotlin` passes.
- `CapabilityPlannerTest`, `FeaturePackMergerTest`, `FeaturePackPathGuardTest`, `ApkBuildCacheTest`, `ApkArtifactVerifierTest` pass.
- Host-only `apkbuilder` change; pure-WEB `liteOnly` planning unaffected.

## Issue

Fixes #257