### PR TITLE
fix(icon): render adaptive foreground full-bleed (no safe-zone padding)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -104,30 +104,7 @@ class ApkTemplate(private val context: Context) {
     }
 
     fun createAdaptiveForegroundIcon(bitmap: Bitmap, size: Int): ByteArray {
-        val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-        val canvas = android.graphics.Canvas(output)
-
-        val safeZone = (size * 66f / 108f).toInt()
-        val scale = minOf(safeZone.toFloat() / bitmap.width, safeZone.toFloat() / bitmap.height)
-        val scaledW = (bitmap.width * scale).toInt()
-        val scaledH = (bitmap.height * scale).toInt()
-        val left = ((size - scaledW) / 2f)
-        val top = ((size - scaledH) / 2f)
-
-        val scaled = Bitmap.createScaledBitmap(bitmap, scaledW, scaledH, true)
-        val paint = android.graphics.Paint().apply {
-            isAntiAlias = true
-            isFilterBitmap = true
-        }
-        canvas.drawBitmap(scaled, left, top, paint)
-
-        val baos = ByteArrayOutputStream()
-        output.compress(Bitmap.CompressFormat.PNG, 100, baos)
-
-        if (scaled != bitmap) scaled.recycle()
-        output.recycle()
-
-        return baos.toByteArray()
+        return scaleBitmapToPng(bitmap, size)
     }
 
     fun createRoundIcon(bitmap: Bitmap, size: Int): ByteArray {


### PR DESCRIPTION
## What & why

After #260, exported icons render **undersized** again. #260 correctly fixed the legacy fallback size (192px) and round/square dispatch (ARSC `IconKind`), but it also re-added the 66/108 safe-zone padding to `createAdaptiveForegroundIcon`, which was the mistake.

That padding only fits foreground art that is **already centered logo design** (the host app's own icon — content bbox `(84,84,348,348)` in 432 = 61%). **User-supplied icons are full-bleed square images** (verified against the provided reference images: ~90–92% content coverage edge-to-edge). Applying 66/108 padding to a full-bleed image shrinks the visible content to 61% with transparent surround → undersized icon.

## Change

`createAdaptiveForegroundIcon` renders full-bleed again (delegates to `scaleBitmapToPng`). The launcher crops to circle/squircle and the content fills the visible area; the transparent adaptive background (`f2242261`) still prevents dark fringe on cropping launchers.

This finalizes the three independent corrections:

| aspect | value |
|---|---|
| adaptive foreground | **432px full-bleed** (this PR — reverts the #260 padding mistake) |
| legacy `ic_launcher` PNG | 192px full-bleed square (#260) |
| legacy `ic_launcher_round` PNG | 192px circular mask (#260) |
| round/square/foreground dispatch | ARSC `IconKind` semantics (#260) |

## Verification

- `:app:compileDebugKotlin` + `ApkArtifactVerifierTest` / `ApkBuildCacheTest` pass.
- Simulated both reference images: foreground now 100% full-bleed (was 61%), legacy 192px, round corners transparent (circular).

## Issue

Fixes #261