### PR TITLE
fix(icon): remove launcher black border (full-bleed foreground + white background)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -103,25 +103,11 @@ class ApkTemplate(private val context: Context) {
 
     fun createAdaptiveForegroundIcon(bitmap: Bitmap, size: Int): ByteArray {
 
-        val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-        val canvas = android.graphics.Canvas(output)
-
-        val safeZoneSize = (size * 72f / 108f).toInt()
-        val padding = (size - safeZoneSize) / 2
-
-        val scaled = Bitmap.createScaledBitmap(bitmap, safeZoneSize, safeZoneSize, true)
-
-        val paint = android.graphics.Paint().apply {
-            isAntiAlias = true
-            isFilterBitmap = true
-        }
-        canvas.drawBitmap(scaled, padding.toFloat(), padding.toFloat(), paint)
-
+        val scaled = Bitmap.createScaledBitmap(bitmap, size, size, true)
         val baos = ByteArrayOutputStream()
-        output.compress(Bitmap.CompressFormat.PNG, 100, baos)
+        scaled.compress(Bitmap.CompressFormat.PNG, 100, baos)
 
         if (scaled != bitmap) scaled.recycle()
-        output.recycle()
 
         return baos.toByteArray()
     }

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#000000</color>
+    <color name="ic_launcher_background">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
Closes #284.

## What & why

Generated APK launcher icons showed a **thin black border** and the transparent
regions of a user-supplied PNG icon rendered as **solid black**. Two compounding
causes:

1. The adaptive-icon background colour was hard-coded to opaque `#000000`
   (`res/values/ic_launcher_background.xml`). On API 26+ the user PNG is
   composited as the foreground over that background, so transparent pixels
   revealed the black layer. Android's adaptive-icon spec mandates an opaque
   background (a truly transparent `#00000000` renders as black on most
   launchers and is worse), so the colour must change rather than be dropped.
2. `ApkTemplate.createAdaptiveForegroundIcon` inset the user bitmap into the
   72/108 safe zone, leaving a ~16.6% transparent padding — that padding was
   the visible thin black border.

## Changes

- `ApkTemplate.createAdaptiveForegroundIcon` now scales the bitmap to the full
  icon size with **no safe-zone padding**, so no background leaks around the
  artwork. Also fixes a pre-existing side effect where density PNGs (API < 26)
  received the inset foreground and looked smaller than intended.
- `ic_launcher_background`: `#000000` → `#FFFFFF` — the least visually jarring
  opaque fill (Android Studio Image Asset Studio default; matches most Google
  first-party icons). Transparent regions of the user PNG now read as white.

## User-visible effect

- No black border around the generated app's launcher icon.
- Transparent regions of the user icon render as white instead of black.
- OEM launcher mask (circle / squircle / rounded square) is **preserved** — the
  icon does not regress to a square legacy PNG.
- No blur or upscaling; full-bleeding actually makes the artwork slightly
  larger (no safe-zone inset) on API < 26 devices too.

## Scope / safety

- `core/apkbuilder` (icon generation) + one colour resource.
- No config field, shell-sync membership, native lib, export packaging, or i18n
  surface is touched → `checkConfigFieldDrift` unaffected.
- The shell template APK is rebuilt by the existing `syncShellTemplateApk`
  `preBuild` hook on every `:app` build, so the new colour reaches generated APKs
  without any manual template step. (The template APK is `.gitignore`d as
  `*.apk`; it is a build artefact, not a tracked source.)

## Verification

- `./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache` ✅
- `./gradlew :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache` ✅
- `aapt2 dump resources` on the rebuilt template confirms
  `color/ic_launcher_background` is now `#ffffffff` (was `#ff000000`).