### PR TITLE
fix(aab): drop resource-table references to skipped plaintext res XML

### DIFF
--- a/app/src/main/java/com/webtoapp/core/playstore/aab/ApkToAabAssembler.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/ApkToAabAssembler.kt
@@ -85,7 +85,27 @@ class ApkToAabAssembler {
                     ?: throw IllegalArgumentException("APK missing resources.arsc")
                 val arscBytes = zip.getInputStream(arscEntry).readBytes()
                 val table = ArscReader(arscBytes).read()
-                val protoTable = ArscToProtoTable.convert(table)
+
+                // Pre-scan res/*.xml for plaintext (uncompiled) XML that we skip below (issue
+                // #272), so we can also drop their references from the resource table. Otherwise
+                // the AAB's resource table references non-existing files and Google Play rejects
+                // it (bundletool build-apks). See issue #293.
+                val plaintextResFiles = mutableSetOf<String>()
+                for (scanEntry in zip.entries()) {
+                    val scanName = scanEntry.name
+                    if (!scanEntry.isDirectory && scanName.startsWith("res/") && scanName.endsWith(".xml")) {
+                        val head = ByteArray(2)
+                        val read = zip.getInputStream(scanEntry).use { it.read(head) }
+                        if (read > 0 && isPlaintextXml(head)) {
+                            plaintextResFiles.add(scanName)
+                        }
+                    }
+                }
+                if (plaintextResFiles.isNotEmpty()) {
+                    AppLogger.d(TAG, "Excluding plaintext res XML from resource table: $plaintextResFiles")
+                }
+
+                val protoTable = ArscToProtoTable.convert(table, plaintextResFiles)
                 writeEntry(out, "base/resources.pb", protoTable.toByteArray())
 
                 val referencedResources = table.collectReferencedResourceFiles()

--- a/app/src/main/java/com/webtoapp/core/playstore/aab/arsc/ArscToProtoTable.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/arsc/ArscToProtoTable.kt
@@ -6,17 +6,21 @@ import com.webtoapp.core.playstore.aab.axml.AxmlConstants
 
 object ArscToProtoTable {
 
-    internal fun convert(table: ArscResourceTable): Resources.ResourceTable {
+    internal fun convert(
+        table: ArscResourceTable,
+        excludedResFiles: Set<String> = emptySet()
+    ): Resources.ResourceTable {
         val builder = Resources.ResourceTable.newBuilder()
         for (pkg in table.packages) {
-            builder.addPackage(convertPackage(pkg, table.valueStringPool))
+            builder.addPackage(convertPackage(pkg, table.valueStringPool, excludedResFiles))
         }
         return builder.build()
     }
 
     private fun convertPackage(
         pkg: ArscPackage,
-        valuePool: List<String>
+        valuePool: List<String>,
+        excludedResFiles: Set<String>
     ): Resources.Package {
         val packageBuilder = Resources.Package.newBuilder()
             .setPackageId(
@@ -35,7 +39,7 @@ object ArscToProtoTable {
             val typeSpec = typeSpecsByTypeId[typeId]
 
             packageBuilder.addType(
-                convertType(typeId, typeName, typeChunks, typeSpec, pkg.keyNames, valuePool)
+                convertType(typeId, typeName, typeChunks, typeSpec, pkg.keyNames, valuePool, excludedResFiles)
             )
         }
         return packageBuilder.build()
@@ -47,7 +51,8 @@ object ArscToProtoTable {
         typeChunks: List<ArscType>,
         typeSpec: ArscTypeSpec?,
         keyNames: List<String>,
-        valuePool: List<String>
+        valuePool: List<String>,
+        excludedResFiles: Set<String>
     ): Resources.Type {
         val typeBuilder = Resources.Type.newBuilder()
             .setTypeId(Resources.TypeId.newBuilder().setId(typeId).build())
@@ -76,11 +81,25 @@ object ArscToProtoTable {
             if (configValues.isEmpty()) continue
 
             val entryName = canonicalName[entryIndex] ?: continue
+
+            // Drop config values whose resource file was excluded (plaintext res XML skipped
+            // from the bundle; see ApkToAabAssembler, issue #293). If nothing remains, drop the
+            // whole entry so the resource table doesn't reference a non-existing file
+            // (bundletool rejects the AAB otherwise).
+            val keptConfigValues = if (excludedResFiles.isEmpty()) {
+                configValues
+            } else {
+                configValues.filterNot { (_, entry) ->
+                    entryReferencesExcludedFile(entry, valuePool, excludedResFiles)
+                }
+            }
+            if (keptConfigValues.isEmpty()) continue
+
             val entryBuilder = Resources.Entry.newBuilder()
                 .setEntryId(Resources.EntryId.newBuilder().setId(entryIndex).build())
                 .setName(entryName)
 
-            val anyPublic = configValues.any { it.second.flags and ENTRY_FLAG_PUBLIC != 0 }
+            val anyPublic = keptConfigValues.any { it.second.flags and ENTRY_FLAG_PUBLIC != 0 }
             if (anyPublic) {
                 entryBuilder.setVisibility(
                     Resources.Visibility.newBuilder()
@@ -90,7 +109,7 @@ object ArscToProtoTable {
             }
 
             val seenConfigBytes = mutableSetOf<List<Byte>>()
-            for ((cfg, entry) in configValues) {
+            for ((cfg, entry) in keptConfigValues) {
                 val protoConfig = convertConfig(cfg)
                 val key = protoConfig.toByteArray().toList()
                 if (!seenConfigBytes.add(key)) continue
@@ -105,6 +124,26 @@ object ArscToProtoTable {
         }
 
         return typeBuilder.build()
+    }
+
+    /** True if any value of this entry references a res file in [excludedResFiles]. */
+    private fun entryReferencesExcludedFile(
+        entry: ArscEntry,
+        valuePool: List<String>,
+        excludedResFiles: Set<String>
+    ): Boolean = when (val body = entry.body) {
+        is ArscEntryBody.Simple -> isExcludedFileValue(body.value, valuePool, excludedResFiles)
+        is ArscEntryBody.Bag -> body.entries.any { isExcludedFileValue(it.value, valuePool, excludedResFiles) }
+    }
+
+    private fun isExcludedFileValue(
+        value: ArscValue,
+        valuePool: List<String>,
+        excludedResFiles: Set<String>
+    ): Boolean {
+        if (value.dataType != AxmlConstants.TYPE_STRING) return false
+        val s = valuePool.getOrElse(value.data) { "" }
+        return s.startsWith("res/") && s in excludedResFiles
     }
 
     private fun convertEntryValue(

--- a/app/src/test/java/com/webtoapp/core/playstore/aab/arsc/ArscToProtoTableExcludedFilesTest.kt
+++ b/app/src/test/java/com/webtoapp/core/playstore/aab/arsc/ArscToProtoTableExcludedFilesTest.kt
@@ -1,0 +1,81 @@
+package com.webtoapp.core.playstore.aab.arsc
+
+import com.android.aapt.Resources
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Regression guard for issue #293: when the AAB assembler skips a plaintext res XML file
+ * (issue #272), the resource table must also drop the entry that references it. Otherwise the
+ * AAB's resource table references a non-existing file and Google Play rejects the bundle
+ * (bundletool: "Resource table of module 'base' contains references to non-existing files").
+ */
+class ArscToProtoTableExcludedFilesTest {
+
+    private fun sampleTable(): ArscResourceTable = ArscResourceTable(
+        valueStringPool = listOf("res/qF.xml", "res/keep.xml"),
+        packages = listOf(
+            ArscPackage(
+                id = 0x7f,
+                name = "com.webtoapp.test",
+                typeNames = listOf("xml"),
+                keyNames = listOf("marker", "keep"),
+                typeSpecs = listOf(ArscTypeSpec(typeId = 1, configFlags = intArrayOf(0, 0))),
+                types = listOf(
+                    ArscType(
+                        typeId = 1,
+                        config = ArscConfig.DEFAULT,
+                        entries = listOf(
+                            ArscEntry(
+                                index = 0,
+                                name = "marker",
+                                flags = 0,
+                                // dataType 0x03 == TYPE_STRING; data indexes valueStringPool.
+                                body = ArscEntryBody.Simple(ArscValue(dataType = 0x03, data = 0))
+                            ),
+                            ArscEntry(
+                                index = 1,
+                                name = "keep",
+                                flags = 0,
+                                body = ArscEntryBody.Simple(ArscValue(dataType = 0x03, data = 1))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    private fun Resources.ResourceTable.fileReferences(): Set<String> {
+        val out = mutableSetOf<String>()
+        for (pkg in packageList) {
+            for (type in pkg.typeList) {
+                for (entry in type.entryList) {
+                    for (cv in entry.configValueList) {
+                        if (cv.value.item.hasFile()) {
+                            out.add(cv.value.item.file.path)
+                        }
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    @Test
+    fun `without exclusion the resource table references the plaintext file`() {
+        val proto = ArscToProtoTable.convert(sampleTable())
+        assertThat(proto.fileReferences()).containsExactly("res/qF.xml", "res/keep.xml")
+    }
+
+    @Test
+    fun `excluding a plaintext file drops its entry but keeps the rest`() {
+        val proto = ArscToProtoTable.convert(sampleTable(), excludedResFiles = setOf("res/qF.xml"))
+        assertThat(proto.fileReferences()).containsExactly("res/keep.xml")
+    }
+
+    @Test
+    fun `collectReferencedResourceFiles sees the plaintext reference before exclusion`() {
+        assertThat(sampleTable().collectReferencedResourceFiles()).contains("res/qF.xml")
+    }
+}


### PR DESCRIPTION
Fixes #293

## User-visible effect

AAB export no longer produces bundles that Google Play rejects with:

> Resource table of module 'base' contains references to non-existing files: [res/qF.xml]

This regressed in v2.3.5: the bundle generated fine but Play Console (bundletool) rejected it. v2.2.0 bundles were accepted.

## Root cause

The #272 fix made the assembler **skip** plaintext `res/*.xml` files (the AGP resource-shrinker `tools:keep`/`tools:discard` marker, e.g. `res/qF.xml`, which is left uncompiled in release APKs) instead of crashing on them. But it did not remove the **resource table's** reference to that file: `resources.pb` (converted from `resources.arsc`) still contained an entry whose value pointed at `res/qF.xml`. The bundle then referenced a file it didn't contain, which bundletool rejects.

## Change

- `ApkToAabAssembler.kt` — pre-scan `res/*.xml` for plaintext files (reusing the existing `isPlaintextXml`) and pass that set into the resource-table conversion.
- `ArscToProtoTable.kt` — `convert` now takes `excludedResFiles`; `convertType` drops any resource entry whose value references an excluded file (and keeps the rest), so the table no longer references files that aren't in the bundle.
- `ArscToProtoTableExcludedFilesTest.kt` — new regression test: without exclusion the table references the plaintext file; with exclusion the referencing entry is dropped while sibling entries are preserved.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.playstore.aab.*"` → all pass (24 tests across the AAB suite, including the #272 plaintext-detection tests and the 3 new exclusion tests), no regressions.
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
