### PR TITLE
fix(webview): make site location/camera/mic access work in generated apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,10 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
+    <!-- ====== 定位（宿主使用：预览需要地理位置的网站，与生成的 APK 保持一致）====== -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <!-- ====== WiFi（宿主使用：网络状态查询、WiFi 扫描；写权限留给子 APK 注入）====== -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3550,7 +3550,8 @@ private fun WebApp.buildWebViewBehaviorBlock(): WebViewBehaviorBlock = WebViewBe
         (apkExportConfig?.let {
             it.notificationEnabled && it.notificationConfig?.type?.key == "web_api"
         } == true),
-    geolocationEnabled = webViewConfig.geolocationEnabled,
+    geolocationEnabled = webViewConfig.geolocationEnabled ||
+        (apkExportConfig?.runtimePermissions?.location == true),
     geolocationAccuracy = webViewConfig.geolocationAccuracy.name,
     geolocationPolicy = webViewConfig.geolocationPolicy.name,
     enableOrientationPolyfill = webViewConfig.enableOrientationPolyfill,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4605,6 +4605,10 @@ object Strings {
     val notificationPolyfillDesc: String get() = StringsE.notificationPolyfillDesc
     val geolocationTitle: String get() = StringsE.geolocationTitle
     val geolocationDesc: String get() = StringsE.geolocationDesc
+    val cameraAccessTitle: String get() = StringsE.cameraAccessTitle
+    val cameraAccessDesc: String get() = StringsE.cameraAccessDesc
+    val microphoneAccessTitle: String get() = StringsE.microphoneAccessTitle
+    val microphoneAccessDesc: String get() = StringsE.microphoneAccessDesc
     val geolocationLocationOffTitle: String get() = StringsE.geolocationLocationOffTitle
     val geolocationLocationOffMessage: String get() = StringsE.geolocationLocationOffMessage
     val geolocationLocationOffOpenSettings: String get() = StringsE.geolocationLocationOffOpenSettings
@@ -62036,6 +62040,54 @@ object StringsE {
         AppLanguage.RUSSIAN -> "Разрешить веб-страницам запрашивать местоположение устройства. Если выключено, запросы местоположения отклоняются автоматически."
         AppLanguage.JAPANESE -> "ウェブページがデバイスの位置情報を要求することを許可します。オフの場合、位置情報リクエストは自動的に拒否されます。"
         AppLanguage.KOREAN -> "웹페이지가 기기 위치를 요청하도록 허용합니다. 끄면 위치 요청이 자동으로 거부됩니다."
+    }
+    val cameraAccessTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "摄像头访问"
+        AppLanguage.ENGLISH -> "Camera access"
+        AppLanguage.ARABIC -> "الوصول إلى الكاميرا"
+        AppLanguage.PORTUGUESE -> "Acesso à câmera"
+        AppLanguage.SPANISH -> "Acceso a la cámara"
+        AppLanguage.FRENCH -> "Accès à la caméra"
+        AppLanguage.GERMAN -> "Kamerazugriff"
+        AppLanguage.RUSSIAN -> "Доступ к камере"
+        AppLanguage.JAPANESE -> "カメラアクセス"
+        AppLanguage.KOREAN -> "카메라 액세스"
+    }
+    val cameraAccessDesc: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "允许网页访问摄像头（如视频验证、扫码、拍照）。仍会弹出系统权限请求。"
+        AppLanguage.ENGLISH -> "Allow web pages to access the camera (e.g. video verification, QR scanning, photo capture). The system permission prompt still applies."
+        AppLanguage.ARABIC -> "السماح لصفحات الويب بالوصول إلى الكاميرا (مثل التحقق بالفيديو، مسح رمز QR، التقاط الصور). يظل طلب إذن النظام ساريًا."
+        AppLanguage.PORTUGUESE -> "Permitir que páginas web acessem a câmera (ex.: verificação por vídeo, leitura de QR, captura de fotos). O prompt de permissão do sistema ainda se aplica."
+        AppLanguage.SPANISH -> "Permitir que las páginas web accedan a la cámara (p. ej., verificación por vídeo, escaneo QR, captura de fotos). El aviso de permiso del sistema sigue aplicándose."
+        AppLanguage.FRENCH -> "Autoriser les pages web à accéder à la caméra (ex. : vérification vidéo, scan QR, capture de photos). L'invite d'autorisation système s'applique toujours."
+        AppLanguage.GERMAN -> "Webseiten erlauben, auf die Kamera zuzugreifen (z. B. Video-Verifizierung, QR-Scan, Fotoaufnahme). Die System-Berechtigungsabfrage gilt weiterhin."
+        AppLanguage.RUSSIAN -> "Разрешить веб-страницам доступ к камере (например, видеопроверка, сканирование QR, съёмка фото). Системный запрос разрешения по-прежнему применяется."
+        AppLanguage.JAPANESE -> "ウェブページがカメラにアクセスすることを許可します（動画認証、QRスキャン、写真撮影など）。システムの権限確認は引き続き表示されます。"
+        AppLanguage.KOREAN -> "웹페이지가 카메라에 액세스하도록 허용합니다(예: 영상 인증, QR 스캔, 사진 촬영). 시스템 권한 안내는 계속 표시됩니다."
+    }
+    val microphoneAccessTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "麦克风访问"
+        AppLanguage.ENGLISH -> "Microphone access"
+        AppLanguage.ARABIC -> "الوصول إلى الميكروفون"
+        AppLanguage.PORTUGUESE -> "Acesso ao microfone"
+        AppLanguage.SPANISH -> "Acceso al micrófono"
+        AppLanguage.FRENCH -> "Accès au microphone"
+        AppLanguage.GERMAN -> "Mikrofonzugriff"
+        AppLanguage.RUSSIAN -> "Доступ к микрофону"
+        AppLanguage.JAPANESE -> "マイクアクセス"
+        AppLanguage.KOREAN -> "마이크 액세스"
+    }
+    val microphoneAccessDesc: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "允许网页访问麦克风（如语音/视频通话、实时验证）。仍会弹出系统权限请求。"
+        AppLanguage.ENGLISH -> "Allow web pages to access the microphone (e.g. voice/video calls, live verification). The system permission prompt still applies."
+        AppLanguage.ARABIC -> "السماح لصفحات الويب بالوصول إلى الميكروفون (مثل المكالمات الصوتية/المرئية، التحقق المباشر). يظل طلب إذن النظام ساريًا."
+        AppLanguage.PORTUGUESE -> "Permitir que páginas web acessem o microfone (ex.: chamadas de voz/vídeo, verificação ao vivo). O prompt de permissão do sistema ainda se aplica."
+        AppLanguage.SPANISH -> "Permitir que las páginas web accedan al micrófono (p. ej., llamadas de voz/vídeo, verificación en vivo). El aviso de permiso del sistema sigue aplicándose."
+        AppLanguage.FRENCH -> "Autoriser les pages web à accéder au microphone (ex. : appels vocaux/vidéo, vérification en direct). L'invite d'autorisation système s'applique toujours."
+        AppLanguage.GERMAN -> "Webseiten erlauben, auf das Mikrofon zuzugreifen (z. B. Sprach-/Videoanrufe, Live-Verifizierung). Die System-Berechtigungsabfrage gilt weiterhin."
+        AppLanguage.RUSSIAN -> "Разрешить веб-страницам доступ к микрофону (например, голосовые/видеозвонки, живая проверка). Системный запрос разрешения по-прежнему применяется."
+        AppLanguage.JAPANESE -> "ウェブページがマイクにアクセスすることを許可します（音声/ビデオ通話、ライブ認証など）。システムの権限確認は引き続き表示されます。"
+        AppLanguage.KOREAN -> "웹페이지가 마이크에 액세스하도록 허용합니다(예: 음성/영상 통화, 실시간 인증). 시스템 권한 안내는 계속 표시됩니다."
     }
     val geolocationLocationOffTitle: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "位置服务未开启"

--- a/app/src/main/java/com/webtoapp/data/model/RuntimePermissionSync.kt
+++ b/app/src/main/java/com/webtoapp/data/model/RuntimePermissionSync.kt
@@ -133,10 +133,19 @@ fun WebApp.withRuntimePermissionsSyncedFromFeatures(): WebApp {
     val required = featureRequiredRuntimePermissions()
     val currentExport = apkExportConfig ?: ApkExportConfig()
     val merged = currentExport.runtimePermissions.enableFrom(required)
-    if (merged == currentExport.runtimePermissions && apkExportConfig != null) {
+    // Location coherence (issue #292): granting the location permission implies the
+    // WebView geolocation API should be enabled. The reverse direction (geolocationEnabled
+    // -> location permission) is already handled by featureRequiredRuntimePermissions above.
+    val effectiveGeolocation = webViewConfig.geolocationEnabled || merged.location
+    val permissionsChanged = merged != currentExport.runtimePermissions || apkExportConfig == null
+    val geolocationChanged = effectiveGeolocation != webViewConfig.geolocationEnabled
+    if (!permissionsChanged && !geolocationChanged) {
         return this
     }
-    return copy(apkExportConfig = currentExport.copy(runtimePermissions = merged))
+    return copy(
+        apkExportConfig = currentExport.copy(runtimePermissions = merged),
+        webViewConfig = webViewConfig.copy(geolocationEnabled = effectiveGeolocation)
+    )
 }
 
 fun ApkExportConfig.withRuntimePermissionsSyncedFromFeatures(

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -533,7 +533,17 @@ fun CreateAppScreen(
             item {
                 SpecialSettingsCard(
                     config = editState.webViewConfig,
-                    onConfigChange = { viewModel.updateEditState { copy(webViewConfig = it) } }
+                    onConfigChange = { viewModel.updateEditState { copy(webViewConfig = it) } },
+                    runtimePermissions = editState.apkExportConfig?.runtimePermissions
+                        ?: com.webtoapp.data.model.ApkRuntimePermissions(),
+                    onRuntimePermissionsChange = { rp ->
+                        viewModel.updateEditState {
+                            copy(
+                                apkExportConfig = (apkExportConfig ?: com.webtoapp.data.model.ApkExportConfig())
+                                    .copy(runtimePermissions = rp)
+                            )
+                        }
+                    }
                 )
             }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -3059,6 +3059,8 @@ fun ErrorPageConfigCard(
 fun SpecialSettingsCard(
     config: com.webtoapp.data.model.WebViewConfig,
     onConfigChange: (com.webtoapp.data.model.WebViewConfig) -> Unit,
+    runtimePermissions: com.webtoapp.data.model.ApkRuntimePermissions,
+    onRuntimePermissionsChange: (com.webtoapp.data.model.ApkRuntimePermissions) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -3511,6 +3513,26 @@ fun SpecialSettingsCard(
                                     label = { Text(Strings.nativeBridgeCapsPrint) }
                                 )
                             }
+                        }
+
+                        WtaSettingCard {
+                            WtaToggleRow(
+                                title = Strings.cameraAccessTitle,
+                                subtitle = Strings.cameraAccessDesc,
+                                icon = Icons.Outlined.PhotoCamera,
+                                checked = runtimePermissions.camera,
+                                onCheckedChange = { onRuntimePermissionsChange(runtimePermissions.copy(camera = it)) }
+                            )
+                        }
+
+                        WtaSettingCard {
+                            WtaToggleRow(
+                                title = Strings.microphoneAccessTitle,
+                                subtitle = Strings.microphoneAccessDesc,
+                                icon = Icons.Outlined.Mic,
+                                checked = runtimePermissions.microphone,
+                                onCheckedChange = { onRuntimePermissionsChange(runtimePermissions.copy(microphone = it)) }
+                            )
                         }
 
                         SpecialAdvancedRow(

--- a/app/src/test/java/com/webtoapp/data/model/RuntimePermissionSyncTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/RuntimePermissionSyncTest.kt
@@ -109,4 +109,29 @@ class RuntimePermissionSyncTest {
         assertThat(reasons["foregroundService"]).contains(PermissionFeatureReason.BACKGROUND_RUN)
         assertThat(reasons["wakeLock"]).contains(PermissionFeatureReason.BACKGROUND_RUN)
     }
+
+    @Test
+    fun `location permission implies geolocation enabled`() {
+        val app = WebApp(
+            name = "Loc",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(
+                runtimePermissions = ApkRuntimePermissions(location = true)
+            )
+        )
+        val synced = app.withRuntimePermissionsSyncedFromFeatures()
+        assertThat(synced.webViewConfig.geolocationEnabled).isTrue()
+    }
+
+    @Test
+    fun `geolocation enabled implies location permission`() {
+        val app = WebApp(
+            name = "Geo",
+            url = "https://example.com",
+            webViewConfig = WebViewConfig(geolocationEnabled = true)
+        )
+        val synced = app.withRuntimePermissionsSyncedFromFeatures()
+        assertThat(synced.apkExportConfig?.runtimePermissions?.location).isTrue()
+        assertThat(synced.webViewConfig.geolocationEnabled).isTrue()
+    }
 }


### PR DESCRIPTION
Fixes #292

## User-visible effect

Websites that need **location**, **camera**, or **microphone** (e.g. live-video verification) now work in generated APKs instead of silently failing.

- The **permission screen's "location" toggle now actually works** — previously it only added the manifest permission without turning on the WebView geolocation API, so location still failed.
- Two new toggles appear in the WebView feature cards (above the Geolocation row): **Camera access** and **Microphone access**. Enabling them lets sites use `getUserMedia` (the normal system permission prompt still applies).

## Root cause

The runtime permission handling (`onPermissionRequest` for camera/mic, `onGeolocationPermissionsShowPrompt` for location) was already correct in both preview and shell. The failure was in the export/manifest/config layer:

1. **Location had two disconnected controls.** `setGeolocationEnabled(config.geolocationEnabled)` (`WebViewManager.kt:1383`) is the WebView geolocation gate and only honors `webViewConfig.geolocationEnabled`. The permission screen's "location" toggle only set `runtimePermissions.location` (manifest permission), never the WebView API — so enabling it did nothing.
2. **Camera/microphone had no discoverable enable path.** `featureRequiredRuntimePermissions` never sets `microphone`, and `camera` only via the BlackTech flashlight. Without the manifest permission, Android silently denies `getUserMedia` (no dialog), so sites couldn't access camera/mic.

## Change

- `ApkBuilder.kt` — at export, derive `geolocationEnabled = webViewConfig.geolocationEnabled || runtimePermissions.location`, so granting the location permission always enables the WebView geolocation API (also covers legacy apps).
- `RuntimePermissionSync.kt` — `withRuntimePermissionsSyncedFromFeatures` now keeps `runtimePermissions.location` and `webViewConfig.geolocationEnabled` coherent in both directions (monotonic/idempotent).
- `AndroidManifest.xml` (host) — add `ACCESS_FINE/COARSE_LOCATION` so the builder's own preview can grant location, matching the existing `CAMERA`/`RECORD_AUDIO` declarations.
- `Strings.kt` — new `cameraAccessTitle/Desc` and `microphoneAccessTitle/Desc` in all 10 languages + facade delegates.
- `CreateAppWebViewCards.kt` / `CreateAppScreen.kt` — Camera access and Microphone access toggles in the WebView feature cards, wired to `runtimePermissions.camera/microphone` (the same source the permission screen uses; no duplicate state). No shell config field is needed for these — they have no WebView API, only manifest permissions, which the existing `buildRequiredPermissions` path injects.
- `RuntimePermissionSyncTest.kt` — two new tests for the location coherence.

Net: 7 files, +127 / −4.

## Testing

- `./gradlew :app:compileDebugKotlin -x syncCloneHostDex` → BUILD SUCCESSFUL.
- `./gradlew :app:testDebugUnitTest --tests "com.webtoapp.data.model.RuntimePermissionSyncTest"` → all 9 pass (7 existing + 2 new).
- `./gradlew :app:checkConfigFieldDrift` → OK (no drift).
