### PR TITLE
fix(disguise): drop no-op speechSynthesis stub that silenced TTS

### DIFF
--- a/app/src/main/java/com/webtoapp/core/appearance/BrowserDisguiseJsGenerator.kt
+++ b/app/src/main/java/com/webtoapp/core/appearance/BrowserDisguiseJsGenerator.kt
@@ -275,24 +275,13 @@ if(navigator.storage&&navigator.storage.estimate){
 }
 }catch(e){}
 
-// ── window.speechSynthesis (语音合成 stub) ──
-try{
-if(!window.speechSynthesis){
-    window.speechSynthesis={
-        pending:false,speaking:false,paused:false,
-        onvoiceschanged:null,
-        getVoices:_mn(function(){return[
-            {default:true,lang:'en-US',localService:true,name:'Google US English',voiceURI:'Google US English'},
-            {default:false,lang:'en-GB',localService:true,name:'Google UK English Female',voiceURI:'Google UK English Female'},
-            {default:false,lang:'de-DE',localService:true,name:'Google Deutsch',voiceURI:'Google Deutsch'},
-            {default:false,lang:'fr-FR',localService:true,name:'Google français',voiceURI:'Google français'},
-            {default:false,lang:'ja-JP',localService:true,name:'Google 日本語',voiceURI:'Google 日本語'}
-        ]}),
-        speak:_mn(function(){}),cancel:_mn(function(){}),pause:_mn(function(){}),resume:_mn(function(){}),
-        addEventListener:_mn(function(){}),removeEventListener:_mn(function(){})
-    };
-}
-}catch(e){}
+// window.speechSynthesis is intentionally NOT stubbed. A previous no-op stub installed a
+// fake API (getVoices returned a hard-coded list, speak/cancel/pause/resume were empty) on
+// WebViews that lack native TTS. But every consumer in this codebase guards with
+// `typeof speechSynthesis !== 'undefined'` (ChromeExtensionPolyfill chrome.tts, the
+// 'Text to speech' code snippet), so the stub turned the safe "not available" path into a
+// silent failure: the guard passed, speak() did nothing, and the user heard nothing.
+// Removing it restores correct graceful-degradation behavior. See issue #268 investigation.
 
 // ── window.isSecureContext ──
 try{Object.defineProperty(window,'isSecureContext',{get:_mn(function(){return true}),enumerable:true,configurable:true});}catch(e){}


### PR DESCRIPTION
## What

Removes the fake `window.speechSynthesis` stub injected by the Browser Disguise script. Found while investigating #268 (AI voice apps producing no audio).

## Root cause

`BrowserDisguiseJsGenerator` installed a no-op `speechSynthesis` polyfill on WebViews that lack native TTS:

```js
if (!window.speechSynthesis) {
    window.speechSynthesis = {
        ...
        getVoices: _mn(function(){ return [ /* hard-coded fake Google voices */ ] }),
        speak: _mn(function(){}),   // ← no-op
        cancel: _mn(function(){}),
        ...
    };
}
```

Every consumer in the codebase guards TTS use with a presence check:

| Consumer | Guard |
|----------|-------|
| `chrome.tts` polyfill (`ChromeExtensionPolyfill.kt:1442+`) | `if (typeof speechSynthesis !== 'undefined')` |
| "Text to speech" code snippet (`CodeSnippets.kt:2256`) | `if ('speechSynthesis' in window)` |

So on a WebView without native TTS:

- **Before this stub existed:** the guard sees `undefined` → consumer takes the safe "not available" path → graceful degradation (e.g. the snippet no-ops, `chrome.tts` resolves empty).
- **With the stub installed:** the guard sees a *defined* object → consumer calls `.speak(...)` → which is `_mn(function(){})` → **silent failure, no audio, no error**.

The stub also had near-zero disguise value: its guard `if (!window.speechSynthesis)` means it only installs when native TTS is **absent**, so it never hides a real device's voices. The only effect was to make "no TTS" WebViews look like Chrome-with-Google-voices to `getVoices()` — a marginal fingerprint side-effect that is not worth the functional breakage.

## Fix

Delete the stub entirely. Consumers revert to detecting the absent API and degrading gracefully, instead of calling through to empty functions.

## Verification

- [x] `:app:compileDebugKotlin -x syncCloneHostDex` — OK
- No behavior change for WebViews *with* native TTS (the stub never installed there).
- Shell-synced class, so the fix reaches both preview and exported APKs.

No test added: there is no existing test asserting the disguise script's byte content (it is assembled from many template fragments), and the change is a pure deletion of a self-contained block. The compile + the consumer-guard analysis above cover the safety argument.
