### PR TITLE
fix(shell): dispatch visibilitychange and keep JS timers alive for web notifications

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -70,6 +70,7 @@ class ShellActivity : AppCompatActivity() {
     private val forcedRunManager by lazy { ForcedRunManager.getInstance(this) }
 
     private var pendingFloatingWindowLaunch = false
+    private var notificationPolyfillEnabled = false
 
     private var webViewStateBundle: Bundle? = null
     private var shellConfig: com.webtoapp.core.shell.ShellConfig? = null
@@ -311,6 +312,7 @@ class ShellActivity : AppCompatActivity() {
 
         com.webtoapp.core.shell.ShellLogger.i("ShellActivity", "配置加载成功: ${config.appName}")
         shellConfig = config
+        notificationPolyfillEnabled = config.webViewConfig.enableNotificationPolyfill
         AppLogger.d("ShellActivity", "WebView UA config from shell: userAgentMode=${config.webViewConfig.userAgentMode}, customUserAgent=${config.webViewConfig.customUserAgent}, userAgent=${config.webViewConfig.userAgent}")
         clearBrowsingDataOnLaunch = config.webViewConfig.clearBrowsingDataOnLaunch
         if (clearBrowsingDataOnLaunch) {
@@ -806,16 +808,44 @@ class ShellActivity : AppCompatActivity() {
         browserSurface?.onResume() ?: webView?.onResume()
 
         browserSurface?.resumeTimers() ?: webView?.resumeTimers()
+        dispatchVisibilityEvent(visible = true)
         com.webtoapp.core.shell.ShellLogger.logLifecycle("ShellActivity", "onResume - WebView resumed, timers resumed")
     }
 
     override fun onPause() {
         super.onPause()
 
-        browserSurface?.onPause() ?: webView?.onPause()
+        dispatchVisibilityEvent(visible = false)
+
+        if (notificationPolyfillEnabled && browserSurface == null) {
+            // Keep JavaScript timers running so background web notifications can fire.
+            // Only applies to system WebView (NativeBridge is unavailable in GeckoView).
+            // The foreground service keeps the process alive.
+            com.webtoapp.core.shell.ShellLogger.logLifecycle("ShellActivity", "onPause - notification polyfill active, keeping JS timers alive")
+        } else {
+            browserSurface?.onPause() ?: webView?.onPause()
+        }
 
         android.webkit.CookieManager.getInstance().flush()
         com.webtoapp.core.shell.ShellLogger.logLifecycle("ShellActivity", "onPause - WebView paused, cookies flushed")
+    }
+
+    /**
+     * Explicitly dispatch a visibilitychange event to the WebView page so that
+     * document.hidden / document.visibilityState reflect the real Activity state.
+     * Android WebView does not reliably do this across all OEM ROMs and versions.
+     */
+    private fun dispatchVisibilityEvent(visible: Boolean) {
+        val js = if (visible) {
+            """(function(){try{Object.defineProperty(document,'visibilityState',{get:function(){return 'visible';},configurable:true});Object.defineProperty(document,'hidden',{get:function(){return false;},configurable:true});document.dispatchEvent(new Event('visibilitychange'));}catch(e){}})();"""
+        } else {
+            """(function(){try{Object.defineProperty(document,'visibilityState',{get:function(){return 'hidden';},configurable:true});Object.defineProperty(document,'hidden',{get:function(){return true;},configurable:true});document.dispatchEvent(new Event('visibilitychange'));}catch(e){}})();"""
+        }
+        try {
+            webView?.evaluateJavascript(js, null)
+        } catch (e: Exception) {
+            AppLogger.w("ShellActivity", "Failed to dispatch visibility event", e)
+        }
     }
 
     override fun onTrimMemory(level: Int) {


### PR DESCRIPTION
## Summary

Packaged HTML apps with the Web Notification polyfill enabled never produced system notifications, even when all notification permissions were granted. This fixes two root causes in `ShellActivity` lifecycle handling.

Fixes #270

## Root Cause

1. **`document.hidden` stuck `false`**: The shell never dispatched `visibilitychange` events to the WebView page when the Activity entered background. Many WebView implementations (especially OEM ROMs) do not reliably set `document.visibilityState` on `WebView.onPause()`. Pages that gate notifications behind `if (!document.hidden) return;` (standard browser pattern) never proceeded.

2. **Background timer throttling**: `ShellActivity.onPause()` called `webView.onPause()`, which lets Chromium throttle `setTimeout`/`setInterval` to fire at most once per minute (or freeze entirely on aggressive OEMs). Reply-generation timers never fired while backgrounded.

The combination made notifications impossible in every state:
- **Foreground**: timer fires, but `document.hidden === false` → page suppresses notification
- **Background**: timers throttled/frozen → reply never generated → no notification
- **Return to foreground**: timers fire, but `document.hidden === false` again → suppressed

## Changes

- **`dispatchVisibilityEvent(visible: Boolean)`** — new helper in `ShellActivity` that injects JS to set `document.visibilityState` / `document.hidden` via `Object.defineProperty` and dispatch the `visibilitychange` event. Called from `onPause()` (`visible=false`) and `onResume()` (`visible=true`).
- **Skip `webView.onPause()` when notification polyfill is active** — when `enableNotificationPolyfill` is enabled and the app uses the system WebView (not GeckoView), `onPause()` no longer pauses the WebView, so background JavaScript timers keep running. The foreground service keeps the process alive.

## Verification

```bash
./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache   # BUILD SUCCESSFUL
./gradlew :shell:compileReleaseKotlin --no-configuration-cache --rerun-tasks      # BUILD SUCCESSFUL (synced source)
```

The fix is authored in `app/` and synced to `shell/` via `syncShellRuntimeSources` (both `ShellActivity` copies compiled clean).

## Test Plan

- [ ] Create an HTML app that calls `new Notification(title, {body})` gated by `document.hidden`
- [ ] Enable NativeBridge + Notification API bridge in export settings
- [ ] Export and install the APK
- [ ] Send a message and press Home before the reply delay elapses
- [ ] Verify a system notification appears after the reply delay
- [ ] Verify `document.hidden` is `true` while backgrounded (check via page logic)
- [ ] Verify normal apps without notification polyfill still pause WebView correctly on background