### PR TITLE
fix(splash): drop countdown/skip chip below the status bar

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -224,6 +224,7 @@ fun ShellSplashOverlay(
         Surface(
             modifier = Modifier
                 .align(Alignment.TopEnd)
+                .statusBarsPadding()
                 .padding(16.dp),
             shape = MaterialTheme.shapes.small,
             color = Color.Black.copy(alpha = 0.6f)

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -538,6 +538,7 @@ fun SplashContent(
         Surface(
             modifier = Modifier
                 .align(Alignment.TopEnd)
+                .statusBarsPadding()
                 .padding(16.dp),
             shape = MaterialTheme.shapes.small,
             color = Color.Black.copy(alpha = 0.6f)

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewSplashOverlay.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewSplashOverlay.kt
@@ -160,6 +160,7 @@ fun SplashOverlay(
         Surface(
             modifier = Modifier
                 .align(Alignment.TopEnd)
+                .statusBarsPadding()
                 .padding(16.dp),
             shape = MaterialTheme.shapes.small,
             color = Color.Black.copy(alpha = 0.6f)


### PR DESCRIPTION
## Summary

Fixes #299.

When a generated/preview app is configured with **fullscreen + show status bar + tappable splash**, the splash countdown/skip chip (top-right `Xs | Skip` capsule) was rendered with a fixed `16.dp` top padding and got **completely covered** by the visible status bar — the countdown was unreadable and the chip untappable.

## Root cause

The chip was anchored with `Alignment.TopEnd` + a constant `padding(16.dp)` in three independent splash implementations, none of which account for the status-bar window inset:

| File | Surface |
|------|---------|
| `app/.../ui/webview/WebViewSplashOverlay.kt` | Host preview `SplashOverlay` |
| `app/.../ui/shell/ShellMediaContent.kt` | Shell runtime `ShellSplashOverlay` (used by exported APK) |
| `app/.../ui/splash/SplashLauncherActivity.kt` | Launcher splash |

## Fix

Apply `.statusBarsPadding()` to the chip `Surface` (after `align`, before the fixed padding) in all three places:

```kotlin
Surface(
    modifier = Modifier
        .align(Alignment.TopEnd)
        .statusBarsPadding()   // ← added
        .padding(16.dp),
    ...
)
```

- Status bar **hidden** (pure immersive fullscreen) → inset is `0`, no behavior change.
- Status bar **visible** → chip drops just below it and stays visible/tappable.

This is the same pattern already used elsewhere in the codebase (`ShellGallery.kt`, `GalleryPlayerScreen.kt`). The fullscreen image/video background is unaffected — the inset only applies to the chip.

## Verification

- `./gradlew :app:compileDebugKotlin -x syncCloneHostDex` ✅
- Rebuilt the shell template (`:shell:clean` + `:shell:assembleRelease` + `:app:syncShellTemplateApk --rerun-tasks`); `classes2.dex` contains `ShellSplashOverlay`, confirming the shell path is covered.

## Notes

- The shell template APK is `.gitignore`d (`*.apk`), so only the 3 Kotlin sources are in this PR; the template is rebuilt locally/on CI.
- No config-field or export-wiring changes, so `checkConfigFieldDrift` is not affected.