### PR TITLE
docs(guide): expand the FAQ into categorized, code-grounded Q&A

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,34 +1,143 @@
 # FAQ
 
-## Is WebToApp free?
+Practical questions, organized by topic. For full detail, follow the links.
+
+## Basics
+
+### Is WebToApp free?
 
 Yes. WebToApp is open source under [The Unlicense](https://github.com/shiaho777/web-to-app/blob/main/LICENSE).
 
-## What Android version do I need?
+### What Android version do I need?
 
 Android 6.0 (API 23) or newer.
 
-## Do I need a PC to build apps?
+### Do I need a PC to build apps?
 
 No. The entire build — binary patching, signing, and AAB export — happens on-device. A PC is only needed if you want to build WebToApp itself from source.
 
-## Why do generated apps target SDK 28?
+### How is this different from a URL-wrapper app?
 
-The low `targetSdk` is deliberate: it lets generated apps fork+exec native runtimes (Node.js, PHP, Python, Go, WordPress) from app storage. The AAB exporter separately rewrites `targetSdk` for Play Store distribution.
+A URL wrapper just opens a website in a WebView. WebToApp additionally runs **real server runtimes on-device** (Node.js, PHP, Python, Go, WordPress via fork+exec), ships a hardened network stack (DoH, TLS fingerprint, ECH), patches and signs APKs at the binary level, and supports modules/userscripts/MV3 extensions — all without a PC or remote build server.
 
-## A feature works in preview but not after export. Why?
+### What app types can I create?
 
-Usually a config field did not flow through the export chain (model → `ApkConfig` JSON → shell config → runtime). See [Config Field Drift](/developer/config-drift) for the diagnosis checklist.
+Twelve: Web, Multi-Web, HTML, Offline Pack, Frontend, PHP, WordPress, Node.js, Python, Go, Media, and Gallery. See [Create App](/guide/app-types/).
 
-## Can I run browser extensions?
+## Creating & editing
 
-Yes. WebToApp supports built-in JS/CSS modules, Tampermonkey-style userscripts, and MV3 Chrome extensions. The **Browser Extensions** tab searches the Chrome Web Store live. See [Extension Authoring](/extensions/).
+### What's the difference between Edit Core Config and Edit Common Config?
 
-## How do I publish a module to the market?
+- **Edit Core Config** — the type-specific source/runtime settings (different for each app type). See [Edit Core Config](/guide/app-actions/edit-core-config).
+- **Edit Common Config** — the shared options every app has (appearance, networking, privacy, extensions, export). See [Edit Common Config](/guide/app-actions/edit-common-config/).
+
+Web apps have a single combined **Edit** entry instead of the two.
+
+### What's the difference between preview and export?
+
+**Preview** runs the host path (everything on the builder's classpath). **Export** builds a standalone APK that runs the shell runtime, reading your config from an embedded `app_config.json`. See [Getting Started](/guide/getting-started).
+
+## Building & export
+
+### What are the build modes (FULL / CONTENT_OVERLAY / REUSE_UNSIGNED)?
+
+Rebuilds are incremental and content-addressed:
+
+- `FULL` — rebuild from the template (always used for encrypted builds).
+- `CONTENT_OVERLAY` — only app content changed.
+- `REUSE_UNSIGNED` — re-sign a previously built unsigned APK.
+
+See [Build APK](/guide/app-actions/build-apk).
+
+### What's the difference between APK and AAB export?
+
+**Build APK** produces an installable, signed APK. **AAB export** (from [Google Play](/guide/more-features/google-play)) produces a Play-ready bundle and rewrites `targetSdk` to the Play-required level. See [APK Export Config](/guide/app-actions/edit-common-config/apk-export).
+
+### Why do generated apps target SDK 28?
+
+The low `targetSdk` is deliberate: it lets generated apps fork+exec native runtimes (Node.js, PHP, Python, Go, WordPress) from app storage. The AAB exporter separately rewrites `targetSdk` for Play distribution.
+
+### How do I sign with my own key?
+
+Create or import a keystore (PKCS12/PFX/JKS/BKS) and choose the signature schemes (V1/V2/V3) in [APK Export Config](/guide/app-actions/edit-common-config/apk-export).
+
+### Where are build outputs stored?
+
+In the [File Manager](/guide/more-features/file-manager) — APK builds, AAB exports, app clones, and build logs.
+
+## Runtimes
+
+### Why does my Node/PHP/Python/Go app download something on first use?
+
+The runtime binaries aren't bundled into the base app to keep it small; they're downloaded once on first use and cached. Manage them in [Runtime Management](/guide/more-features/runtime-management) and the [Linux Environment](/guide/more-features/linux-environment).
+
+### My Node.js app fails with a `loadNode` / `loadJniBridge` error. Why?
+
+The exported APK must embed `libnode_bridge.so`, `libnode.so` (16KB-aligned), and `libc++_shared.so`. A missing native library causes this failure. See the [Node.js](/guide/app-types/nodejs) export requirements.
+
+### How are ports managed? What if there's a conflict?
+
+Runtime apps allocate ports through the [Port Manager](/guide/more-features/port-manager) with a conflict policy: `REASSIGN` (pick another port), `AUTO_KILL` (stop the conflicting service), or `ALERT` (notify).
+
+### Why does my runtime app need a DNS bridge?
+
+The packed native binaries (musl-based) can't always reach the system DNS resolver, so a local DNS bridge proxy provides DNS resolution and outbound HTTP. This is wired automatically.
+
+## Features & config
+
+### How do I make my app fullscreen or hide the status bar?
+
+Use [Fullscreen Mode](/guide/app-actions/edit-common-config/fullscreen) — it controls immersive mode and whether the status/navigation bars stay visible.
+
+### How does ad blocking work in exported apps?
+
+The host ad blocker serves preview, and the compiled rule set ships inside the exported APK. Configure rules/subscriptions per app under [Ad Blocking](/guide/app-actions/edit-common-config/ad-blocking); manage lists in [Hosts Ad Blocking](/guide/more-features/hosts-adblock).
+
+### How do I use a custom DNS or DNS-over-HTTPS?
+
+See [Custom DNS](/guide/app-actions/edit-common-config/custom-dns) — choose a DoH provider (Cloudflare, Google, AdGuard, NextDNS, CleanBrowsing, Quad9, Mullvad) or a custom endpoint.
+
+## Extensions
+
+### What's the difference between modules, userscripts, and MV3 extensions?
+
+- **JS/CSS modules** — WebToApp's native format with a config UI and panel. See [JS Modules](/extensions/js-module).
+- **Userscripts** — Tampermonkey/Greasemonkey-style `.user.js` with `GM_*` APIs. See [Userscripts](/extensions/userscript).
+- **MV3 extensions** — Chrome Manifest V3 extensions with `chrome.*` APIs. See [Chrome MV3](/extensions/chrome-mv3).
+
+### Are userscript `GM_*` functions gated by `@grant`?
+
+No. `@grant` declarations are parsed and listed in `GM_info`, but all `GM_*` functions are exposed unconditionally. Declare grants anyway for portability with real Tampermonkey/Greasemonkey. See the [API Reference](/extensions/api-reference).
+
+### Do MV3 extensions run in a truly isolated world?
+
+No. Android WebView has a single JavaScript context; `ISOLATED` and `MAIN` worlds are simulated (each extension overwrites `globalThis.chrome`). See [Chrome MV3](/extensions/chrome-mv3).
+
+### How do I publish a module to the market?
 
 Add a folder under `modules/`, update `registry.json`, and open a pull request. See [Publish to the Market](/extensions/publish).
 
-## Where do I get help?
+## Troubleshooting
+
+### A feature works in preview but not after export. Why?
+
+Usually a config field did not flow through the export chain (model → `ApkConfig` JSON → shell config → runtime). See [Config Field Drift](/developer/config-drift) for the diagnosis checklist.
+
+### My build failed. Where do I look?
+
+The build dialog shows a diagnostic report (failure stage, cause, and the build-log tail) that you can copy. Build logs are also viewable in the [File Manager](/guide/more-features/file-manager).
+
+### My exported app can't reach the network. What should I check?
+
+Check the app's [Custom DNS](/guide/app-actions/edit-common-config/custom-dns) and proxy settings under [Advanced Settings](/guide/app-actions/edit-common-config/advanced-settings). For runtime apps, the local DNS bridge handles resolution automatically.
+
+## Data & help
+
+### How do I back up or migrate my apps?
+
+Use **Data backup / restore** in [About](/guide/more-features/about), or export individual apps as reusable templates via [Export](/guide/app-actions/export-apk).
+
+### Where do I get help?
 
 - GitHub: [github.com/shiaho777/web-to-app](https://github.com/shiaho777/web-to-app)
 - Telegram: [t.me/webtoapp777](https://t.me/webtoapp777)

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -1,34 +1,143 @@
 # 常见问题
 
-## WebToApp 免费吗?
+按主题组织的实用问答。要看完整细节,点链接。
+
+## 基础
+
+### WebToApp 免费吗?
 
 是的。WebToApp 以 [The Unlicense](https://github.com/shiaho777/web-to-app/blob/main/LICENSE) 开源。
 
-## 需要什么 Android 版本?
+### 需要什么 Android 版本?
 
 Android 6.0(API 23)或更高。
 
-## 构建应用需要电脑吗?
+### 构建应用需要电脑吗?
 
 不需要。整个构建 —— 二进制打补丁、签名、AAB 导出 —— 都在设备上完成。只有当你想从源码构建 WebToApp 本身时才需要电脑。
 
-## 为什么生成的应用 targetSdk 是 28?
+### 这和网址套壳应用有什么不同?
 
-较低的 `targetSdk` 是刻意为之:它让生成的应用能从应用存储 fork+exec 原生运行时(Node.js、PHP、Python、Go、WordPress)。AAB 导出器会单独为 Play 商店分发重写 `targetSdk`。
+网址套壳只是在 WebView 里打开网站。WebToApp 额外在**设备上运行真实的服务运行时**(Node.js、PHP、Python、Go、WordPress,经 fork+exec)、搭载加固网络栈(DoH、TLS 指纹、ECH)、在二进制层面修改并签名 APK,并支持模块/油猴脚本/MV3 扩展 —— 全程无需电脑或远程构建服务器。
 
-## 某功能预览正常,导出后失效,为什么?
+### 能创建哪些应用类型?
 
-通常是某个配置字段没有贯通导出链路(模型 → `ApkConfig` JSON → shell 配置 → 运行时)。诊断清单见[配置字段漂移](/zh/developer/config-drift)。
+12 种:网页、多站点、HTML、离线包、前端、PHP、WordPress、Node.js、Python、Go、媒体和画廊。见[创建应用](/zh/guide/app-types/)。
 
-## 能运行浏览器扩展吗?
+## 创建与编辑
 
-能。WebToApp 支持内置 JS/CSS 模块、Tampermonkey 风格油猴脚本和 MV3 Chrome 扩展。**浏览器扩展** 标签页可实时搜索 Chrome 网上应用店。见[扩展开发](/zh/extensions/)。
+### 编辑核心配置和编辑通用配置有什么区别?
 
-## 如何把模块发布到市场?
+- **编辑核心配置** —— 类型专属的来源/运行时设置(每种应用类型都不同)。见[编辑核心配置](/zh/guide/app-actions/edit-core-config)。
+- **编辑通用配置** —— 每个应用都有的共享选项(外观、网络、隐私、扩展、导出)。见[编辑通用配置](/zh/guide/app-actions/edit-common-config/)。
+
+网页应用没有这两项,而是单一的合并 **编辑** 入口。
+
+### 预览和导出有什么区别?
+
+**预览** 走宿主路径(一切都在构建器的 classpath 上)。**导出** 构建一个独立 APK,运行 shell 运行时,从嵌入的 `app_config.json` 读取你的配置。见[快速开始](/zh/guide/getting-started)。
+
+## 构建与导出
+
+### 构建模式(FULL / CONTENT_OVERLAY / REUSE_UNSIGNED)是什么?
+
+重建是增量且内容寻址的:
+
+- `FULL` —— 从模板重建(加密构建恒用)。
+- `CONTENT_OVERLAY` —— 仅应用内容变化。
+- `REUSE_UNSIGNED` —— 对先前构建的未签名 APK 重新签名。
+
+见[构建 APK](/zh/guide/app-actions/build-apk)。
+
+### APK 导出和 AAB 导出有什么区别?
+
+**构建 APK** 产生一个可安装的已签名 APK。**AAB 导出**(从 [Google Play](/zh/guide/more-features/google-play))产生 Play 级打包,并把 `targetSdk` 重写到 Play 要求的级别。见 [APK导出配置](/zh/guide/app-actions/edit-common-config/apk-export)。
+
+### 为什么生成的应用 targetSdk 是 28?
+
+较低的 `targetSdk` 是刻意为之:它让生成的应用能从应用存储 fork+exec 原生运行时(Node.js、PHP、Python、Go、WordPress)。AAB 导出器会单独为 Play 分发重写 `targetSdk`。
+
+### 如何用自己的密钥签名?
+
+创建或导入密钥库(PKCS12/PFX/JKS/BKS),并在 [APK导出配置](/zh/guide/app-actions/edit-common-config/apk-export)中选择签名方案(V1/V2/V3)。
+
+### 构建产物存在哪里?
+
+在[文件管理](/zh/guide/more-features/file-manager)中 —— APK 构建、AAB 导出、应用克隆和构建日志。
+
+## 运行时
+
+### 为什么我的 Node/PHP/Python/Go 应用首次使用要下载东西?
+
+为了让基础应用保持小巧,运行时二进制不打包进去;它们在首次使用时下载一次并缓存。在[运行时管理](/zh/guide/more-features/runtime-management)和 [Linux 环境](/zh/guide/more-features/linux-environment)中管理。
+
+### 我的 Node.js 应用报 `loadNode` / `loadJniBridge` 错误,为什么?
+
+导出的 APK 必须嵌入 `libnode_bridge.so`、`libnode.so`(16KB 对齐)和 `libc++_shared.so`。缺少原生库会导致此失败。见 [Node.js](/zh/guide/app-types/nodejs) 的导出要求。
+
+### 端口如何管理?冲突了怎么办?
+
+运行时应用通过[端口管理](/zh/guide/more-features/port-manager)以冲突策略分配端口:`REASSIGN`(选另一个端口)、`AUTO_KILL`(停止冲突服务)或 `ALERT`(通知)。
+
+### 为什么我的运行时应用需要 DNS 桥?
+
+打包的原生二进制(基于 musl)不一定能触达系统 DNS 解析器,因此一个本地 DNS 桥代理提供 DNS 解析和出站 HTTP。这是自动接好的。
+
+## 功能与配置
+
+### 如何让应用全屏或隐藏状态栏?
+
+用[全屏模式](/zh/guide/app-actions/edit-common-config/fullscreen)—— 它控制沉浸式模式以及状态栏/导航栏是否保持可见。
+
+### 导出的应用里去广告如何工作?
+
+宿主去广告器服务预览,编译后的规则集随导出的 APK 一起发布。在[广告拦截](/zh/guide/app-actions/edit-common-config/ad-blocking)中按应用配置规则/订阅;在 [Hosts 拦截](/zh/guide/more-features/hosts-adblock)中管理列表。
+
+### 如何使用自定义 DNS 或 DNS-over-HTTPS?
+
+见[自定义DNS](/zh/guide/app-actions/edit-common-config/custom-dns)—— 选择 DoH 提供商(Cloudflare、Google、AdGuard、NextDNS、CleanBrowsing、Quad9、Mullvad)或自定义端点。
+
+## 扩展
+
+### 模块、油猴脚本和 MV3 扩展有什么区别?
+
+- **JS/CSS 模块** —— WebToApp 的原生格式,带配置 UI 和面板。见 [JS 模块](/zh/extensions/js-module)。
+- **油猴脚本** —— Tampermonkey/Greasemonkey 风格的 `.user.js`,带 `GM_*` API。见[油猴脚本](/zh/extensions/userscript)。
+- **MV3 扩展** —— Chrome Manifest V3 扩展,带 `chrome.*` API。见 [Chrome MV3](/zh/extensions/chrome-mv3)。
+
+### 油猴脚本的 `GM_*` 函数按 `@grant` 门控吗?
+
+不。`@grant` 声明会被解析并列入 `GM_info`,但所有 `GM_*` 函数都无条件暴露。为了与真正的 Tampermonkey/Greasemonkey 保持可移植性,仍应声明 grant。见 [API 参考](/zh/extensions/api-reference)。
+
+### MV3 扩展运行在真正隔离的 world 中吗?
+
+不。Android WebView 只有单一 JavaScript 上下文;`ISOLATED` 和 `MAIN` world 是模拟的(每个扩展覆盖 `globalThis.chrome`)。见 [Chrome MV3](/zh/extensions/chrome-mv3)。
+
+### 如何把模块发布到市场?
 
 在 `modules/` 下添加一个文件夹,更新 `registry.json`,然后开一个 pull request。见[发布到市场](/zh/extensions/publish)。
 
-## 去哪里获取帮助?
+## 故障排除
+
+### 某功能预览正常,导出后失效,为什么?
+
+通常是某个配置字段没有贯通导出链路(模型 → `ApkConfig` JSON → shell 配置 → 运行时)。诊断清单见[配置字段漂移](/zh/developer/config-drift)。
+
+### 构建失败了,去哪里看?
+
+构建对话框会显示一份诊断报告(失败阶段、原因和构建日志尾部),可复制。构建日志也可在[文件管理](/zh/guide/more-features/file-manager)中查看。
+
+### 我导出的应用连不上网,该检查什么?
+
+检查应用的[自定义DNS](/zh/guide/app-actions/edit-common-config/custom-dns)和[高级设置](/zh/guide/app-actions/edit-common-config/advanced-settings)中的代理设置。对于运行时应用,本地 DNS 桥会自动处理解析。
+
+## 数据与帮助
+
+### 如何备份或迁移我的应用?
+
+使用[关于](/zh/guide/more-features/about)中的 **数据备份 / 恢复**,或通过[导出](/zh/guide/app-actions/export-apk)把单个应用导出为可复用模板。
+
+### 去哪里获取帮助?
 
 - GitHub:[github.com/shiaho777/web-to-app](https://github.com/shiaho777/web-to-app)
 - Telegram:[t.me/webtoapp777](https://t.me/webtoapp777)


### PR DESCRIPTION
## Summary

Closes #317.

Rewrites the FAQ from 8 flat questions into **8 categorized sections** with ~25 practical questions (bilingual): Basics · Creating & editing · Building & export · Runtimes · Features & config · Extensions · Troubleshooting · Data & help.

## Grounding

Answers reflect the actual code, not marketing: build modes (`FULL`/`CONTENT_OVERLAY`/`REUSE_UNSIGNED`), the native libs behind `loadNode`/`loadJniBridge` errors, `PortManager` conflict policies, the dual-mode (preview vs export) architecture, and the extension accuracy notes (`GM_*` not grant-gated; no real MV3 world isolation). Each links to the relevant detail page.

## Verification

- `npm run build` ✅ — no dead-link errors.