### PR TITLE
Revert "fix(icon): remove launcher black border" (#285)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -103,11 +103,25 @@ class ApkTemplate(private val context: Context) {
 
     fun createAdaptiveForegroundIcon(bitmap: Bitmap, size: Int): ByteArray {
 
-        val scaled = Bitmap.createScaledBitmap(bitmap, size, size, true)
+        val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = android.graphics.Canvas(output)
+
+        val safeZoneSize = (size * 72f / 108f).toInt()
+        val padding = (size - safeZoneSize) / 2
+
+        val scaled = Bitmap.createScaledBitmap(bitmap, safeZoneSize, safeZoneSize, true)
+
+        val paint = android.graphics.Paint().apply {
+            isAntiAlias = true
+            isFilterBitmap = true
+        }
+        canvas.drawBitmap(scaled, padding.toFloat(), padding.toFloat(), paint)
+
         val baos = ByteArrayOutputStream()
-        scaled.compress(Bitmap.CompressFormat.PNG, 100, baos)
+        output.compress(Bitmap.CompressFormat.PNG, 100, baos)
 
         if (scaled != bitmap) scaled.recycle()
+        output.recycle()
 
         return baos.toByteArray()
     }

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <color name="ic_launcher_background">#000000</color>
 </resources>


### PR DESCRIPTION
Reverts #285 (commit ff73423a).

The fix in #285 made the generated-app launcher icon **worse** rather than
better on real devices, so it needs to come out of `main` immediately while the
correct approach is reconsidered.

Restores the pre-#285 behaviour exactly:

- `ApkTemplate.createAdaptiveForegroundIcon` goes back to insetting the bitmap
  into the 72/108 safe zone with padding.
- `ic_launcher_background` goes back to `#000000`.

Refs #284 (the original bug stays open for a corrected fix).