### PR TITLE
chore(version): bump to 2.3.5 (versionCode 50)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.3.0** (`versionCode 49`).
+This guide targets **WebToApp 2.3.5** (`versionCode 50`).
 
 ---
 
@@ -218,7 +218,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.3.0**（`versionCode 49`）。
+本指南对应 **WebToApp 2.3.5**（`versionCode 50`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 49
-        versionName = "2.3.0"
+        versionCode = 50
+        versionName = "2.3.5"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/modules/README.md
+++ b/modules/README.md
@@ -201,7 +201,7 @@ entry mirrors the module manifest plus a `path` (folder name) and a
 
 `minAppVersion` lets you ship a module that needs APIs only present from a
 specific WebToApp `versionCode` onwards — older clients hide the entry.
-The current `versionCode` is **49** (`v2.3.0`); set this only if you
+The current `versionCode` is **50** (`v2.3.5`); set this only if you
 genuinely depend on a newer build.
 
 `iconUrl` is optional. Either a relative path (`"icon.png"`, `"icon.svg"`,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 49
-        versionName = "2.3.0"
+        versionCode = 50
+        versionName = "2.3.5"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## Summary

Bump the release version to **2.3.5** (`versionCode 50`).

| File | Change |
|------|--------|
| `app/build.gradle.kts` | `versionCode 49 → 50`, `versionName 2.3.0 → 2.3.5` |
| `shell/build.gradle.kts` | `versionCode 49 → 50`, `versionName 2.3.0 → 2.3.5` |
| `.github/CONTRIBUTING.md` | version refs updated (en + zh) |
| `modules/README.md` | `versionCode 49 (v2.3.0) → 50 (v2.3.5)` |

## Notes
- `versionCode` is bumped alongside `versionName` — both Play Store and the installer require a monotonically increasing `versionCode`, so bumping only the name would reject overwrite installs / store upload.
- The shell module version stays in sync with the host: it is the template baked into every generated APK, and its version identifiers land in the exported APK's manifest.
- `app/release/output-metadata.json` still references 2.3.0 but is a build artifact regenerated on the next build, so it is intentionally not edited.