### PR TITLE
fix(icon): correct legacy fallback size, round/square dispatch, foreground safe-zone

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -1026,6 +1026,7 @@ class ApkBuilder(private val context: Context) {
         var strippedNativeLibSize = 0L
         val replacedIconPaths = mutableSetOf<String>()
         var discoveredOldIconPaths = emptySet<String>()
+        var discoveredIconKinds = emptyMap<String, ArscRebuilder.IconKind>()
 
         val assetEncryptor = if (encryptionConfig.enabled && encryptionKey != null) {
             AssetEncryptor(encryptionKey)
@@ -1123,6 +1124,7 @@ class ApkBuilder(private val context: Context) {
                             )
 
                             discoveredOldIconPaths = arscRebuilder.getLastDiscoveredIconPaths()
+                            discoveredIconKinds = arscRebuilder.getLastDiscoveredIconKinds()
                             logger.log("Discovered old icon paths from ARSC: $discoveredOldIconPaths")
                             writeEntryStored(zipOut, entry.name, modifiedData)
                         }
@@ -1135,9 +1137,11 @@ class ApkBuilder(private val context: Context) {
                         iconBitmap != null && (isIconEntry(entry.name) || discoveredOldIconPaths.contains(entry.name)) -> {
 
                             if (discoveredOldIconPaths.contains(entry.name)) {
-                                val iconBytes = when {
-                                    entry.name.contains("round") -> template.createRoundIcon(iconBitmap, 432)
-                                    else -> template.scaleBitmapToPng(iconBitmap, 432)
+                                val kind = discoveredIconKinds[entry.name]
+                                val iconBytes = when (kind) {
+                                    ArscRebuilder.IconKind.FOREGROUND -> template.createAdaptiveForegroundIcon(iconBitmap, 432)
+                                    ArscRebuilder.IconKind.ROUND -> template.createRoundIcon(iconBitmap, 192)
+                                    else -> template.scaleBitmapToPng(iconBitmap, 192)
                                 }
                                 writeEntryDeflated(zipOut, entry.name, iconBytes)
                             } else {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -104,7 +104,30 @@ class ApkTemplate(private val context: Context) {
     }
 
     fun createAdaptiveForegroundIcon(bitmap: Bitmap, size: Int): ByteArray {
-        return scaleBitmapToPng(bitmap, size)
+        val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = android.graphics.Canvas(output)
+
+        val safeZone = (size * 66f / 108f).toInt()
+        val scale = minOf(safeZone.toFloat() / bitmap.width, safeZone.toFloat() / bitmap.height)
+        val scaledW = (bitmap.width * scale).toInt()
+        val scaledH = (bitmap.height * scale).toInt()
+        val left = ((size - scaledW) / 2f)
+        val top = ((size - scaledH) / 2f)
+
+        val scaled = Bitmap.createScaledBitmap(bitmap, scaledW, scaledH, true)
+        val paint = android.graphics.Paint().apply {
+            isAntiAlias = true
+            isFilterBitmap = true
+        }
+        canvas.drawBitmap(scaled, left, top, paint)
+
+        val baos = ByteArrayOutputStream()
+        output.compress(Bitmap.CompressFormat.PNG, 100, baos)
+
+        if (scaled != bitmap) scaled.recycle()
+        output.recycle()
+
+        return baos.toByteArray()
     }
 
     fun createRoundIcon(bitmap: Bitmap, size: Int): ByteArray {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ArscRebuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ArscRebuilder.kt
@@ -82,7 +82,8 @@ class ArscRebuilder {
 
             if (replaceIcons) {
                 val iconPaths = findIconPathIndices(remainingData, strings)
-                _lastDiscoveredIconPaths = iconPaths.map { (idx, _) -> strings[idx] }.toSet()
+                _lastDiscoveredIconPaths = iconPaths.map { (idx, _, _) -> strings[idx] }.toSet()
+                _lastDiscoveredIconKinds = iconPaths.associate { (idx, _, kind) -> strings[idx] to kind }
                 AppLogger.d(TAG, "Discovered old icon paths (for ZIP replacement): $_lastDiscoveredIconPaths")
             }
 
@@ -156,11 +157,16 @@ class ArscRebuilder {
     private var _lastDiscoveredIconPaths = emptySet<String>()
     fun getLastDiscoveredIconPaths(): Set<String> = _lastDiscoveredIconPaths
 
+    enum class IconKind { ROUND, SQUARE, FOREGROUND }
+
+    private var _lastDiscoveredIconKinds = emptyMap<String, IconKind>()
+    fun getLastDiscoveredIconKinds(): Map<String, IconKind> = _lastDiscoveredIconKinds
+
     private fun findIconPathIndices(
         packageData: ByteArray,
         globalStrings: List<String>
-    ): List<Pair<Int, String>> {
-        val result = mutableListOf<Pair<Int, String>>()
+    ): List<Triple<Int, String, IconKind>> {
+        val result = mutableListOf<Triple<Int, String, IconKind>>()
 
         try {
             val buf = ByteBuffer.wrap(packageData).order(ByteOrder.LITTLE_ENDIAN)
@@ -294,8 +300,9 @@ class ArscRebuilder {
                                 val oldPath = globalStrings[globalStrIdx]
                                 val keyName = if (entryKeyIndex >= 0 && entryKeyIndex < keyStrings.size) keyStrings[entryKeyIndex] else "?"
                                 if (oldPath.endsWith(".png")) {
-                                    result.add(globalStrIdx to oldPath)
-                                    AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' (raster PNG, REPLACING)")
+                                    val kind = if (entryKeyIndex == icLauncherRoundKeyIdx) IconKind.ROUND else IconKind.SQUARE
+                                    result.add(Triple(globalStrIdx, oldPath, kind))
+                                    AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' ($kind raster PNG, REPLACING)")
                                 } else {
                                     AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' (adaptive icon XML, KEEPING)")
                                 }
@@ -306,7 +313,7 @@ class ArscRebuilder {
                             if (entryKeyIndex == icLauncherFgKeyIdx) {
                                 val oldPath = globalStrings[globalStrIdx]
                                 AppLogger.d(TAG, "Found drawable/ic_launcher_foreground → '$oldPath' (foreground image, REPLACING)")
-                                result.add(globalStrIdx to oldPath)
+                                result.add(Triple(globalStrIdx, oldPath, IconKind.FOREGROUND))
                             }
                         }
                     }


### PR DESCRIPTION
## What & why

After #258, exported APK icons render as **oversized plain squares** with no shape adaptation. #258 fixed the earlier "grid icon / undersized" symptom but introduced three new regressions by dispatching all ARSC-discovered icons full-bleed via mangled-name matching:

- **A. Oversized legacy fallback.** The discovered `mipmap/ic_launcher` / `ic_launcher_round` PNGs (`res/o-.png`, `res/Gc.png`) are declared **xxxhdpi** (logical 192px) in `resources.arsc`, but were rewritten at **432px**. Launchers selecting the legacy fallback (Android < 8, OEM classic mode) scaled them ~2.25×.
- **B. Round misclassified as square.** `res/Gc.png` (the `ic_launcher_round` fallback) does not contain the substring `"round"`, so `contains("round")` missed it → square instead of circle.
- **C. Foreground full-bleed.** `createAdaptiveForegroundIcon` was changed to delegate to `scaleBitmapToPng` (full-bleed). The correct adaptive foreground centers content at the 66/108 safe zone (~61%) with transparent padding, matching the reference host app (foreground content bbox `(84,84,348,348)` in 432 = 61.1%); cropping launchers then fill the visible area.

## Changes

- `ArscRebuilder.kt` — each discovered icon now carries an `IconKind` (`ROUND` / `SQUARE` / `FOREGROUND`) derived from the ARSC key index, exposed via `getLastDiscoveredIconKinds()`. Dispatch no longer relies on mangled-name substrings.
- `ApkBuilder.kt` — export loop renders by `IconKind`: `FOREGROUND` → `createAdaptiveForegroundIcon(432)` (66/108 safe zone), `ROUND` → `createRoundIcon(192)`, `SQUARE` → `scaleBitmapToPng(192)`. Legacy fallbacks use 192px to match their xxxhdpi declaration.
- `ApkTemplate.kt` — `createAdaptiveForegroundIcon` restored: content centered at 66/108 safe zone (~61%), aspect-preserving, transparent padding; matches the host app reference.

| resource | render |
|---|---|
| `ic_launcher_foreground` (adaptive) | 432px, content ~61% centered, transparent padding |
| `mipmap/ic_launcher` legacy PNG | 192px full-bleed square |
| `mipmap/ic_launcher_round` legacy PNG | 192px circular mask |
| adaptive XML (`BW.xml` / `0K.xml`) | copied unchanged |

## Verification

- `:app:compileDebugKotlin` passes.
- `CapabilityPlannerTest`, `FeaturePackMergerTest`, `FeaturePackPathGuardTest`, `ApkBuildCacheTest`, `ApkArtifactVerifierTest`, `ApkConfigWiringGuardTest` pass.
- Foreground content ratio verified at 61.1%, matching the host app reference.

## Issue

Fixes #259