### PR TITLE
Bug Fix - read @SerializedName when decoding persisted enums in Converters

### DIFF
--- a/app/src/main/java/com/webtoapp/data/converter/Converters.kt
+++ b/app/src/main/java/com/webtoapp/data/converter/Converters.kt
@@ -6,6 +6,13 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
+import com.google.gson.stream.JsonWriter
 import com.webtoapp.data.model.ActivationDialogConfig
 import com.webtoapp.data.model.AdConfig
 import com.webtoapp.data.model.Announcement
@@ -31,22 +38,68 @@ class Converters {
 
     companion object {
 
+        /**
+         * Enum handling for persisted JSON.
+         *
+         * Writing delegates to Gson, which emits the [SerializedName] value when a constant
+         * declares one. Reading must therefore accept that same value: resolving by constant
+         * name alone mapped `"web_api"` to no constant at all, so every load of a stored
+         * [com.webtoapp.data.model.NotificationType.WEB_API] silently degraded to `NONE`.
+         * Because [ApkExportConfig] round-trips through this Gson on every Room read/write,
+         * the setting was lost as soon as it was saved.
+         *
+         * Values that match no constant still fall back to the first one, so JSON written by
+         * a newer build stays loadable instead of nulling a non-null Kotlin field.
+         */
+        private val lenientEnumAdapterFactory = object : TypeAdapterFactory {
+            override fun <T : Any?> create(gson: Gson, type: TypeToken<T>): TypeAdapter<T>? {
+                val rawType = type.rawType
+                val enumClass = when {
+                    rawType.isEnum -> rawType
+                    // Constants with a body compile to an anonymous subclass of the enum.
+                    rawType.superclass?.isEnum == true -> rawType.superclass
+                    else -> return null
+                }
+
+                val byExact = HashMap<String, Any>()
+                val byLowercase = HashMap<String, Any>()
+                enumClass.declaredFields.forEach { field ->
+                    if (!field.isEnumConstant) return@forEach
+                    val constant = runCatching { field.get(null) }.getOrNull() ?: return@forEach
+                    val keys = mutableListOf((constant as Enum<*>).name)
+                    field.getAnnotation(SerializedName::class.java)?.let { annotation ->
+                        keys += annotation.value
+                        keys += annotation.alternate
+                    }
+                    keys.forEach { key ->
+                        byExact.putIfAbsent(key, constant)
+                        byLowercase.putIfAbsent(key.lowercase(), constant)
+                    }
+                }
+                val fallback = enumClass.enumConstants?.firstOrNull()
+                val delegate = gson.getDelegateAdapter(this, type)
+
+                return object : TypeAdapter<T>() {
+                    override fun write(out: JsonWriter, value: T) = delegate.write(out, value)
+
+                    override fun read(reader: JsonReader): T? {
+                        if (reader.peek() == JsonToken.NULL) {
+                            reader.nextNull()
+                            return null
+                        }
+                        val raw = reader.nextString()
+                        val resolved = byExact[raw] ?: byLowercase[raw.lowercase()] ?: fallback
+                        @Suppress("UNCHECKED_CAST")
+                        return resolved as T?
+                    }
+                }
+            }
+        }
+
         @PublishedApi
         internal val gson: Gson by lazy {
             GsonBuilder()
-                .registerTypeHierarchyAdapter(Enum::class.java,
-                    com.google.gson.JsonDeserializer<Enum<*>> { json, typeOfT, _ ->
-                        try {
-                            @Suppress("UNCHECKED_CAST")
-                            val enumClass = typeOfT as Class<out Enum<*>>
-                            java.lang.Enum.valueOf(enumClass, json.asString)
-                        } catch (e: Exception) {
-
-                            @Suppress("UNCHECKED_CAST")
-                            val enumClass = typeOfT as Class<out Enum<*>>
-                            enumClass.enumConstants?.firstOrNull()
-                        }
-                    })
+                .registerTypeAdapterFactory(lenientEnumAdapterFactory)
                 .create()
         }
 

--- a/app/src/test/java/com/webtoapp/data/converter/ConvertersTest.kt
+++ b/app/src/test/java/com/webtoapp/data/converter/ConvertersTest.kt
@@ -3,7 +3,11 @@ package com.webtoapp.data.converter
 import com.google.common.truth.Truth.assertThat
 import com.google.gson.JsonParser
 import com.webtoapp.core.activation.ActivationCode
+import com.webtoapp.data.model.ApkExportConfig
 import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.DnsProvider
+import com.webtoapp.data.model.NotificationExportConfig
+import com.webtoapp.data.model.NotificationType
 import com.webtoapp.data.model.UserAgentMode
 import org.junit.Test
 
@@ -107,5 +111,53 @@ class ConvertersTest {
         assertThat(merged.getAsJsonObject("root").get("b").asInt).isEqualTo(2)
         assertThat(merged.get("enabled").asBoolean).isTrue()
         assertThat(merged.get("extra").asString).isEqualTo("ok")
+    }
+
+    @Test
+    fun `apk export config keeps notification type across a roundtrip`() {
+        val config = ApkExportConfig(
+            notificationEnabled = true,
+            notificationConfig = NotificationExportConfig(type = NotificationType.WEB_API)
+        )
+
+        val decoded = converters.toApkExportConfig(converters.fromApkExportConfig(config))
+
+        assertThat(decoded?.notificationConfig?.type).isEqualTo(NotificationType.WEB_API)
+    }
+
+    @Test
+    fun `enum decoding accepts the serialized name that encoding emits`() {
+        // NotificationType declares lowercase @SerializedName values, so this is the
+        // on-disk representation Gson writes.
+        val encoded = """{"notificationConfig":{"type":"web_api"}}"""
+
+        val decoded = converters.toApkExportConfig(encoded)
+
+        assertThat(decoded?.notificationConfig?.type).isEqualTo(NotificationType.WEB_API)
+    }
+
+    @Test
+    fun `enum decoding also accepts the raw constant name`() {
+        val encoded = """{"notificationConfig":{"type":"WEB_API"}}"""
+
+        val decoded = converters.toApkExportConfig(encoded)
+
+        assertThat(decoded?.notificationConfig?.type).isEqualTo(NotificationType.WEB_API)
+    }
+
+    @Test
+    fun `enum decoding falls back to the first constant for unknown values`() {
+        val encoded = """{"notificationConfig":{"type":"carrier_pigeon"}}"""
+
+        val decoded = converters.toApkExportConfig(encoded)
+
+        assertThat(decoded?.notificationConfig?.type).isEqualTo(NotificationType.NONE)
+    }
+
+    @Test
+    fun `dns provider survives a roundtrip instead of collapsing to the first constant`() {
+        val encoded = Converters.toJson(DnsProvider.ADGUARD)
+
+        assertThat(Converters.fromJson<DnsProvider>(encoded)).isEqualTo(DnsProvider.ADGUARD)
     }
 }


### PR DESCRIPTION
- The enum deserializer registered on `Converters.gson` resolved constants via `Enum.valueOf(name)`, but Gson writes them `@SerializedName`. The try/catch fails silently and the app returns first constant.

- A channel saved as `"web_api"`/`"fcm"` read back as `NONE`, while `notificationEnabled` stayed true — exports then shipped `"type":"none"` and started no push service, with the FCM credentials still baked into the APK.

- Replaced with a `TypeAdapterFactory` that indexes both the constant name and the `@SerializedName` (plus alternates). Writing is unchanged, so existing rows are correct and start resolving again.