### PR TITLE
docs(guide): rework Introduction & Getting Started from code; rename Start group

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,7 +10,7 @@ const t = {
   en: {
     nav: { guide: 'Guide', developer: 'Developer', extensions: 'Extensions' },
     guide: {
-      start: 'Getting Started',
+      start: 'Start',
       intro: 'Introduction',
       gettingStarted: 'Getting Started',
       mainScreen: 'Main Screen',
@@ -93,7 +93,7 @@ const t = {
   zh: {
     nav: { guide: '使用手册', developer: '开发者', extensions: '扩展开发' },
     guide: {
-      start: '入门',
+      start: '开始',
       intro: '简介',
       gettingStarted: '快速开始',
       mainScreen: '主界面',

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,58 +1,66 @@
 # Getting Started
 
-This walkthrough takes you from a fresh install to your first signed APK, following the actual flow in the app.
+This walkthrough takes you from a fresh install to your first signed APK. At each step it notes what the app is actually doing under the hood, so the flow makes sense in terms of the code.
 
-## 1. Install WebToApp
+## 1. Install and launch
 
-Install the WebToApp builder on an Android device running **Android 6.0 (API 23) or newer**. On first launch you land on **My Apps** — the home screen that lists every app you create. See [Main Screen](/guide/main-screen/my-apps) for a tour of it.
+Install the WebToApp builder on a device running **Android 6.0 (API 23) or newer**.
 
-## 2. Open the create menu
+On launch, `WebToAppApplication` starts in **builder mode** (`SHELL_RUNTIME_ONLY = false`): it initializes the i18n strings, the Room database, and the dependency graph, then shows **My Apps** — the home screen that lists every app you create. See [Main Screen](/guide/main-screen/my-apps).
 
-At the bottom of **My Apps**, tap the **Create** button. A panel expands with a 3-column grid of app types:
+## 2. Create an app definition
+
+At the bottom of **My Apps**, tap **Create**. A panel expands with a 3-column grid of the 12 [app types](/guide/app-types/):
 
 **Web · Multi-Web · HTML · Offline Pack · Frontend · PHP · WordPress · Node.js · Python · Go · Media · Gallery**
 
-For your first app, tap **Web**.
+Tap **Web** for your first app. The Web editor opens.
 
 ## 3. Fill in the basics
 
-The Web editor opens. Fill in the top **Basic info** card:
+Fill in the top **Basic info** card:
 
-- **App name** — anything you like
+- **App name**
 - **Target URL** — e.g. `https://example.com`
-- **Icon** — pick an image (optional; a type-specific default is used otherwise)
+- **Icon** — optional; a type-specific default is used otherwise
 
-The rest of the editor is a long list of optional capability cards (fullscreen, splash screen, ad blocking, DNS, fingerprint disguise, and more). You can ignore all of them for now — sensible defaults are used. Each is explained under [App Configuration](/guide/config/).
+The rest of the editor is a long list of optional capability cards (fullscreen, splash, ad blocking, DNS, disguise, …). Ignore them for now — defaults are used. Each is covered under [App Configuration](/guide/config/).
 
-Tap **Save**. Your app now appears in the list on **My Apps**.
+Tap **Save**. Under the hood, the editor assembles a `WebApp` object (with `appType = WEB` and a `webViewConfig`) and writes it to the `web_apps` Room table. Your app now appears in the list.
 
 ## 4. Preview
 
-On **My Apps**, tap your app's card. WebToApp launches it in preview, exactly as it will behave once exported. (Tap the ⋮ button on the card instead to open the action menu — see [App Actions](/guide/app-actions/edit-core-config).)
+On **My Apps**, tap your app's card. The preview router checks the app's `appType` and launches the matching runtime:
+
+- `IMAGE` / `VIDEO` → the media player activity
+- `GALLERY` → the gallery player activity
+- everything else (including `WEB`) → the WebView activity
+
+For a Web app, the WebView activity loads your URL with your configured settings — the same code the exported app will run. (Tap the card's ⋮ button instead to open the [action menu](/guide/app-actions/edit-core-config).)
 
 ::: warning Preview ≠ export
-Preview and export share the same runtime code, but export additionally serializes your configuration into the generated APK. If a feature works in preview but not after export, a config field likely did not flow through the export chain. See [Config Field Drift](/developer/config-drift).
+Preview runs the **host** path (everything on the builder's classpath). Export runs the **shell** path, reading your config from an embedded JSON. A feature can work in preview yet vanish after export if a config field doesn't survive that trip. See [Config Field Drift](/developer/config-drift).
 :::
 
 ## 5. Build the APK
 
-Back on **My Apps**, tap the ⋮ button on your app's card, then **Build APK**. In the dialog you can:
+Tap ⋮ on your app's card, then **Build APK**. In the dialog you can:
 
 - pick the **browser engine** (System WebView or GeckoView),
 - optionally enable **resource encryption**, **isolation**, **background run**, and **notifications**,
 - force a **full rebuild** (otherwise an incremental mode is chosen automatically).
 
-Tap build. WebToApp patches the shell template, embeds your config and content, and signs the result. When it finishes, the APK is ready.
+Tap build. The `ApkBuilder` takes the shell template APK, patches its package name / icon / permissions, embeds your `WebApp` config as `app_config.json`, and signs the result (V1/V2/V3). See [Build APK](/guide/app-actions/build-apk).
 
-## 6. Find and install it
+## 6. Install it
 
-Open **⋮ → File Manager** from the top-right of **My Apps**. Your build output is there — install it on your device or share it to another device. Launch it: it runs the shell runtime reading *your* embedded configuration, independent of the builder.
+Open **⋮ → [File Manager](/guide/more-features/file-manager)** from the top-right of My Apps. Your APK is there — install it or share it. When you launch it, that APK runs in **shell mode** (`SHELL_RUNTIME_ONLY = true`): `ShellModeManager` reads *your* embedded `app_config.json` and drives the runtime, fully independent of the builder.
 
 ## Next steps
 
 - Tour the [Main Screen](/guide/main-screen/my-apps).
-- Learn what each [app type](/guide/app-types/) can do.
-- Explore the per-app [App Actions](/guide/app-actions/edit-core-config) (shortcut, share, export, AAB).
+- Learn what each [app type](/guide/app-types/) does.
+- Explore the per-app [App Actions](/guide/app-actions/edit-core-config).
 - Open the top-right **⋮** menu — see [More Features](/guide/more-features/ai-coding).
 
 ## Build from source

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,34 +1,48 @@
 # Introduction
 
-**WebToApp** turns web projects into standalone, signed Android APKs — entirely on your phone. It is not a URL wrapper. It is a pocket-sized APK workshop that can run real server runtimes, ship a hardened anti-censorship network stack, sign bundles for Google Play, and run MV3 browser extensions, all without a PC or a remote build server.
+WebToApp is an Android application that turns web projects into installable APKs **on the device**. This page describes what it actually is, in terms of the code, so you know what to expect before you start.
 
-## What makes it different
+## What the app is, concretely
 
-Most "website to app" tools stop at wrapping a URL in a WebView. WebToApp diverges exactly where the hard parts are:
+At its core, WebToApp manages a list of **app definitions**. Each definition is a `WebApp` record stored in a local Room database (the `web_apps` table). A `WebApp` holds:
 
-- **It runs real server runtimes on-device.** Node.js, PHP, Python, Go, and WordPress are fork+exec'd as native binaries straight from app storage — like Termux, packaged into an installable APK. URL-wrapper tools cannot do this at all.
-- **It ships a hardened network stack.** DNS-over-HTTPS, TLS fingerprint spoofing (Chrome / Firefox / Safari JA3 templates) with a local MITM bridge, Encrypted Client Hello (ECH) on the GeckoView engine, per-app proxies, and CORS bypass for locked-down SPAs.
-- **The whole build is self-contained.** Binary AXML/ARSC patching, permission pruning, V1/V2/V3 signing, and Google Play-ready AAB export all happen inside the app via `apksig`.
-- **It stays extensible after shipping.** Add JS/CSS modules, Tampermonkey-style userscripts, or MV3 Chrome extensions without rebuilding the host.
+- **Identity** — `name`, `url`, `iconPath`, `packageName`, and an `appType`.
+- **A type-specific config** — one of `mediaConfig`, `galleryConfig`, `htmlConfig`, `wordpressConfig`, `nodejsConfig`, `phpAppConfig`, `pythonAppConfig`, `goAppConfig`, or `multiWebConfig`, depending on the type.
+- **Feature flags + configs** — activation, ads, announcement, ad blocking, WebView settings, splash, background music, translation, extensions, auto-start, disguise, and an `apkExportConfig` for packaging.
 
-## What you can build
+When you "build" an app, the builder takes the shell template APK, patches its identity and resources, embeds your `WebApp` configuration as an assets JSON, and signs the result. The output is a standalone APK you can install or share.
 
-| Input | Output | Good for |
-| --- | --- | --- |
-| Website URL | WebView-based APK | Landing pages, tools, dashboards, docs, internal systems |
-| HTML / static front-end | Localhost-backed APK | React, Vue, Vite, static builds, offline web apps |
-| Node.js / PHP / Python / Go | APK with an on-device local server | Small server apps, admin tools, demos, prototypes |
-| WordPress | APK running WordPress over local PHP + SQLite | Portable sites, theme/plugin demos, content packages |
-| Images / video / galleries | Media-focused APK | Albums, course materials, portfolios, offline viewers |
-| Multiple sites | Tab/card/feed/drawer multi-web APK | Link hubs, portals, app collections |
-| Installed APK | Rebranded clone or shortcut disguise | Icon/name/package experiments, repackaging research |
+## The 12 app types
+
+The `AppType` enum defines what an app can be:
+
+`WEB` · `IMAGE` · `VIDEO` · `HTML` · `GALLERY` · `FRONTEND` · `WORDPRESS` · `NODEJS_APP` · `PHP_APP` · `PYTHON_APP` · `GO_APP` · `MULTI_WEB`
+
+The web-oriented types load a URL or local files in a WebView; the runtime types (`NODEJS_APP`, `PHP_APP`, `PYTHON_APP`, `GO_APP`, `WORDPRESS`) fork a native server binary on-device and point the WebView at a local port; the media types (`IMAGE`, `VIDEO`, `GALLERY`) play content directly. See [Create App](/guide/app-types/) for each.
+
+## One codebase, two ways to run
+
+The same `WebToAppApplication` runs in two modes, selected by a build flag:
+
+- **Builder (host)** — `SHELL_RUNTIME_ONLY = false`. This is the app you install from the store: the editor, the app list, and the export pipeline, with everything on the main classpath.
+- **Generated app (shell runtime)** — `SHELL_RUNTIME_ONLY = true`. The exported APK runs the synced shell runtime and reads *your* embedded config from `app_config.json` via `ShellModeManager`. Node.js even runs in a separate `:nodejs` OS process.
+
+This is why "works in preview but not after export" is a real failure mode: preview runs the host path, export runs the shell path, and a config field has to survive the trip between them. See [Config Field Drift](/developer/config-drift).
+
+## Where things live in the UI
+
+- [My Apps](/guide/main-screen/my-apps) — the home screen: your app list, categories, and the create button.
+- [Create App](/guide/app-types/) — the 12 app types and their creation flows.
+- [App Actions](/guide/app-actions/edit-core-config) — what you can do per app (edit, build, share, export, …).
+- [More Features](/guide/more-features/ai-coding) — the global tools behind the top-right ⋮ menu.
+- [App Configuration](/guide/config/) — the shared per-app options (network, privacy, appearance, runtimes).
 
 ## How to read these docs
 
-- **[User Guide](/guide/getting-started)** — tour the [main screen](/guide/main-screen/my-apps), build your first APK, learn the [app types](/guide/app-types/) and [per-app actions](/guide/app-actions/edit-core-config), explore the [more-features menu](/guide/more-features/ai-coding), and configure apps under [App Configuration](/guide/config/).
-- **[Developer Docs](/developer/)** — how the codebase is organized, how the export pipeline and shell sync work, and the recipes for common changes.
-- **[Extension Authoring](/extensions/)** — write JS/CSS modules, userscripts, and MV3 Chrome extensions, and publish them to the in-app market.
+- **[Start](/guide/getting-started)** — build your first APK and tour the main screen.
+- **[Developer Docs](/developer/)** — the codebase layout, the export pipeline, shell sync, and change recipes.
+- **[Extension Authoring](/extensions/)** — write JS/CSS modules, userscripts, and MV3 Chrome extensions.
 
 ::: tip
-The host app UI is available in 10 languages. Switch it anytime from the **language button in the top bar** of My Apps. The language of the apps you *generate* is configured separately per app.
+The builder UI is available in 10 languages — switch from the [language button](/guide/main-screen/language) in the top bar. The language of the apps you *generate* is configured per app.
 :::

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -1,58 +1,66 @@
 # 快速开始
 
-本教程按应用内的真实流程,带你从全新安装走到第一个已签名的 APK。
+本教程带你从全新安装走到第一个已签名的 APK。每一步都会说明应用在背后实际做了什么,让流程能从代码的角度理解。
 
-## 1. 安装 WebToApp
+## 1. 安装并启动
 
-在 **Android 6.0(API 23)或更高版本** 的设备上安装 WebToApp 构建器。首次启动会进入 **我的应用** —— 即列出你所创建的全部应用的主页。主界面导览见[主界面](/zh/guide/main-screen/my-apps)。
+在运行 **Android 6.0(API 23)或更高版本** 的设备上安装 WebToApp 构建器。
 
-## 2. 打开创建菜单
+启动时,`WebToAppApplication` 以 **构建器模式**(`SHELL_RUNTIME_ONLY = false`)启动:初始化 i18n 字符串、Room 数据库和依赖图,然后显示 **我的应用** —— 即列出你所创建的全部应用的主页。见[主界面](/zh/guide/main-screen/my-apps)。
 
-在 **我的应用** 底部,点击 **创建** 按钮。会展开一个 3 列网格的应用类型面板:
+## 2. 创建一个应用定义
+
+在 **我的应用** 底部,点击 **创建**。会展开一个面板,含 12 种[应用类型](/zh/guide/app-types/)的 3 列网格:
 
 **网页 · 多站点 · HTML · 离线包 · 前端 · PHP · WordPress · Node.js · Python · Go · 媒体 · 画廊**
 
-第一个应用,点击 **网页**。
+第一个应用点击 **网页**。网页编辑器打开。
 
 ## 3. 填写基本信息
 
-网页编辑器打开。填写顶部的 **基本信息** 卡片:
+填写顶部的 **基本信息** 卡片:
 
-- **应用名称** —— 随意
+- **应用名称**
 - **目标 URL** —— 例如 `https://example.com`
-- **图标** —— 选一张图片(可选,否则用类型专属默认图标)
+- **图标** —— 可选;否则用类型专属默认图标
 
-编辑器其余部分是一长串可选能力卡片(全屏、启动画面、去广告、DNS、指纹伪装等)。现在可以全部忽略 —— 会使用合理默认值。每一项都在[应用配置](/zh/guide/config/)中说明。
+编辑器其余部分是一长串可选能力卡片(全屏、启动画面、去广告、DNS、伪装……)。现在忽略它们 —— 会使用默认值。每一项都在[应用配置](/zh/guide/config/)中说明。
 
-点击 **保存**。你的应用现在出现在 **我的应用** 的列表中。
+点击 **保存**。在背后,编辑器组装一个 `WebApp` 对象(`appType = WEB`,带一个 `webViewConfig`),并写入 `web_apps` Room 表。你的应用现在出现在列表中。
 
 ## 4. 预览
 
-在 **我的应用** 中,点击你的应用卡片。WebToApp 会以预览方式启动它,行为与导出后完全一致。(改为点击卡片上的 ⋮ 按钮可打开操作菜单 —— 见[应用功能](/zh/guide/app-actions/edit-core-config)。)
+在 **我的应用** 中,点击你的应用卡片。预览路由检查应用的 `appType` 并启动对应的运行时:
+
+- `IMAGE` / `VIDEO` → 媒体播放器 activity
+- `GALLERY` → 画廊播放器 activity
+- 其他一切(包括 `WEB`)→ WebView activity
+
+对于网页应用,WebView activity 用你配置的设置加载你的 URL —— 与导出的应用将运行的代码相同。(改为点击卡片上的 ⋮ 按钮可打开[操作菜单](/zh/guide/app-actions/edit-core-config)。)
 
 ::: warning 预览 ≠ 导出
-预览和导出共享同一套运行时代码,但导出还会把你的配置序列化进生成的 APK。如果某功能预览正常、导出后失效,通常是某个配置字段没有贯通导出链路。见[配置字段漂移](/zh/developer/config-drift)。
+预览走 **宿主** 路径(一切都在构建器的 classpath 上)。导出走 **shell** 路径,从嵌入的 JSON 读取你的配置。如果某个配置字段没有走完这段旅程,功能可能预览正常、导出后却消失。见[配置字段漂移](/zh/developer/config-drift)。
 :::
 
 ## 5. 构建 APK
 
-回到 **我的应用**,点击应用卡片上的 ⋮ 按钮,再点 **构建 APK**。在对话框中你可以:
+点击应用卡片上的 ⋮,再点 **构建 APK**。在对话框中你可以:
 
 - 选择 **浏览器引擎**(系统 WebView 或 GeckoView),
 - 可选启用 **资源加密**、**隔离**、**后台运行** 和 **通知**,
 - 强制 **全量重建**(否则自动选择增量模式)。
 
-点击构建。WebToApp 修改 shell 模板、嵌入你的配置与内容并签名。完成后,APK 就绪。
+点击构建。`ApkBuilder` 取得 shell 模板 APK,修改其包名 / 图标 / 权限,把你的 `WebApp` 配置作为 `app_config.json` 嵌入,并签名(V1/V2/V3)。见[构建 APK](/zh/guide/app-actions/build-apk)。
 
-## 6. 找到并安装
+## 6. 安装
 
-从 **我的应用** 右上角打开 **⋮ → 文件管理**。你的构建产物就在那里 —— 安装到设备,或分享到另一台设备。启动它:它运行 shell 运行时,读取*你*嵌入的配置,独立于构建器。
+从我的应用右上角打开 **⋮ → [文件管理](/zh/guide/more-features/file-manager)**。你的 APK 就在那里 —— 安装或分享。启动它时,那个 APK 以 **shell 模式**(`SHELL_RUNTIME_ONLY = true`)运行:`ShellModeManager` 读取*你*嵌入的 `app_config.json` 并驱动运行时,完全独立于构建器。
 
 ## 下一步
 
 - 导览[主界面](/zh/guide/main-screen/my-apps)。
 - 了解每种[应用类型](/zh/guide/app-types/)能做什么。
-- 探索各应用[应用功能](/zh/guide/app-actions/edit-core-config)(快捷方式、分享、导出、AAB)。
+- 探索各应用[应用功能](/zh/guide/app-actions/edit-core-config)。
 - 打开右上角 **⋮** 菜单 —— 见[更多功能](/zh/guide/more-features/ai-coding)。
 
 ## 从源码构建

--- a/docs/zh/guide/introduction.md
+++ b/docs/zh/guide/introduction.md
@@ -1,34 +1,48 @@
 # 简介
 
-**WebToApp** 把网页项目变成独立、已签名的 Android APK —— 完全在手机上完成。它不是网址套壳,而是一个掌上 APK 工坊:能运行真实的服务端运行时、搭载加固的反审查网络栈、为 Google Play 签名打包、运行 MV3 浏览器扩展,全程无需电脑或远程构建服务器。
+WebToApp 是一个 Android 应用,它**在设备上**把网页项目变成可安装的 APK。本页从代码的角度说明它到底是什么,让你在上手前心里有数。
 
-## 它有何不同
+## 具体而言,这个应用是什么
 
-大多数"网址转 App"工具止步于把 URL 套进 WebView。WebToApp 恰恰在最难的地方另辟蹊径:
+WebToApp 的核心是管理一份**应用定义**列表。每个定义是一条 `WebApp` 记录,存储在本地 Room 数据库(`web_apps` 表)中。一个 `WebApp` 包含:
 
-- **在设备上运行真实的服务运行时。** Node.js、PHP、Python、Go、WordPress 作为原生二进制直接从应用存储 fork+exec —— 如同 Termux,但打包成可安装的 APK。网址套壳工具根本做不到。
-- **搭载加固网络栈。** DNS-over-HTTPS、带本地 MITM 桥的 TLS 指纹伪造(Chrome / Firefox / Safari JA3 模板)、GeckoView 引擎上的加密客户端 Hello(ECH)、按应用代理,以及针对受限 SPA 的 CORS 绕过。
-- **构建全程自包含。** 二进制 AXML/ARSC 打补丁、权限裁剪、V1/V2/V3 签名、Google Play 级 AAB 导出,全部通过 `apksig` 在应用内完成。
-- **发布后仍可扩展。** 添加 JS/CSS 模块、Tampermonkey 风格油猴脚本或 MV3 Chrome 扩展,无需重建宿主。
+- **身份** —— `name`、`url`、`iconPath`、`packageName`,以及一个 `appType`。
+- **类型专属配置** —— `mediaConfig`、`galleryConfig`、`htmlConfig`、`wordpressConfig`、`nodejsConfig`、`phpAppConfig`、`pythonAppConfig`、`goAppConfig` 或 `multiWebConfig` 之一,取决于类型。
+- **功能开关 + 配置** —— 激活、广告、公告、去广告、WebView 设置、启动画面、背景音乐、翻译、扩展、自启动、伪装,以及用于打包的 `apkExportConfig`。
 
-## 你能构建什么
+当你"构建"一个应用时,构建器取得 shell 模板 APK,修改其身份与资源,把你的 `WebApp` 配置作为 assets JSON 嵌入,并签名。产物是一个可安装或可分享的独立 APK。
 
-| 输入 | 输出 | 适用场景 |
-| --- | --- | --- |
-| 网站 URL | 基于 WebView 的 APK | 落地页、工具、仪表盘、文档、内部系统 |
-| HTML / 静态前端 | 本地托管的 APK | React、Vue、Vite、静态构建、离线 Web 应用 |
-| Node.js / PHP / Python / Go | 带设备端本地服务器的 APK | 小型服务端应用、管理工具、演示、原型 |
-| WordPress | 在本地 PHP + SQLite 上运行 WordPress 的 APK | 便携站点、主题/插件演示、内容打包 |
-| 图片 / 视频 / 图集 | 以媒体为核心的 APK | 相册、课程资料、作品集、离线查看器 |
-| 多个站点 | 标签/卡片/信息流/抽屉式多网站 APK | 链接枢纽、门户、应用合集 |
-| 已安装的 APK | 换壳克隆或快捷方式伪装 | 图标/名称/包名实验、重打包研究 |
+## 12 种应用类型
+
+`AppType` 枚举定义了一个应用可以是什么:
+
+`WEB` · `IMAGE` · `VIDEO` · `HTML` · `GALLERY` · `FRONTEND` · `WORDPRESS` · `NODEJS_APP` · `PHP_APP` · `PYTHON_APP` · `GO_APP` · `MULTI_WEB`
+
+网页类类型在 WebView 中加载 URL 或本地文件;运行时类型(`NODEJS_APP`、`PHP_APP`、`PYTHON_APP`、`GO_APP`、`WORDPRESS`)在设备上 fork 一个原生服务二进制,并把 WebView 指向本地端口;媒体类型(`IMAGE`、`VIDEO`、`GALLERY`)直接播放内容。每种见[创建应用](/zh/guide/app-types/)。
+
+## 一套代码,两种运行方式
+
+同一个 `WebToAppApplication` 以两种模式运行,由一个构建标志选择:
+
+- **构建器(宿主)** —— `SHELL_RUNTIME_ONLY = false`。这是你从商店安装的应用:编辑器、应用列表和导出管线,所有东西都在主 classpath 上。
+- **生成的应用(shell 运行时)** —— `SHELL_RUNTIME_ONLY = true`。导出的 APK 运行同步来的 shell 运行时,并通过 `ShellModeManager` 从 `app_config.json` 读取*你*嵌入的配置。Node.js 甚至运行在独立的 `:nodejs` 操作系统进程中。
+
+这正是"预览正常、导出失效"会成为真实故障模式的原因:预览走宿主路径,导出走 shell 路径,而配置字段必须在这两者之间存活下来。见[配置字段漂移](/zh/developer/config-drift)。
+
+## 各界面在哪里
+
+- [我的应用](/zh/guide/main-screen/my-apps) —— 主页:你的应用列表、分类和创建按钮。
+- [创建应用](/zh/guide/app-types/) —— 12 种应用类型及其创建流程。
+- [应用功能](/zh/guide/app-actions/edit-core-config) —— 每个应用能做什么(编辑、构建、分享、导出……)。
+- [更多功能](/zh/guide/more-features/ai-coding) —— 右上角 ⋮ 菜单后的全局工具。
+- [应用配置](/zh/guide/config/) —— 共享的按应用选项(网络、隐私、外观、运行时)。
 
 ## 如何阅读这些文档
 
-- **[使用手册](/zh/guide/getting-started)** —— 导览[主界面](/zh/guide/main-screen/my-apps)、构建第一个 APK、了解[应用类型](/zh/guide/app-types/)与[各应用操作](/zh/guide/app-actions/edit-core-config)、探索[更多功能菜单](/zh/guide/more-features/ai-coding),并在[应用配置](/zh/guide/config/)下配置应用。
-- **[开发者文档](/zh/developer/)** —— 代码如何组织、导出管线与 shell 同步如何工作,以及常见改动的配方。
-- **[扩展开发](/zh/extensions/)** —— 编写 JS/CSS 模块、油猴脚本和 MV3 Chrome 扩展,并发布到应用内市场。
+- **[开始](/zh/guide/getting-started)** —— 构建第一个 APK 并导览主界面。
+- **[开发者文档](/zh/developer/)** —— 代码库布局、导出管线、shell 同步和改动配方。
+- **[扩展开发](/zh/extensions/)** —— 编写 JS/CSS 模块、油猴脚本和 MV3 Chrome 扩展。
 
 ::: tip
-宿主应用界面提供 10 种语言,可在 **我的应用顶栏的语言按钮** 中随时切换。你*生成*的应用的语言则按应用单独配置。
+构建器界面提供 10 种语言 —— 从顶栏的[语言按钮](/zh/guide/main-screen/language)切换。你*生成*的应用的语言按应用配置。
 :::


### PR DESCRIPTION
## Summary

Closes #310.

Reworks the two orientation pages so they are grounded in the **actual code** rather than README marketing copy, and fixes the sidebar group name overlap.

## Changes

**Sidebar group rename**
- `Getting Started` → `Start` (EN), `入门` → `开始` (ZH) — no longer overlaps with the Getting Started page.

**`introduction.md` (EN + ZH), rewritten from code:**
- What a `WebApp` record actually is — Room `web_apps` table; identity + type-specific config + feature flags.
- The real `AppType` enum (12 values: WEB, IMAGE, VIDEO, HTML, GALLERY, FRONTEND, WORDPRESS, NODEJS_APP, PHP_APP, PYTHON_APP, GO_APP, MULTI_WEB).
- The one-codebase/two-modes architecture: `SHELL_RUNTIME_ONLY = false` builder vs `= true` shell runtime reading `app_config.json` via `ShellModeManager` (and the `:nodejs` subprocess).

**`getting-started.md` (EN + ZH), rewritten to explain the code at each step:**
- Builder-mode startup (`WebToAppApplication`).
- Saving a `WebApp` to Room on Save.
- Preview routing by `appType` (WebView vs media-player vs gallery activity).
- `ApkBuilder` patching the shell template + embedding config + signing.
- Shell-mode launch reading `app_config.json`.

## Verification

- `npm run build` ✅ — no dead-link errors.