### PR TITLE
polish(ui): bump Wta setting-row titles to Medium weight

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
@@ -388,7 +388,7 @@ fun WtaSettingRow(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
                     color = contentColor,
                     maxLines = titleMaxLines,
                     overflow = TextOverflow.Ellipsis
@@ -511,7 +511,7 @@ fun WtaTextFieldRow(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
             color = MaterialTheme.colorScheme.onSurface
         )
         if (!subtitle.isNullOrBlank()) {
@@ -551,7 +551,7 @@ fun WtaSliderRow(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Column(modifier = Modifier.weight(1f)) {
-                Text(title, style = MaterialTheme.typography.bodyLarge)
+                Text(title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
                 if (!subtitle.isNullOrBlank()) {
                     Text(
                         subtitle,


### PR DESCRIPTION
Closes #279.

## What & why

The title `Text` in `WtaSettingRow`, `WtaTextFieldRow`, and `WtaSliderRow`
(`app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt`) used the plain
`MaterialTheme.typography.bodyLarge` style, which renders at **normal** weight.
On rows that also carry a subtitle or a value/field, the label visually blended
into the surrounding text, leaving the hierarchy flat.

This bumps only the title style to
`bodyLarge.copy(fontWeight = FontWeight.Medium)` so the label reads as the
primary element of each row.

## User-visible effect

Setting-row titles render in Medium weight; subtitles, values, and all layout /
spacing / colors are unchanged. The change is uniform across the three shared
setting-row components used throughout the editor.

## Scope / safety

- Pure UI polish in the host design system.
- **No** config field, shell sync, export pipeline, native bridge, or i18n
  string is touched — the high-sensitivity chains listed in `AGENTS.md` are not
  on this path.
- `FontWeight` was already imported and used elsewhere in the same file; no new
  dependency.
- No new/changed user-facing copy, so the 10-language requirement does not
  apply.

## Verification

- `./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache`
  passes locally.
- Affected rows confirmed by diff: `WtaSettings.kt` lines ~391, ~514, ~554.

```diff
-    style = MaterialTheme.typography.bodyLarge,
+    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
```