### PR TITLE
fix(webview): stop local HTML apps crashing with ERR_ACCESS_DENIED on external links

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -526,7 +526,12 @@ class GeckoViewEngine(
                     if (scheme == "http" || scheme == "https") {
                         val targetHost = runCatching { android.net.Uri.parse(uri).host?.lowercase() }.getOrNull()
                         val currentHost = runCatching { currentUrl?.let { android.net.Uri.parse(it).host?.lowercase() } }.getOrNull()
-                        if (targetHost != null && currentHost != null &&
+                        // Loopback-to-loopback navigations are the app's own local content,
+                        // not external links (e.g. 127.0.0.1 <-> localhost in a local HTML app).
+                        val bothLoopback = targetHost != null && currentHost != null &&
+                            isLoopbackHost(targetHost) && isLoopbackHost(currentHost)
+                        if (!bothLoopback &&
+                            targetHost != null && currentHost != null &&
                             targetHost != currentHost &&
                             !targetHost.endsWith(".$currentHost") &&
                             !currentHost.endsWith(".$targetHost")) {
@@ -547,6 +552,11 @@ class GeckoViewEngine(
                 return null
             }
         }
+    }
+
+    private fun isLoopbackHost(host: String): Boolean {
+        val h = host.lowercase()
+        return h == "127.0.0.1" || h == "localhost" || h == "[::1]" || h == "::1"
     }
 
     private fun setupProgressDelegate(session: GeckoSession, callback: BrowserEngineCallback) {

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -190,6 +190,40 @@ class WebViewManager(
             return WEBVIEW_WV_MARKER_REGEX.replace(userAgent, ")")
         }
 
+        /**
+         * Classifies whether a navigation target is an external link relative to the current
+         * page. Navigations between the app's own local origins (file:// or the loopback dev
+         * server) are internal content, never external; a local page with no host (file://)
+         * opening a remote URL is external.
+         */
+        @JvmStatic
+        fun isExternalUrl(targetUrl: String, currentUrl: String?): Boolean {
+            if (currentUrl == null) return false
+            if (isLocalAppUrl(targetUrl) && isLocalAppUrl(currentUrl)) return false
+            val targetHost = runCatching { Uri.parse(targetUrl).host?.lowercase() }.getOrNull() ?: return false
+            val currentHost = runCatching { Uri.parse(currentUrl).host?.lowercase() }.getOrNull()
+            if (currentHost.isNullOrEmpty()) return true
+            if (targetHost == currentHost) return false
+            return !targetHost.endsWith(".$currentHost") && !currentHost.endsWith(".$targetHost")
+        }
+
+        /** True for URLs that belong to the app's own local content (file:// or loopback server). */
+        @JvmStatic
+        fun isLocalAppUrl(url: String?): Boolean {
+            if (url == null) return false
+            val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return false
+            if (uri.scheme?.lowercase() == "file") return true
+            val host = uri.host?.lowercase() ?: return false
+            return isLoopbackHost(host)
+        }
+
+        /** True for loopback hosts (127.0.0.1 / localhost / ::1). */
+        @JvmStatic
+        fun isLoopbackHost(host: String): Boolean {
+            val h = host.lowercase()
+            return h == "127.0.0.1" || h == "localhost" || h == "[::1]" || h == "::1"
+        }
+
         fun beginFreshBrowsingSession() {
             browsingDataClearGeneration++
         }
@@ -1833,6 +1867,12 @@ class WebViewManager(
                 }
 
                 if (config.openExternalLinks && isExternalUrl(url, view?.url)) {
+                    // For local-file apps, only open externally on a genuine user gesture.
+                    // Otherwise an automatic entry/redirect navigation gets hijacked and the
+                    // WebView is left on net::ERR_ACCESS_DENIED with no content to fall back to.
+                    if (isLocalAppUrl(view?.url) && !isUserGesture) {
+                        return false
+                    }
                     callbacks.onExternalLink(url)
                     return true
                 }
@@ -3157,8 +3197,8 @@ class WebViewManager(
 
         if (scheme == "file") {
             val currentUrl = currentMainFrameUrl
-            if (currentUrl != null && currentUrl.startsWith("file://")) {
-                AppLogger.d("WebViewManager", "Allowing file:// same-origin navigation: $url")
+            if (currentUrl != null && isLocalAppUrl(currentUrl)) {
+                AppLogger.d("WebViewManager", "Allowing file:// navigation from local app content: $url")
                 return false
             }
         }
@@ -3278,14 +3318,6 @@ class WebViewManager(
             return null
         }
         return normalizeHttpUrlForSecurity(trimmed)
-    }
-
-    private fun isExternalUrl(targetUrl: String, currentUrl: String?): Boolean {
-        if (currentUrl == null) return false
-        val targetHost = runCatching { Uri.parse(targetUrl).host?.lowercase() }.getOrNull() ?: return false
-        val currentHost = runCatching { Uri.parse(currentUrl).host?.lowercase() }.getOrNull() ?: return false
-        if (targetHost == currentHost) return false
-        return !targetHost.endsWith(".$currentHost") && !currentHost.endsWith(".$targetHost")
     }
 
     fun destroyWebView(webView: WebView) {

--- a/app/src/test/java/com/webtoapp/core/webview/WebViewManagerExternalLinkTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/WebViewManagerExternalLinkTest.kt
@@ -1,0 +1,65 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class WebViewManagerExternalLinkTest {
+
+    @Test
+    fun `isLocalAppUrl recognizes file and loopback origins`() {
+        assertThat(WebViewManager.isLocalAppUrl("file:///android_asset/index.html")).isTrue()
+        assertThat(WebViewManager.isLocalAppUrl("file:///data/user/0/com.x/files/html/index.html")).isTrue()
+        assertThat(WebViewManager.isLocalAppUrl("http://127.0.0.1:8080/index.html")).isTrue()
+        assertThat(WebViewManager.isLocalAppUrl("http://localhost:8080/index.html")).isTrue()
+        assertThat(WebViewManager.isLocalAppUrl("https://example.com/")).isFalse()
+        assertThat(WebViewManager.isLocalAppUrl(null)).isFalse()
+    }
+
+    @Test
+    fun `isLoopbackHost matches loopback hosts only`() {
+        assertThat(WebViewManager.isLoopbackHost("127.0.0.1")).isTrue()
+        assertThat(WebViewManager.isLoopbackHost("localhost")).isTrue()
+        assertThat(WebViewManager.isLoopbackHost("[::1]")).isTrue()
+        assertThat(WebViewManager.isLoopbackHost("::1")).isTrue()
+        assertThat(WebViewManager.isLoopbackHost("example.com")).isFalse()
+    }
+
+    @Test
+    fun `isExternalUrl treats same host and subdomains as internal`() {
+        assertThat(WebViewManager.isExternalUrl("https://example.com/a", "https://example.com/b")).isFalse()
+        assertThat(WebViewManager.isExternalUrl("https://cdn.example.com/x", "https://example.com/")).isFalse()
+        assertThat(WebViewManager.isExternalUrl("https://other.com/", "https://example.com/")).isTrue()
+    }
+
+    @Test
+    fun `isExternalUrl treats local-to-local navigations as internal`() {
+        // Regression: a local HTML app served from 127.0.0.1 that navigates to localhost
+        // (or between file:// pages) was misclassified as external and hijacked, leaving the
+        // WebView on net::ERR_ACCESS_DENIED.
+        assertThat(
+            WebViewManager.isExternalUrl("http://localhost:8080/home.html", "http://127.0.0.1:8080/index.html")
+        ).isFalse()
+        assertThat(
+            WebViewManager.isExternalUrl("file:///data/x/home.html", "file:///data/x/index.html")
+        ).isFalse()
+        assertThat(
+            WebViewManager.isExternalUrl("http://127.0.0.1:8080/", "file:///data/x/index.html")
+        ).isFalse()
+    }
+
+    @Test
+    fun `isExternalUrl treats remote target from local page as external`() {
+        assertThat(WebViewManager.isExternalUrl("https://example.com/", "file:///data/x/index.html")).isTrue()
+        assertThat(WebViewManager.isExternalUrl("https://example.com/", "http://127.0.0.1:8080/")).isTrue()
+    }
+
+    @Test
+    fun `isExternalUrl returns false without a current url`() {
+        assertThat(WebViewManager.isExternalUrl("https://example.com/", null)).isFalse()
+    }
+}


### PR DESCRIPTION
Fixes #330

## User-visible effect

A local HTML (offline, `file://`) app no longer crashes on launch with `net::ERR_ACCESS_DENIED` when **open external links** is enabled. Behavior now:
- App entry/redirect navigations load in-app (no crash).
- Links the user actually taps that point to other sites still open in the system browser.
- Links within the app's own local content (file://, 127.0.0.1, localhost) stay in-app.
- Online-URL apps are unchanged for user-tapped external links.

## Root cause

`WebViewManager.shouldOverrideUrlLoading` classified "external" purely by comparing URL hosts:
- `isExternalUrl` did not recognize the app's own local origins, so a local app served from `127.0.0.1` navigating to `localhost` (or between local origins) was treated as external.
- The interception did not distinguish user gestures from automatic navigations, so the app's own entry/redirect was hijacked — `onExternalLink` opened it externally while `return true` cancelled the WebView's main-frame load, leaving `net::ERR_ACCESS_DENIED`.
- `handleSpecialUrl` only allowed `file://` when the current frame was already `file://`, fragile at launch/redirects.

## Change

- `WebViewManager.kt` — add `isLocalAppUrl` / `isLoopbackHost`; `isExternalUrl` treats local-to-local navigations as internal and a host-less local page (file://) opening a remote URL as external; the external-link interception only fires on a genuine user gesture for local-file apps; `handleSpecialUrl` always allows `file://` from local app content. The classification logic lives in companion functions (matching `stripWebViewMarker`) so it is unit-testable.
- `GeckoViewEngine.kt` — same loopback exemption in `onLoadRequest`.
- `WebViewManagerExternalLinkTest.kt` — new Robolectric test covering the classification, including the `127.0.0.1 <-> localhost` regression case.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.webview.WebViewManagerExternalLinkTest"` → all 6 pass.
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
- `./gradlew :shell:assembleRelease :app:syncShellTemplateApk` → BUILD SUCCESSFUL; shell copy and template APK contain the fix.
