### PR TITLE
fix(shell): scrollable multi-web tabs + fullscreen content padding

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -113,6 +113,7 @@ data class ApkConfig(
     val showStatusBarInFullscreen: Boolean get() = webView.showStatusBarInFullscreen
     val showNavigationBarInFullscreen: Boolean get() = webView.showNavigationBarInFullscreen
     val showToolbarInFullscreen: Boolean get() = webView.showToolbarInFullscreen
+    val fullscreenContentPaddingDp: Int get() = webView.fullscreenContentPaddingDp
     val landscapeMode: Boolean get() = webView.landscapeMode
     val orientationMode: String get() = webView.orientationMode
     val injectScripts: List<com.webtoapp.data.model.UserScript> get() = webView.injectScripts
@@ -471,6 +472,7 @@ data class WebViewBlock(
     val showStatusBarInFullscreen: Boolean = false,
     val showNavigationBarInFullscreen: Boolean = false,
     val showToolbarInFullscreen: Boolean = false,
+    val fullscreenContentPaddingDp: Int = 0,
     val landscapeMode: Boolean = false,
     val orientationMode: String = "PORTRAIT",
     val injectScripts: List<com.webtoapp.data.model.UserScript> = emptyList(),

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -175,6 +175,7 @@ internal object ApkConfigJsonFactory {
         "showStatusBarInFullscreen" to webView.showStatusBarInFullscreen,
         "showNavigationBarInFullscreen" to webView.showNavigationBarInFullscreen,
         "showToolbarInFullscreen" to webView.showToolbarInFullscreen,
+        "fullscreenContentPaddingDp" to webView.fullscreenContentPaddingDp,
         "landscapeMode" to webView.landscapeMode,
         "injectScripts" to webView.injectScripts.map { script ->
             linkedMapOf(

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2285,6 +2285,8 @@ object Strings {
     val showStatusBarHint: String get() = StringsC.showStatusBarHint
     val showNavigationBar: String get() = StringsC.showNavigationBar
     val showNavigationBarHint: String get() = StringsC.showNavigationBarHint
+    val fullscreenContentPadding: String get() = StringsC.fullscreenContentPadding
+    val fullscreenContentPaddingHint: String get() = StringsC.fullscreenContentPaddingHint
     val statusBarStyleConfigLabel: String get() = StringsC.statusBarStyleConfigLabel
     val statusBarLightModeLabel: String get() = StringsC.statusBarLightModeLabel
     val statusBarDarkModeLabel: String get() = StringsC.statusBarDarkModeLabel
@@ -33269,6 +33271,32 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Держать нижнюю панель навигации видимой в полноэкранном режиме (Назад, Главная, Недавние)"
         AppLanguage.JAPANESE -> "全画面モードで下部ナビゲーションバーを表示し続ける（戻る、ホーム、最近）"
         AppLanguage.KOREAN -> "전체 화면 모드에서 하단 내비게이션 바를 계속 표시（뒤로, 홈, 최근）"
+    }
+
+    val fullscreenContentPadding: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "内容内边距"
+        AppLanguage.ENGLISH -> "Content Padding"
+        AppLanguage.ARABIC -> "هامش المحتوى"
+        AppLanguage.PORTUGUESE -> "Preenchimento de Conteúdo"
+        AppLanguage.SPANISH -> "Relleno de Contenido"
+        AppLanguage.FRENCH -> "Marge de Contenu"
+        AppLanguage.GERMAN -> "Innenabstand des Inhalts"
+        AppLanguage.RUSSIAN -> "Внутренний отступ контента"
+        AppLanguage.JAPANESE -> "コンテンツの余白"
+        AppLanguage.KOREAN -> "콘텐츠 안쪽 여백"
+    }
+
+    val fullscreenContentPaddingHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "全屏模式下给内容四周留白，让屏幕角落的按钮更容易点按，并缓解与返回手势边缘的冲突。若返回手势区仍偏小，可开启上方的“显示导航栏”恢复标准手势区。"
+        AppLanguage.ENGLISH -> "Add padding around content in fullscreen so corner buttons are easier to tap and it conflicts less with the back-gesture edge. If the back-gesture area still feels small, turn on “Show Navigation Bar” above to restore the standard gesture zone."
+        AppLanguage.ARABIC -> "أضف هامشًا حول المحتوى في وضع ملء الشاشة لتسهيل النقر على أزرار الزوايا وتقليل التعارض مع حافة إيماءة الرجوع. إذا ظل منطقة إيماءة الرجوع صغيرة، فعّل «إظهار شريط التنقل» بالأعلى لاستعادة منطقة الإيماءات القياسية."
+        AppLanguage.PORTUGUESE -> "Adicione preenchimento ao redor do conteúdo em tela cheia para facilitar tocar nos botões dos cantos e reduzir conflitos com a borda do gesto de voltar. Se a área do gesto de voltar ainda parecer pequena, ative “Mostrar Barra de Navegação” acima para restaurar a zona padrão de gestos."
+        AppLanguage.SPANISH -> "Añade relleno alrededor del contenido en pantalla completa para que los botones de las esquinas sean más fáciles de tocar y haya menos conflicto con el borde del gesto de retroceso. Si el área del gesto sigue pareciendo pequeña, activa “Mostrar Barra de Navegación” arriba para restaurar la zona estándar de gestos."
+        AppLanguage.FRENCH -> "Ajoutez une marge autour du contenu en plein écran pour faciliter l'appui sur les boutons d'angle et réduire les conflits avec la zone du geste de retour. Si la zone du geste de retour reste petite, activez « Afficher la Barre de Navigation » ci-dessus pour restaurer la zone de gestes standard."
+        AppLanguage.GERMAN -> "Fügt im Vollbildmodus einen Abstand um den Inhalt hinzu, damit Eckbuttons leichter antippbar sind und weniger Konflikte mit der Zurück-Geste-Kante entstehen. Wenn die Zone für die Zurück-Geste noch klein wirkt, aktivieren Sie oben „Navigationsleiste anzeigen“, um die Standard-Gestenzone wiederherzustellen."
+        AppLanguage.RUSSIAN -> "Добавляет отступ вокруг контента в полноэкранном режиме, чтобы кнопки в углах было легче нажимать, и уменьшает конфликт с краем жеста «назад». Если зона жеста «назад» всё ещё мала, включите выше «Показывать панель навигации», чтобы восстановить стандартную зону жестов."
+        AppLanguage.JAPANESE -> "全画面モードでコンテンツの周囲に余白を設け、画面の隅のボタンをタップしやすくし、戻るジェスチャーの縁との競合を和らげます。戻るジェスチャー領域がまだ狭い場合は、上の「ナビゲーションバーを表示」をオンにして標準のジェスチャー領域を復元してください。"
+        AppLanguage.KOREAN -> "전체 화면 모드에서 콘텐츠 주위에 여백을 추가해 화면 모서리의 버튼을 누르기 쉽게 하고, 뒤로 가기 제스처 경계와의 충돌을 줄입니다. 뒤로 가기 제스처 영역이 여전히 좁게 느껴지면 위의 “내비게이션 바 표시”를 켜서 표준 제스처 영역을 복원하세요."
     }
 
     val statusBarStyleConfigLabel: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -1082,6 +1082,9 @@ data class WebViewShellConfig(
     @SerializedName("showToolbarInFullscreen")
     val showToolbarInFullscreen: Boolean = false,
 
+    @SerializedName("fullscreenContentPaddingDp")
+    val fullscreenContentPaddingDp: Int = 0,
+
     @SerializedName("landscapeMode")
     val landscapeMode: Boolean = false,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -265,6 +265,7 @@ data class WebViewConfig(
     val showStatusBarInFullscreen: Boolean = false,
     val showNavigationBarInFullscreen: Boolean = false,
     val showToolbarInFullscreen: Boolean = false,
+    val fullscreenContentPaddingDp: Int = 0,
     val landscapeMode: Boolean = false,
     val orientationMode: OrientationMode = OrientationMode.PORTRAIT,
     val injectScripts: List<UserScript> = emptyList(),

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -2236,6 +2236,20 @@ fun FullscreenModeCard(
                     onCheckedChange = onShowNavigationBarChange
                 )
 
+                WtaSectionDivider()
+                WtaSliderRow(
+                    title = Strings.fullscreenContentPadding,
+                    subtitle = Strings.fullscreenContentPaddingHint,
+                    value = webViewConfig.fullscreenContentPaddingDp.toFloat(),
+                    onValueChange = {
+                        onWebViewConfigChange(
+                            webViewConfig.copy(fullscreenContentPaddingDp = it.toInt())
+                        )
+                    },
+                    valueLabel = "${webViewConfig.fullscreenContentPaddingDp}dp",
+                    valueRange = 0f..48f
+                )
+
                 if (showStatusBar) {
                     WtaSectionDivider()
 

--- a/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -137,6 +140,7 @@ private fun TabsMode(
     onRefresh: () -> Unit
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
+    val tabsListState = rememberLazyListState()
 
     LaunchedEffect(selectedTab, sites.size) {
         val site = sites.getOrNull(selectedTab)
@@ -145,6 +149,13 @@ private fun TabsMode(
             if (site.url.isNotBlank()) {
                 webViewCallbacks.onPageStarted(site.url)
             }
+        }
+    }
+
+    // 选中项变化时把它滚动到可见区域，避免被挤出屏幕（站点多时可横向滚动）。
+    LaunchedEffect(selectedTab) {
+        if (sites.size > 1) {
+            tabsListState.animateScrollToItem(selectedTab)
         }
     }
 
@@ -158,18 +169,20 @@ private fun TabsMode(
                     color = MaterialTheme.colorScheme.surface,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Row(
+                    LazyRow(
+                        state = tabsListState,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(48.dp),
-                        horizontalArrangement = Arrangement.SpaceEvenly,
-                        verticalAlignment = Alignment.CenterVertically
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        contentPadding = PaddingValues(horizontal = 8.dp)
                     ) {
-                        sites.forEachIndexed { index, site ->
+                        itemsIndexed(sites) { index, site ->
                             val isSelected = selectedTab == index
                             Column(
                                 modifier = Modifier
-                                    .weight(1f)
+                                    .widthIn(min = 72.dp)
                                     .fillMaxHeight()
                                     .clickable { selectedTab = index },
                                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -205,10 +218,24 @@ private fun TabsMode(
             }
         }
     ) { padding ->
+        // 全屏模式下可选的内容内边距，与单站点 ShellScaffoldLayout 行为一致：
+        // 把网页交互区从屏幕边缘内移，让角落按钮易于点按，并缓解与系统返回手势边缘带的冲突。
+        val contentPad = webViewConfig.fullscreenContentPaddingDp.dp
+        val topPad = if (webViewConfig.hideToolbar && webViewConfig.showStatusBarInFullscreen) {
+            WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+        } else {
+            contentPad
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .padding(
+                    start = contentPad,
+                    end = contentPad,
+                    bottom = contentPad,
+                    top = if (webViewConfig.hideToolbar) topPad else contentPad
+                )
         ) {
             val visitedTabs = remember { mutableStateMapOf<Int, Boolean>() }
             visitedTabs[selectedTab] = true

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -138,6 +138,10 @@ fun BoxScope.ShellScaffoldLayout(
 
         val actualStatusBarPadding = if (statusBarHeightDp >= 0) statusBarHeightDp.dp else systemStatusBarHeightDp
 
+        // 全屏模式下可选的内容内边距：把网页交互区从屏幕边缘内移，让角落按钮易于点按，
+        // 同时缓解与系统返回手势边缘带的冲突。默认 0 → 向后兼容旧行为。
+        val contentPad = config.webViewConfig.fullscreenContentPaddingDp.dp
+
         val contentModifier = when {
             hideToolbar && showToolbar -> {
 
@@ -145,11 +149,16 @@ fun BoxScope.ShellScaffoldLayout(
             }
             hideToolbar && config.webViewConfig.showStatusBarInFullscreen -> {
 
-                Modifier.fillMaxSize().padding(top = actualStatusBarPadding)
+                Modifier.fillMaxSize().padding(
+                    top = actualStatusBarPadding,
+                    start = contentPad,
+                    end = contentPad,
+                    bottom = contentPad
+                )
             }
             hideToolbar -> {
 
-                Modifier.fillMaxSize()
+                Modifier.fillMaxSize().padding(contentPad)
             }
             else -> {
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -46,6 +46,7 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         showStatusBarInFullscreen = config.webViewConfig.showStatusBarInFullscreen,
         showNavigationBarInFullscreen = config.webViewConfig.showNavigationBarInFullscreen,
         showToolbarInFullscreen = config.webViewConfig.showToolbarInFullscreen,
+        fullscreenContentPaddingDp = config.webViewConfig.fullscreenContentPaddingDp,
         landscapeMode = config.webViewConfig.landscapeMode,
         orientationMode = try {
             com.webtoapp.data.model.OrientationMode.valueOf(config.webViewConfig.orientationMode)


### PR DESCRIPTION
## Summary

Closes #283. Addresses the three points raised by @SuperPauly.

### 1. Multi-web Tabs menu is now scrollable
`TabsMode` rendered every site in a non-scrollable `Row`, giving each tab `.weight(1f)`. With 6+ sites each tab shrank until labels ellipsized and overflow tabs were unreachable.

- Bottom bar is now a `LazyRow` with `widthIn(min = 72.dp)` per tab.
- The selected tab auto-scrolls into view via `animateScrollToItem`.

### 2. New fullscreen content padding option
In fullscreen the WebView filled edge-to-edge (even under the display cutout), making corner buttons hard to tap. Added a configurable `fullscreenContentPaddingDp` (0–48 dp slider, default 0 = backward compatible).

Threaded through the full config pipeline, mirroring the existing `statusBarHeightDp`:

| Layer | File |
|-------|------|
| Model | `data/model/WebApp.kt` (`WebViewConfig`) |
| ApkConfig | `core/apkbuilder/ApkConfig.kt` (`WebViewBlock` + getter) |
| JSON factory | `core/apkbuilder/ApkConfigJsonFactory.kt` |
| Shell config | `core/shell/ShellModeManager.kt` (`WebViewShellConfig`) |
| Shell→host conversion | `ui/shell/ShellWebViewConfig.kt` |
| Runtime use (single-site) | `ui/shell/ShellScaffoldLayout.kt` (fullscreen branches) |
| Runtime use (multi-web) | `ui/shell/MultiWebShellMode.kt` (TabsMode content box) |
| Editor UI | `ui/screens/CreateAppWebViewCards.kt` (`FullscreenModeCard`) |
| i18n | `core/i18n/Strings.kt` (2 strings × 10 languages) |

### 3. Back-gesture guidance
Shrinking the back-gesture strip in immersive fullscreen is an inherent consequence of edge-to-edge + hiding the nav bar (Android platform behavior). The content padding from (2) helps by pulling web hit-targets off the gesture edge, and the new setting hint points users to the existing **Show Navigation Bar** toggle, which restores the standard gesture zone when enabled.

No change to `WindowHelper.applyImmersiveFullscreen` — preserving the current immersive behavior while letting users opt into padding / nav-bar visibility.

## Verification
- [x] `python3 scripts/check_config_field_drift.py` → OK (payload=427 shell=457, no drift)
- [x] `./gradlew :app:checkConfigFieldDrift --no-configuration-cache` → OK
- [x] `./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache` → BUILD SUCCESSFUL
- [x] `./gradlew :shell:clean :shell:assembleRelease :app:syncShellTemplateApk --no-configuration-cache` → BUILD SUCCESSFUL
- [x] Shell template DEX contains the new field/method/string (`fullscreenContentPaddingDp`, `animateScrollToItem`, `fullscreenContentPadding`)
- [x] Backward compatible: existing config JSON without the field → Gson default 0 → previous behavior

## Notes
- `shell/src/` and `webview_shell.apk` are build artifacts (gitignored); regenerated at build time. Only the 9 source files are committed.
- Did not touch `displayMode` selection UI or `WindowHelper` behavior per scope discussion.