### PR TITLE
build: resolve a working Python 3 interpreter instead of hardcoding python3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -478,6 +478,33 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
 
+/**
+ * Resolves a Python 3 interpreter command for the current platform. Windows usually exposes
+ * Python as `python` (or the `py -3` launcher) rather than `python3`, so a hardcoded
+ * `python3` fails there. Each candidate is verified to actually be Python 3 before use.
+ * NOTE: intentionally duplicated in the root build.gradle.kts (this project has no buildSrc).
+ */
+fun resolvePython3Command(): List<String> {
+    val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+    val candidates: List<List<String>> = if (isWindows) {
+        listOf(listOf("python3"), listOf("python"), listOf("py", "-3"))
+    } else {
+        listOf(listOf("python3"), listOf("python"))
+    }
+    for (candidate in candidates) {
+        try {
+            val probe = ProcessBuilder(candidate + "--version").redirectErrorStream(true).start()
+            val output = probe.inputStream.bufferedReader().readText()
+            if (probe.waitFor() == 0 && output.contains("Python 3")) {
+                return candidate
+            }
+        } catch (_: Exception) {
+            // Candidate unavailable; try the next one.
+        }
+    }
+    return listOf("python3")
+}
+
 tasks.register("checkConfigFieldDrift") {
     group = "verification"
     description = "Detect field-name drift between ApkConfig payload keys and ShellConfig @SerializedName (static guard for preview/export config consistency)"
@@ -489,7 +516,7 @@ tasks.register("checkConfigFieldDrift") {
     inputs.files(script, payloadFile, apkConfigFile, shellConfigFile, allowlist)
     outputs.upToDateWhen { false }
     doLast {
-        val pb = ProcessBuilder("python3", script.absolutePath)
+        val pb = ProcessBuilder(resolvePython3Command() + script.absolutePath)
         pb.directory(rootProject.projectDir)
         pb.redirectErrorStream(true)
         val proc = pb.start()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,17 +11,45 @@ tasks.register("clean", Delete::class) {
     delete(rootProject.layout.buildDirectory)
 }
 
+/**
+ * Resolves a Python 3 interpreter command for the current platform. Windows usually exposes
+ * Python as `python` (or the `py -3` launcher) rather than `python3`, so a hardcoded
+ * `python3` fails there. Each candidate is verified to actually be Python 3 before use.
+ * NOTE: intentionally duplicated in app/build.gradle.kts (this project has no buildSrc).
+ */
+fun resolvePython3Command(): List<String> {
+    val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+    val candidates: List<List<String>> = if (isWindows) {
+        listOf(listOf("python3"), listOf("python"), listOf("py", "-3"))
+    } else {
+        listOf(listOf("python3"), listOf("python"))
+    }
+    for (candidate in candidates) {
+        try {
+            val probe = ProcessBuilder(candidate + "--version").redirectErrorStream(true).start()
+            val output = probe.inputStream.bufferedReader().readText()
+            if (probe.waitFor() == 0 && output.contains("Python 3")) {
+                return candidate
+            }
+        } catch (_: Exception) {
+            // Candidate unavailable; try the next one.
+        }
+    }
+    return listOf("python3")
+}
+
 tasks.register<Exec>("checkUiDesignSystem") {
     group = "verification"
     description = "Checks Compose UI files against the WebToApp design-system debt baseline."
     workingDir = rootDir
     commandLine(
-        "python3",
-        ".github/scripts/audit_ui_design_system.py",
-        "--enforce-baseline",
-        "--allowlist",
-        ".github/scripts/ui_design_allowlist.txt",
-        "--top",
-        "12"
+        resolvePython3Command() + listOf(
+            ".github/scripts/audit_ui_design_system.py",
+            "--enforce-baseline",
+            "--allowlist",
+            ".github/scripts/ui_design_allowlist.txt",
+            "--top",
+            "12"
+        )
     )
 }


### PR DESCRIPTION
Fixes #332

## What this fixes

Two developer-facing Gradle tasks hardcoded the `python3` executable, which fails on Windows (Python is usually `python` or the `py` launcher there; `python3` often does not exist). `checkConfigFieldDrift` is the config-drift gate `AGENTS.md` asks developers to run, so Windows developers hit this directly. CI is unaffected (Ubuntu runners ship `python3`).

## Change

- Add `resolvePython3Command()`: probes candidates in order — `python3`, `python`, and `py -3` on Windows — running `--version` on each and confirming it reports Python 3, then returns the first that works (falls back to `python3` so the task fails with a clear error if none is found).
- `checkUiDesignSystem` (root `build.gradle.kts`) and `checkConfigFieldDrift` (`app/build.gradle.kts`) now use it instead of a hardcoded `python3`.
- The helper is duplicated in the two build scripts (this project has no `buildSrc`), with a comment noting that.

## Testing

- `./gradlew :app:checkConfigFieldDrift` → runs successfully through the resolver (resolves `python3` on macOS, script reports OK).
- `./gradlew checkUiDesignSystem --dry-run` → task realizes correctly with the resolver (BUILD SUCCESSFUL).
- Windows path (`python` / `py -3` candidates) is exercised by the same probe logic; not runnable in this macOS/CI environment.
