### PR TITLE
fix(webview): unlock audio session on first gesture for async playback

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/AudioUnlockInjector.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/AudioUnlockInjector.kt
@@ -1,0 +1,75 @@
+package com.webtoapp.core.webview
+
+import android.webkit.WebView
+
+/**
+ * Unlocks the WebView audio session for apps that play audio *asynchronously* after a user gesture,
+ * such as AI voice-chat apps (Grok / ChatGPT / Gemini voice mode).
+ *
+ * Problem: when [WebSettings.mediaPlaybackRequiresUserGesture] is true (the default, since
+ * `mediaAutoplayEnabled` defaults to false), `audio.play()` is silently rejected unless it runs in
+ * the synchronous call stack of a user gesture. Voice-chat apps receive the streamed audio from the
+ * server *after* the gesture window has closed, so playback is dropped — even though the user
+ * clearly intended to hear it.
+ *
+ * Fix: on the first real user gesture (pointerdown / keydown), synchronously "warm up" both audio
+ * paths (Web Audio + HTMLAudioElement) with a near-silent buffer. That lifts the gesture gate for
+ * the rest of the session, so later async `play()` calls succeed. This is the standard workaround
+ * for autoplay-restricted voice-chat scenarios and does not bypass the policy for non-interactive
+ * media: it still requires a genuine user gesture to fire.
+ *
+ * Shell-synced: injected unconditionally from [WebViewManager.onPageStarted], so it takes effect in
+ * both host preview and exported APKs without any config field.
+ */
+object AudioUnlockInjector {
+
+    internal const val UNLOCK_JS = """
+        (function() {
+            'use strict';
+            if (window.__wta_audio_unlocked__) return;
+            window.__wta_audio_unlocked__ = true;
+
+            // 0.1s of silence, 8-bit mono PCM @ 8kHz, Base64. Tiny but valid so <audio>.play()
+            // counts as real media playback and lifts the gesture gate for the session.
+            var SILENCE_WAV = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+
+            function unlock() {
+                try {
+                    var AudioCtx = window.AudioContext || window.webkitAudioContext;
+                    if (AudioCtx) {
+                        var ctx = new AudioCtx();
+                        var osc = ctx.createOscillator();
+                        var gain = ctx.createGain();
+                        gain.gain.value = 0;
+                        osc.connect(gain);
+                        gain.connect(ctx.destination);
+                        osc.start();
+                        osc.stop(ctx.currentTime + 0.001);
+                        if (ctx.state === 'suspended') { ctx.resume(); }
+                    }
+                } catch (e) {}
+                try {
+                    var a = new Audio(SILENCE_WAV);
+                    a.muted = false;
+                    a.volume = 0.0001;
+                    var p = a.play();
+                    if (p && typeof p.then === 'function') { p.catch(function () {}); }
+                } catch (e) {}
+                try {
+                    window.removeEventListener('pointerdown', unlock, true);
+                    window.removeEventListener('keydown', unlock, true);
+                } catch (e) {}
+            }
+
+            try {
+                window.addEventListener('pointerdown', unlock, true);
+                window.addEventListener('keydown', unlock, true);
+            } catch (e) {}
+        })();
+    """
+
+    /** Injects the unlock bridge into [webView]. Safe to call on every page load (re-entrant). */
+    fun inject(webView: WebView) {
+        webView.evaluateJavascript(UNLOCK_JS, null)
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1930,6 +1930,11 @@ class WebViewManager(
                     view?.evaluateJavascript(CLIPBOARD_POLYFILL_JS, null)
                 }
 
+                // Warm up the audio session on the first user gesture so async audio (e.g. AI
+                // voice-chat responses that arrive after the gesture window) can play even when
+                // mediaPlaybackRequiresUserGesture is true. See AudioUnlockInjector / issue #268.
+                view?.let { AudioUnlockInjector.inject(it) }
+
                 if (config.enableNotificationPolyfill) {
                     view?.let { injectNotificationPolyfill(it) }
                 }

--- a/app/src/test/java/com/webtoapp/core/webview/AudioUnlockInjectorTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/AudioUnlockInjectorTest.kt
@@ -1,0 +1,76 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Guards the contract of [AudioUnlockInjector.UNLOCK_JS] — the script must unlock both Web Audio and
+ * HTMLAudioElement playback paths inside a real user-gesture handler, without bypassing the gesture
+ * requirement (i.e. it must never call `play()` at the top level of the injected script).
+ *
+ * See issue #268: AI voice-chat apps play audio asynchronously after the gesture window closes, so
+ * the unlock bridge warms up the audio session on the first genuine interaction.
+ */
+class AudioUnlockInjectorTest {
+
+    private val script = AudioUnlockInjector.UNLOCK_JS
+
+    @Test
+    fun `script is guarded against re-injection`() {
+        assertThat(script).contains("__wta_audio_unlocked__")
+        // Early-return on re-entry must come before any listener registration.
+        val guardIdx = script.indexOf("__wta_audio_unlocked__")
+        val addListenerIdx = script.indexOf("addEventListener('pointerdown'")
+        assertThat(addListenerIdx).isGreaterThan(0)
+        assertThat(guardIdx).isLessThan(addListenerIdx)
+    }
+
+    @Test
+    fun `script listens for real user gestures only`() {
+        // Must hook a genuine gesture (not e.g. load/custom events), in capture phase so it fires
+        // before the page's own handlers can stop propagation.
+        assertThat(script).contains("addEventListener('pointerdown'")
+        assertThat(script).contains("addEventListener('keydown'")
+        assertThat(script).contains(", true)")
+    }
+
+    @Test
+    fun `script warms up Web Audio path`() {
+        assertThat(script).contains("AudioContext")
+        assertThat(script).contains("webkitAudioContext")
+        assertThat(script).contains("createOscillator")
+        assertThat(script).contains("createGain")
+    }
+
+    @Test
+    fun `script warms up HTMLAudioElement path with a valid silent media source`() {
+        // <audio>.play() needs a real media resource to count as playback; a silent WAV data URL
+        // is the smallest valid payload.
+        assertThat(script).contains("new Audio(")
+        assertThat(script).contains("data:audio/wav;base64,")
+    }
+
+    @Test
+    fun `script never calls play at top level - only inside the gesture handler`() {
+        // The unlock must run inside a user gesture, never automatically on load. Match the real
+        // invocation `a.play()` (the assigned Audio element), which only exists inside the handler
+        // body — not the `<audio>.play()` mention in the leading comment.
+        val realCallIdx = script.indexOf("a.play()")
+        assertThat(realCallIdx).isGreaterThan(0)
+        val handlerBodyIdx = script.indexOf("function unlock()")
+        assertThat(handlerBodyIdx).isGreaterThan(0)
+        assertThat(realCallIdx).isGreaterThan(handlerBodyIdx)
+    }
+
+    @Test
+    fun `script removes its listeners after unlocking to avoid repeated work`() {
+        assertThat(script).contains("removeEventListener('pointerdown'")
+        assertThat(script).contains("removeEventListener('keydown'")
+    }
+
+    @Test
+    fun `script is an IIFE with strict mode`() {
+        assertThat(script.trimStart().startsWith("(function()")).isTrue()
+        assertThat(script).contains("'use strict'")
+    }
+}


### PR DESCRIPTION
## What

Fixes #268 — AI voice-chat web apps (Grok / ChatGPT / Gemini) packaged via WebToApp produce no audio output, even though the microphone works fine and the same site plays audio in a regular browser.

## Root cause

Generated apps default to `mediaPlaybackRequiresUserGesture = true` (the "Media Autoplay" toggle is off by default; `WebApp.kt` → `WebViewManager.kt:1370`). When a user taps the mic in a voice-chat app, the page:

1. captures input via `getUserMedia` (works — it goes through the permission flow, no gesture needed), then
2. receives the streamed audio response from the server and calls `audio.play()` **asynchronously**.

By the time step 2 runs, the call has left the "user gesture" window Android WebView requires, so playback is **silently dropped**. This exactly matches the asymmetry the reporter saw: mic works, output does not, regular browser is fine.

## Fix

Inject a small "audio session unlock" bridge from `WebViewManager.onPageStarted`. On the **first genuine user gesture** (`pointerdown` / `keydown`, capture phase), it synchronously warms up both playback paths inside the gesture call stack:

- **Web Audio:** an `AudioContext` + near-silent oscillator (gain = 0)
- **HTMLAudioElement:** `new Audio(silentWavDataUrl).play()`

Lifting these in a real gesture removes the gesture gate for the rest of the session, so later async `play()` calls succeed. This is the standard workaround for autoplay-restricted voice-chat scenarios (same idea widely used on iOS Safari and Android WebView).

It does **not** bypass the autoplay policy for non-interactive media — a real gesture is still required — and it leaves the default `mediaAutoplayEnabled` / `mediaPlaybackRequiresUserGesture` behavior for ordinary pages unchanged.

Because `AudioUnlockInjector` and `WebViewManager` are both shell-synced classes and the injection needs no config field, the fix takes effect in **both host preview and exported APKs** without touching the export pipeline or shell template.

## Changes

| File | Change |
|------|--------|
| `core/webview/AudioUnlockInjector.kt` (new) | `object` with the unlock JS + `inject(webView)`. Re-entrant guard, gesture-only, self-removing listeners. |
| `core/webview/WebViewManager.kt` | One line in `onPageStarted` to call `AudioUnlockInjector.inject`. |
| `test/.../AudioUnlockInjectorTest.kt` (new) | 7 tests guarding the script contract (re-entrant guard, gesture-only listeners, both audio paths warmed, `play()` only inside handler, self-cleanup, IIFE + strict mode). |

## Verification

- [x] `:app:compileDebugKotlin -x syncCloneHostDex` — OK
- [x] `:app:testDebugUnitTest --tests AudioUnlockInjectorTest` — 7/7 pass
- [x] Related: `WebViewConfigBooleanCoverageTest`, `WebViewManagerUserAgentAndPolyfillTest` — pass
- [x] `:app:checkConfigFieldDrift` — OK (`payload=426 shell=456 allowlist=48 shared=418`); no config field added or changed
- No shell membership / export / packaging change → no template rebuild needed

## Related issues found while investigating (not addressed here, worth separate follow-ups)

1. **`speechSynthesis` no-op stub** (`BrowserDisguiseJsGenerator.kt:278-295`): only installs when the WebView genuinely lacks native TTS, so unlikely to be the cause for Grok (which uses streaming `Audio`, not Web Speech), but it does silently break `chrome.tts` / TTS code snippets in those environments.
2. **`mediaAutoplayScope` misleading semantics**: `VIDEO_ONLY` actually blocks audio too, because `WebSettings.mediaPlaybackRequiresUserGesture` is binary and cannot distinguish media types. The UI copy should clarify this.
3. **No `AudioManager` / audio-focus management** anywhere in the WebView layer — a gap for pure voice-call scenarios (speaker routing, focus handling), but adding it affects system-level behavior and should be evaluated separately.

Happy to open follow-up issues for any of these on request.

## Workaround for affected users (today)

In the editor → app settings → **Browser engine & webview** → enable **Media Autoplay** → scope **Audio Only** (or **Video & Audio**) → rebuild. Voice output then works without this fix.

Closes #268.