### PR TITLE
fix(extension): sanitize modules to prevent ModuleCard NPE crash

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionManager.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionManager.kt
@@ -256,7 +256,7 @@ class ExtensionManager private constructor(private val context: Context) {
             val jsonArray = parsed.asJsonArray
             val result = jsonArray.mapNotNull { element ->
                 try {
-                    gson.fromJson(element, ExtensionModule::class.java)
+                    gson.fromJson(element, ExtensionModule::class.java)?.sanitized()
                 } catch (_: Exception) {
                     null
                 }
@@ -463,6 +463,7 @@ class ExtensionManager private constructor(private val context: Context) {
 
     suspend fun addModule(module: ExtensionModule): Result<ExtensionModule> {
         return try {
+            val module = module.sanitized()
 
             val errors = module.validate()
             if (errors.isNotEmpty()) {
@@ -614,7 +615,7 @@ class ExtensionManager private constructor(private val context: Context) {
             val module = try {
                 val reader = JsonReader(InputStreamReader(inputStream.buffered()))
                 reader.isLenient = true
-                gson.fromJson<ExtensionModule>(reader, ExtensionModule::class.java)
+                gson.fromJson<ExtensionModule>(reader, ExtensionModule::class.java)?.sanitized()
             } catch (e: Exception) {
                 AppLogger.e(TAG, "Stream-based parsing failed", e)
                 null
@@ -661,7 +662,7 @@ class ExtensionManager private constructor(private val context: Context) {
 
             val importedModules = mutableListOf<ExtensionModule>()
             for (module in pkg.modules) {
-                val importedModule = module.copy(
+                val importedModule = module.sanitized().copy(
                     id = java.util.UUID.randomUUID().toString(),
                     builtIn = false,
                     createdAt = System.currentTimeMillis(),

--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
@@ -551,7 +551,7 @@ data class ExtensionModule(
 
         fun fromJson(json: String): ExtensionModule? {
             return try {
-                gson.fromJson(json, ExtensionModule::class.java)
+                gson.fromJson(json, ExtensionModule::class.java)?.sanitized()
             } catch (e: Exception) {
                 null
             }
@@ -593,6 +593,47 @@ data class ExtensionModule(
             return bos.toByteArray()
         }
     }
+
+    /**
+     * Gson allocates instances via Unsafe and leaves Kotlin non-null fields null when the
+     * JSON omits them (Kotlin default values are bypassed). Coerce every object-typed field
+     * back to its declared default so consumers never observe null in a non-null field
+     * (fixes the ModuleCard NullPointerException when rendering such a module). Primitive
+     * fields (enabled/builtIn/noframes/createdAt/updatedAt) cannot be null and are left as-is.
+     */
+    fun sanitized(): ExtensionModule = copy(
+        id = (id as String?)?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString(),
+        name = (name as String?) ?: "",
+        description = (description as String?) ?: "",
+        icon = (icon as String?) ?: "package",
+        category = (category as ModuleCategory?) ?: ModuleCategory.OTHER,
+        tags = (tags as List<String>?) ?: emptyList(),
+        version = (version as ModuleVersion?) ?: ModuleVersion(),
+        code = (code as String?) ?: "",
+        cssCode = (cssCode as String?) ?: "",
+        panelHtml = (panelHtml as String?) ?: "",
+        codeFiles = (codeFiles as Map<String, String>?) ?: emptyMap(),
+        runAt = (runAt as ModuleRunTime?) ?: ModuleRunTime.DOCUMENT_END,
+        urlMatches = (urlMatches as List<UrlMatchRule>?) ?: emptyList(),
+        permissions = (permissions as List<ModulePermission>?) ?: emptyList(),
+        configItems = (configItems as List<ModuleConfigItem>?) ?: emptyList(),
+        configValues = (configValues as Map<String, String>?) ?: emptyMap(),
+        dependencies = (dependencies as List<String>?) ?: emptyList(),
+        uiConfig = (uiConfig as ModuleUiConfig?) ?: ModuleUiConfig.DEFAULT,
+        runMode = (runMode as ModuleRunMode?) ?: ModuleRunMode.INTERACTIVE,
+        sourceType = (sourceType as ModuleSourceType?) ?: ModuleSourceType.CUSTOM,
+        chromeExtId = (chromeExtId as String?) ?: "",
+        storeIconPath = (storeIconPath as String?) ?: "",
+        storeTags = (storeTags as List<String>?) ?: emptyList(),
+        world = (world as String?) ?: "ISOLATED",
+        backgroundScript = (backgroundScript as String?) ?: "",
+        popupPath = (popupPath as String?) ?: "",
+        optionsPagePath = (optionsPagePath as String?) ?: "",
+        manifestJson = (manifestJson as String?) ?: "",
+        gmGrants = (gmGrants as List<String>?) ?: emptyList(),
+        requireUrls = (requireUrls as List<String>?) ?: emptyList(),
+        resources = (resources as Map<String, String>?) ?: emptyMap(),
+    )
 
     fun toJson(): String = gson.toJson(this)
 

--- a/app/src/test/java/com/webtoapp/core/extension/ExtensionModuleTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ExtensionModuleTest.kt
@@ -88,4 +88,31 @@ class ExtensionModuleTest {
         assertThat(executable).contains("ext-module-module-1")
         assertThat(executable).contains("window.__flag = getConfig('flag', 'off')")
     }
+
+    @Test
+    fun `sanitized coerces Gson-null fields back to defaults`() {
+        // Gson allocates via Unsafe and leaves Kotlin non-null fields null when the JSON
+        // omits them (Kotlin defaults are bypassed). sanitized() must restore the declared
+        // defaults so consumers never observe null in a non-null field (regression: the
+        // ModuleCard NullPointerException when rendering such a module).
+        val module = com.google.gson.Gson().fromJson("{}", ExtensionModule::class.java)
+
+        // Precondition: plain Gson left the non-null object fields as null (the bug condition).
+        assertThat(module.name as String?).isNull()
+        assertThat(module.description as String?).isNull()
+        assertThat(module.storeIconPath as String?).isNull()
+
+        val sanitized = module.sanitized()
+
+        assertThat(sanitized.id).isNotEmpty()
+        assertThat(sanitized.name).isEqualTo("")
+        assertThat(sanitized.description).isEqualTo("")
+        assertThat(sanitized.icon).isEqualTo("package")
+        assertThat(sanitized.storeIconPath).isEqualTo("")
+        assertThat(sanitized.world).isEqualTo("ISOLATED")
+        assertThat(sanitized.category).isEqualTo(ModuleCategory.OTHER)
+        assertThat(sanitized.tags).isEmpty()
+        assertThat(sanitized.storeTags).isEmpty()
+        assertThat(sanitized.version).isNotNull()
+    }
 }


### PR DESCRIPTION
Fixes #326

## User-visible effect

Opening the module picker ("select modules") no longer crashes. Previously, a single stored module with a missing field would crash the entire module list with a `NullPointerException` in `ModuleCard`, so the screen was unusable.

## Root cause

`ExtensionModule` declares non-null fields with Kotlin defaults (e.g. `description: String = ""`, `storeIconPath: String = ""`, `category = OTHER`), but Gson allocates instances via `Unsafe` and bypasses those defaults. When a module's JSON omits a field — from market installs, share-code/package imports, or older schemas — the non-null field becomes `null` at runtime. `ModuleCard` reads these fields as non-null (`storeIconPath.isNotBlank()`, `description.isNotBlank()`, `module.name`, `module.version.name`, …) and crashes.

## Change

- `ExtensionModule.kt` — add `sanitized()`, which coerces every object-typed non-null field back to its declared default (regenerating `id` if blank). Primitive fields (`enabled`/`builtIn`/`noframes`/`createdAt`/`updatedAt`) cannot be null and are left as-is. Also apply it in `ExtensionModule.fromJson` (share-code path).
- `ExtensionManager.kt` — apply `sanitized()` at each parse/entry boundary: `parseModulesJson`, `importModule`, `importModulePackage`, and `addModule` (catch-all for any module entering the manager).
- `ExtensionModuleTest.kt` — regression test: deserialize `{}` (reproducing the null-field condition) and assert `sanitized()` restores the defaults.

Net: 3 files, +73 / −4.

## Testing

- `./gradlew :app:compileDebugKotlin -x syncCloneHostDex` → BUILD SUCCESSFUL.
- `./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.extension.ExtensionModuleTest"` → all pass, including the new `sanitized coerces Gson-null fields back to defaults`.
