### PR TITLE
chore(gitignore): ignore .zcode/ and gradle/gradle-daemon-jvm.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ release/
 build/
 .vscode/
 .claude/
+.zcode/
 local.properties
 gradle/config.properties
+gradle/gradle-daemon-jvm.properties
 rule.md
 CLAUDE.md
 *.iml


### PR DESCRIPTION
Closes #281.

## What & why

A fresh clone with no manual edits shows two untracked paths in `git status`
because they are produced locally by tooling but missing from `.gitignore`:

- `.zcode/` — session directory created by the ZCode CLI.
- `gradle/gradle-daemon-jvm.properties` — emitted by Gradle's
  `updateDaemonJvm` task (file header self-identifies as generated; never
  tracked in history).

That is status noise that obscures real changes and invites accidental
commits. This adds both to `.gitignore`, placed next to the semantically
matching existing entries.

## Change

`.gitignore` only — two lines:

```diff
 .vscode/
 .claude/
+.zcode/
 local.properties
 gradle/config.properties
+gradle/gradle-daemon-jvm.properties
```

## Scope / safety

- `.gitignore` only. No source, build, config-field, shell-sync, export, or
  i18n surface is touched.
- Neither path is currently tracked, so no file is removed from history.