### PR TITLE
Align App Modifier capabilities

### DIFF
--- a/app/src/main/java/com/webtoapp/core/appmodifier/InstalledAppInfo.kt
+++ b/app/src/main/java/com/webtoapp/core/appmodifier/InstalledAppInfo.kt
@@ -4,7 +4,6 @@ import android.graphics.drawable.Drawable
 import com.webtoapp.core.activation.ActivationCode
 import com.webtoapp.data.model.ActivationDialogConfig
 import com.webtoapp.data.model.Announcement
-import com.webtoapp.data.model.BgmConfig
 import com.webtoapp.data.model.SplashConfig
 
 data class InstalledAppInfo(
@@ -47,10 +46,7 @@ data class AppModifyConfig(
     val activationRemoteConfig: com.webtoapp.data.model.RemoteActivationConfig = com.webtoapp.data.model.RemoteActivationConfig(),
 
     val announcementEnabled: Boolean = false,
-    val announcement: Announcement = Announcement(),
-
-    val bgmEnabled: Boolean = false,
-    val bgmConfig: BgmConfig? = null
+    val announcement: Announcement = Announcement()
 )
 
 sealed class AppModifyResult {

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4938,6 +4938,7 @@ object Strings {
     val appModifierModeCloneDesc: String get() = StringsE.appModifierModeCloneDesc
     val appModifierRecommended: String get() = StringsE.appModifierRecommended
     val appModifierCloneNeedsOriginalIcon: String get() = StringsE.appModifierCloneNeedsOriginalIcon
+    val appModifierCloneNoEnhancements: String get() = StringsE.appModifierCloneNoEnhancements
     val appModifierShortcutHint: String get() = StringsE.appModifierShortcutHint
     val appModifierWorking: String get() = StringsE.appModifierWorking
     fun appModifierResultCount(count: Int): String = StringsE.appModifierResultCount(count)
@@ -65171,6 +65172,19 @@ object StringsE {
         AppLanguage.RUSSIAN -> "Клон недоступен с пользовательской иконкой. Используйте ярлык или верните оригинальную иконку"
         AppLanguage.JAPANESE -> "カスタムアイコン時はクローン不可。ショートカットを使うか元のアイコンに戻す"
         AppLanguage.KOREAN -> "사용자 지정 아이콘에서는 클론 설치 불가. 바로가기를 쓰거나 원본 아이콘 복원"
+    }
+
+    val appModifierCloneNoEnhancements: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "克隆安装暂不支持开屏、激活码与公告，请改用快捷方式或关闭这些增强"
+        AppLanguage.ENGLISH -> "Clone install does not support splash, activation, or announcement. Use shortcut mode or turn these off"
+        AppLanguage.ARABIC -> "تثبيت النسخة لا يدعم الافتتاح أو التفعيل أو الإعلان. استخدم الاختصار أو أوقف هذه الميزات"
+        AppLanguage.PORTUGUESE -> "O clone não suporta splash, ativação nem anúncio. Use atalho ou desative esses recursos"
+        AppLanguage.SPANISH -> "El clon no admite splash, activación ni aviso. Usa acceso directo o desactiva estas funciones"
+        AppLanguage.FRENCH -> "Le clone ne prend pas en charge splash, activation ni annonce. Utilisez le raccourci ou désactivez-les"
+        AppLanguage.GERMAN -> "Der Klon unterstützt Splash, Aktivierung und Hinweis nicht. Verknüpfung nutzen oder diese deaktivieren"
+        AppLanguage.RUSSIAN -> "Клон не поддерживает splash, активацию и объявление. Используйте ярлык или отключите их"
+        AppLanguage.JAPANESE -> "クローンはスプラッシュ/認証/お知らせに未対応。ショートカットを使うかこれらを無効にしてください"
+        AppLanguage.KOREAN -> "클론 설치는 스플래시, 활성화, 공지를 지원하지 않습니다. 바로가기를 쓰거나 해당 기능을 끄세요"
     }
 
     val appModifierShortcutHint: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/AppModifierEditState.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AppModifierEditState.kt
@@ -7,7 +7,6 @@ import com.webtoapp.core.appmodifier.AppModifyConfig
 import com.webtoapp.core.appmodifier.InstalledAppInfo
 import com.webtoapp.data.model.ActivationDialogConfig
 import com.webtoapp.data.model.Announcement
-import com.webtoapp.data.model.BgmConfig
 import com.webtoapp.data.model.SplashConfig
 
 @Stable
@@ -28,10 +27,7 @@ data class AppModifierEditState(
     val activationRemoteConfig: com.webtoapp.data.model.RemoteActivationConfig = com.webtoapp.data.model.RemoteActivationConfig(),
 
     val announcementEnabled: Boolean = false,
-    val announcement: Announcement = Announcement(),
-
-    val bgmEnabled: Boolean = false,
-    val bgmConfig: BgmConfig = BgmConfig()
+    val announcement: Announcement = Announcement()
 ) {
     fun toConfig(originalApp: InstalledAppInfo): AppModifyConfig {
         return AppModifyConfig(
@@ -46,9 +42,7 @@ data class AppModifierEditState(
             activationDialogConfig = activationDialogConfig,
             activationRemoteConfig = activationRemoteConfig,
             announcementEnabled = announcementEnabled,
-            announcement = announcement,
-            bgmEnabled = bgmEnabled,
-            bgmConfig = if (bgmEnabled) bgmConfig else null
+            announcement = announcement
         )
     }
 }

--- a/app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt
@@ -83,12 +83,12 @@ import com.webtoapp.core.appmodifier.AppCloner
 import com.webtoapp.core.appmodifier.AppFilterType
 import com.webtoapp.core.appmodifier.AppListProvider
 import com.webtoapp.core.appmodifier.AppModifyResult
+import com.webtoapp.core.appmodifier.CloneConfigBuilder
 import com.webtoapp.core.appmodifier.InstalledAppInfo
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.SplashType
 import com.webtoapp.ui.components.ActivationCodeCard
 import com.webtoapp.ui.components.AppNameTextFieldSimple
-import com.webtoapp.ui.components.BgmCard
 import com.webtoapp.ui.components.IconPickerWithLibrary
 import com.webtoapp.ui.design.WtaButton
 import com.webtoapp.ui.design.WtaButtonSize
@@ -780,7 +780,13 @@ private fun AppModifyContent(
     }
 
     val hasCustomIcon = editState.newIconUri != null || editState.newIconPath != null
-    val canClone = !hasCustomIcon
+    val cloneBlockedReason = when {
+        hasCustomIcon -> Strings.appModifierCloneNeedsOriginalIcon
+        CloneConfigBuilder.hasAnyModification(editState.toConfig(app)) ->
+            Strings.appModifierCloneNoEnhancements
+        else -> null
+    }
+    val canClone = cloneBlockedReason == null
     val nameReady = editState.newAppName.isNotBlank()
 
     LaunchedEffect(canClone) {
@@ -822,7 +828,7 @@ private fun AppModifyContent(
 
             OutputModeCard(
                 mode = outputMode,
-                canClone = canClone,
+                cloneBlockedReason = cloneBlockedReason,
                 onModeChange = { outputMode = it }
             )
 
@@ -908,13 +914,6 @@ private fun AppModifyContent(
                         )
                     }
                 }
-            )
-
-            BgmCard(
-                enabled = editState.bgmEnabled,
-                config = editState.bgmConfig,
-                onEnabledChange = { update { copy(bgmEnabled = it) } },
-                onConfigChange = { update { copy(bgmConfig = it) } }
             )
 
             if (outputMode == ModifyOutputMode.CLONE) {
@@ -1031,9 +1030,10 @@ private fun IdentitySide(
 @Composable
 private fun OutputModeCard(
     mode: ModifyOutputMode,
-    canClone: Boolean,
+    cloneBlockedReason: String?,
     onModeChange: (ModifyOutputMode) -> Unit
 ) {
+    val canClone = cloneBlockedReason == null
     WtaCard(tone = WtaCardTone.Surface, contentPadding = PaddingValues(12.dp)) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Text(
@@ -1052,11 +1052,7 @@ private fun OutputModeCard(
             ModeOption(
                 selected = mode == ModifyOutputMode.CLONE,
                 title = Strings.cloneInstall,
-                description = if (canClone) {
-                    Strings.appModifierModeCloneDesc
-                } else {
-                    Strings.appModifierCloneNeedsOriginalIcon
-                },
+                description = cloneBlockedReason ?: Strings.appModifierModeCloneDesc,
                 icon = Icons.Outlined.ContentCopy,
                 enabled = canClone,
                 onClick = { if (canClone) onModeChange(ModifyOutputMode.CLONE) }


### PR DESCRIPTION
Closes #296\n\n## Summary\n- Disable CLONE when its unavailable customizations are configured and show the specific reason.\n- Automatically fall back to SHORTCUT when CLONE becomes unavailable.\n- Remove the ineffective App Modifier background-music control and configuration state.\n- Preserve background music support in Create App and generated APK flows.\n\n## Validation\n- ./gradlew --no-daemon --no-configuration-cache -Dkotlin.compiler.execution.strategy=in-process -PskipShellTemplateSync=true -PallowDebugSignedRelease=true :app:compileDebugKotlin :shell:compileDebugKotlin :app:testDebugUnitTest :app:checkConfigFieldDrift\n- git diff --check\n- python3 .github/scripts/audit_ui_design_system.py