### PR TITLE
fix(aab): skip plaintext res XML instead of crashing assembler

### DIFF
--- a/app/src/main/java/com/webtoapp/core/playstore/aab/ApkToAabAssembler.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/ApkToAabAssembler.kt
@@ -17,6 +17,19 @@ class ApkToAabAssembler {
 
     companion object {
         private const val TAG = "ApkToAabAssembler"
+
+        /**
+         * Binary AXML starts with the chunk header magic `03 00` (type RES_XML_TYPE = 0x0003,
+         * little-endian). Plain-text XML — notably the AGP resource-shrinker's `tools:keep` /
+         * `tools:discard` marker, which is left uncompiled under `res/` — starts with `<?xml`
+         * (`3c 3f 78 6d`). Returns true for the latter so the caller can skip it instead of
+         * handing it to the binary AXML parser. See issue #272.
+         */
+        internal fun isPlaintextXml(data: ByteArray): Boolean {
+            if (data.size < 2) return false
+            // 0x3c = '<'. Binary AXML's first byte is 0x03, so this cleanly separates the two.
+            return data[0] == 0x3c.toByte()
+        }
     }
 
     fun assemble(
@@ -30,6 +43,7 @@ class ApkToAabAssembler {
         var manifestEntries = 0
         var resourceXmlConverted = 0
         var resourceXmlSkipped = 0
+        var resourceXmlPlainTextSkipped = 0
         var resourceVerbatim = 0
         var dexCount = 0
         var assetCount = 0
@@ -104,8 +118,23 @@ class ApkToAabAssembler {
                                 continue
                             }
 
+                            val xmlBytes = zip.getInputStream(entry).readBytes()
+
+                            // Some res/*.xml entries are plain-text source XML, not compiled
+                            // binary AXML. The canonical case is the resource-shrinker's
+                            // tools:keep / tools:discard marker document emitted by AGP (often
+                            // alongside Firebase), which AGP deliberately leaves uncompiled in
+                            // release APKs. Such files are build-time metadata with no runtime
+                            // semantics and are not needed by Google Play, so we drop them
+                            // instead of feeding them to the binary AXML parser (which would
+                            // throw "Not an AXML file"). See issue #272.
+                            if (isPlaintextXml(xmlBytes)) {
+                                AppLogger.d(TAG, "Skipping plaintext res XML: $name")
+                                resourceXmlPlainTextSkipped++
+                                continue
+                            }
+
                             try {
-                                val xmlBytes = zip.getInputStream(entry).readBytes()
                                 val proto = AxmlToProtoXml.convert(xmlBytes)
                                 writeEntry(out, "base/$name", proto.toByteArray())
                                 resourceXmlConverted++
@@ -182,6 +211,7 @@ class ApkToAabAssembler {
             manifestConverted = manifestEntries,
             resourceXmlConverted = resourceXmlConverted,
             resourceXmlSkipped = resourceXmlSkipped,
+            resourceXmlPlainTextSkipped = resourceXmlPlainTextSkipped,
             resourceVerbatimCopied = resourceVerbatim,
             assetCount = assetCount,
             nativeLibCount = nativeLibCount,
@@ -222,6 +252,7 @@ class ApkToAabAssembler {
         val manifestConverted: Int,
         val resourceXmlConverted: Int,
         val resourceXmlSkipped: Int,
+        val resourceXmlPlainTextSkipped: Int = 0,
         val resourceVerbatimCopied: Int,
         val assetCount: Int,
         val nativeLibCount: Int,
@@ -236,6 +267,7 @@ class ApkToAabAssembler {
             append(", manifest=$manifestConverted")
             append(", resXml=$resourceXmlConverted")
             if (resourceXmlSkipped > 0) append(", resXmlFail=$resourceXmlSkipped")
+            if (resourceXmlPlainTextSkipped > 0) append(", resXmlText=$resourceXmlPlainTextSkipped")
             append(", resBin=$resourceVerbatimCopied")
             append(", assets=$assetCount")
             append(", nativeLibs=$nativeLibCount(${abis.joinToString(",")})")

--- a/app/src/test/java/com/webtoapp/core/playstore/aab/ApkToAabAssemblerPlaintextXmlTest.kt
+++ b/app/src/test/java/com/webtoapp/core/playstore/aab/ApkToAabAssemblerPlaintextXmlTest.kt
@@ -1,0 +1,46 @@
+package com.webtoapp.core.playstore.aab
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Regression guard for issue #272: the AAB assembler must recognize plain-text res XML files (the
+ * AGP resource-shrinker's `tools:keep` / `tools:discard` marker, left uncompiled under `res/`) and
+ * skip them instead of handing them to the binary AXML parser, which throws `Not an AXML file`.
+ *
+ * These tests lock the format-detection contract independently of the real shell template (whose
+ * contents shift over time and which CI may not have built).
+ */
+class ApkToAabAssemblerPlaintextXmlTest {
+
+    @Test
+    fun `detects tools keep marker as plaintext`() {
+        // Exact content of res/qF.xml from the shell template (Firebase / AGP shrinker output).
+        val keepXml = (
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<resources xmlns:tools=\"http://schemas.android.com/tools\" " +
+                "tools:keep=\"@string/google_app_id,@string/gcm_defaultSenderId\" />"
+        ).toByteArray(Charsets.UTF_8)
+
+        assertThat(ApkToAabAssembler.isPlaintextXml(keepXml)).isTrue()
+    }
+
+    @Test
+    fun `detects generic plaintext xml by leading angle bracket`() {
+        val plain = "<root/>".toByteArray()
+        assertThat(ApkToAabAssembler.isPlaintextXml(plain)).isTrue()
+    }
+
+    @Test
+    fun `binary AXML is not flagged as plaintext`() {
+        // Binary AXML chunk header: type=0x0003 (RES_XML_TYPE), headerSize=0x0008, little-endian.
+        val binaryAxml = byteArrayOf(0x03, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00)
+        assertThat(ApkToAabAssembler.isPlaintextXml(binaryAxml)).isFalse()
+    }
+
+    @Test
+    fun `empty or too-short input is not flagged`() {
+        assertThat(ApkToAabAssembler.isPlaintextXml(byteArrayOf())).isFalse()
+        assertThat(ApkToAabAssembler.isPlaintextXml(byteArrayOf(0x3c))).isFalse()
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/playstore/aab/ApkToAabAssemblerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/playstore/aab/ApkToAabAssemblerTest.kt
@@ -31,12 +31,20 @@ class ApkToAabAssemblerTest {
         assertThat(stats.resourceXmlSkipped).isEqualTo(0)
         assertThat(stats.resourceXmlConverted).isGreaterThan(50)
         assertThat(stats.dexCount).isAtLeast(1)
+
+        // Regression for issue #272: the template ships a plain-text res/*.xml (the AGP
+        // resource-shrinker's tools:keep marker, emitted alongside Firebase). It must be
+        // skipped, not fed to the binary AXML parser.
+        assertThat(stats.resourceXmlPlainTextSkipped).isAtLeast(1)
         assertThat(stats.nativeLibCount).isGreaterThan(0)
         assertThat(stats.abis).isNotEmpty()
 
         val entryNames = ZipFile(output).use { zip ->
             zip.entries().toList().map { it.name }.toSet()
         }
+        // The plain-text tools:keep file (res/qF.xml in the template) must NOT appear as a
+        // base/res/ proto entry in the AAB.
+        assertThat(entryNames).doesNotContain("base/res/qF.xml")
         assertThat(entryNames).contains("BundleConfig.pb")
         assertThat(entryNames).contains("base/manifest/AndroidManifest.xml")
         assertThat(entryNames).contains("base/resources.pb")


### PR DESCRIPTION
## What

Fixes #272 — AAB export fails with `Failed to assemble AAB: Cannot convert res/qF.xml: Not an AXML file (magic = 0x3f3c)`, blocking **every** Play Store bundle export from the current template.

## Root cause

`res/qF.xml` in the shell template is **plain-text XML**, not binary AXML:

```xml
<?xml version="1.0" encoding="utf-8"?>
<resources xmlns:tools="http://schemas.android.com/tools"
    tools:keep="@string/google_app_id,@string/gcm_defaultSenderId,@string/google_api_key,..." />
```

This is the **AGP resource-shrinker's `tools:keep` marker document** (emitted alongside the Firebase / Google Services plugin). AGP deliberately leaves it **uncompiled** under `res/` even in a release APK — it is build-time metadata for the shrinker itself, not a runtime resource. After shrinking it gets the short remapped name `qF` (resource shrinking is on for `:shell`, code obfuscation is off via `-dontobfuscate`).

`ApkToAabAssembler` assumed every `res/*.xml` is binary AXML (magic `03 00`) and handed each one straight to `AxmlToProtoXml.convert` → `AxmlReader`, which rejects anything not starting with `0x0003`:

```
Not an AXML file (magic = 0x3f3c)   ← '<?' little-endian
```

This is a regression that landed when the shell template picked up Firebase dependencies. The existing `ApkToAabAssemblerTest` exercises the real template, so the bug is also a test gap — the test would have thrown before reaching its assertions.

## Fix

Detect plain-text XML in the assembler by its leading byte (`0x3c` = `'<'`; binary AXML starts with `0x03`, so the two never overlap) and **skip** it. Rationale for skipping rather than converting:

- `tools:keep` / `tools:discard` carry **no runtime semantics** — they instruct the shrinker, nothing reads them at runtime or on Play.
- They are not needed by `bundletool` / Play validation; dropping them is safe and matches what `bundletool` tolerates.
- This class of artifact will recur for any release-built APK the converter touches (it's AGP-produced, not something our builder writes), so handling it at the consumer side is more robust than patching the template.

The count is exposed via a new `AssembleStats.resourceXmlPlainTextSkipped` field for observability.

## Changes

| File | Change |
|------|--------|
| `core/playstore/aab/ApkToAabAssembler.kt` | Sniff first byte before `AxmlToProtoXml.convert`; skip + count plain-text entries. New `isPlaintextXml` helper (companion, `internal` for tests). New stat field. |
| `test/.../ApkToAabAssemblerTest.kt` | Regression assertion: real template's `qF.xml` is skipped, `base/res/qF.xml` absent from AAB. |
| `test/.../ApkToAabAssemblerPlaintextXmlTest.kt` (new) | 4 isolated tests for the format check (real `tools:keep` payload, generic `<root/>`, binary AXML header, empty/truncated input) — locks the contract without depending on template contents. |

## Verification

- [x] `:app:testDebugUnitTest --tests ApkToAabAssemblerTest --tests ApkToAabAssemblerPlaintextXmlTest` — 6/6 pass (real template assemble runs, `skipped=0`; `qF.xml` correctly dropped)
- [x] `:app:checkConfigFieldDrift` — OK (no config field touched)
- No shell membership / export packaging change → no template rebuild needed

Closes #272.
