### PR TITLE
fix(apkbuilder): stop duplicate lib/<abi>/ native lib entries for GO_APP/NODEJS_APP

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -66,6 +66,23 @@ class ApkBuilder(private val context: Context) {
             "org.mozilla.gecko.process.GeckoChildProcessServices\$utility",
             "org.mozilla.gecko.process.GeckoChildProcessServices\$ipdlunittest"
         )
+
+        /**
+         * Zip entry names (lib/<deviceAbi>/<lib>.so) that the per-app-type native-lib injection
+         * step writes for the device ABI. The template-copy phase skips these so the injection
+         * (16KB-aligned) is the single source and no duplicate entry is emitted — fixes the
+         * GO_APP / NODEJS_APP "duplicate entry: lib/<abi>/<lib>.so" build failure.
+         */
+        internal fun injectedDeviceLibEntries(appType: String, deviceAbi: String): Set<String> =
+            injectedNativeLibNames(appType).mapTo(mutableSetOf()) { "lib/$deviceAbi/$it" }
+
+        private fun injectedNativeLibNames(appType: String): Set<String> = when (appType) {
+            "GO_APP" -> setOf("libgo_exec_loader.so")
+            "NODEJS_APP" -> setOf("libc++_shared.so", "libnode_bridge.so", "libnode.so")
+            "PHP_APP", "WORDPRESS" -> setOf("libphp.so")
+            "PYTHON_APP" -> setOf("libpython3.so", "libmusl-linker.so")
+            else -> emptySet()
+        }
     }
 
     private val template = ApkTemplate(context)
@@ -992,6 +1009,13 @@ class ApkBuilder(private val context: Context) {
         val replacedIconPaths = mutableSetOf<String>()
         var discoveredOldIconPaths = emptySet<String>()
 
+        // Native libs the per-app-type injection step writes for the device ABI (16KB-aligned).
+        // The template also ships them; skip the template's device-ABI copy in the loop below so
+        // the injection is the single source and we don't emit a duplicate zip entry
+        // ("duplicate entry: lib/<abi>/<lib>.so").
+        val deviceAbi = android.os.Build.SUPPORTED_ABIS?.firstOrNull() ?: "arm64-v8a"
+        val injectedDeviceLibs = injectedDeviceLibEntries(config.appType, deviceAbi)
+
         val assetEncryptor = if (encryptionConfig.enabled && encryptionKey != null) {
             AssetEncryptor(encryptionKey)
         } else null
@@ -1101,6 +1125,10 @@ class ApkBuilder(private val context: Context) {
                             val libName = entry.name.substringAfterLast("/")
 
                             when {
+
+                                injectedDeviceLibs.contains(entry.name) -> {
+                                    AppLogger.d("ApkBuilder", "Skipping template native lib (injected for device ABI): ${entry.name}")
+                                }
 
                                 abiFilters.isNotEmpty() && !abiFilters.contains(abi) -> {
                                     AppLogger.d("ApkBuilder", "Skipping architecture: ${entry.name}")

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuilderInjectedLibsTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuilderInjectedLibsTest.kt
@@ -1,0 +1,50 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Regression guard for the GO_APP / NODEJS_APP "duplicate entry: lib/<abi>/<lib>.so" build
+ * failure: the template APK ships these runtime libs AND the per-app-type injection step writes
+ * them (16KB-aligned) for the device ABI. modifyApk skips the template's device-ABI copy using
+ * [ApkBuilder.injectedDeviceLibEntries], so this locks the exact entry names that must be skipped
+ * to avoid emitting a duplicate zip entry.
+ */
+class ApkBuilderInjectedLibsTest {
+
+    @Test
+    fun `go app skips the device-abi go exec loader from the template`() {
+        assertThat(ApkBuilder.injectedDeviceLibEntries("GO_APP", "arm64-v8a"))
+            .containsExactly("lib/arm64-v8a/libgo_exec_loader.so")
+    }
+
+    @Test
+    fun `node app skips the device-abi node libs from the template`() {
+        assertThat(ApkBuilder.injectedDeviceLibEntries("NODEJS_APP", "arm64-v8a"))
+            .containsExactly(
+                "lib/arm64-v8a/libc++_shared.so",
+                "lib/arm64-v8a/libnode_bridge.so",
+                "lib/arm64-v8a/libnode.so"
+            )
+    }
+
+    @Test
+    fun `php and wordpress skip the device-abi php lib`() {
+        assertThat(ApkBuilder.injectedDeviceLibEntries("PHP_APP", "armeabi-v7a"))
+            .containsExactly("lib/armeabi-v7a/libphp.so")
+        assertThat(ApkBuilder.injectedDeviceLibEntries("WORDPRESS", "armeabi-v7a"))
+            .containsExactly("lib/armeabi-v7a/libphp.so")
+    }
+
+    @Test
+    fun `python app skips the device-abi python libs`() {
+        assertThat(ApkBuilder.injectedDeviceLibEntries("PYTHON_APP", "arm64-v8a"))
+            .containsExactly("lib/arm64-v8a/libpython3.so", "lib/arm64-v8a/libmusl-linker.so")
+    }
+
+    @Test
+    fun `non-runtime app types skip nothing`() {
+        assertThat(ApkBuilder.injectedDeviceLibEntries("WEB", "arm64-v8a")).isEmpty()
+        assertThat(ApkBuilder.injectedDeviceLibEntries("HTML", "arm64-v8a")).isEmpty()
+    }
+}


### PR DESCRIPTION
Fixes #335

## User-visible effect

`GO_APP` export no longer fails with `duplicate entry: lib/arm64-v8a/libgo_exec_loader.so` when building for the device ABI (e.g. 64-bit on an arm64 device). The same latent failure for `NODEJS_APP` (`libnode_bridge.so`, `libc++_shared.so`) is fixed too.

## Root cause

The runtime loader libs are written into the output APK twice:
1. **Template copy** — `isRequiredNativeLib` keeps `libgo_exec_loader.so` (GO_APP) / `libnode_bridge.so`+`libc++_shared.so` (NODEJS_APP) from the template, subject to the architecture `abiFilters`.
2. **Injection** — `injectGoExecLoaderNativeLib` / `injectNodeJsNativeLibs` write the same libs again for the device ABI (16KB-aligned).

When the device ABI passes `abiFilters` (64-bit build on an arm64 device) the two collide and `ZipOutputStream` throws `duplicate entry`. A 32-bit build filters the template's arm64-v8a copy out, so it happens to succeed.

## Change (`ApkBuilder.kt`)

- Add `ApkBuilder.injectedDeviceLibEntries(appType, deviceAbi)` (companion, `internal`): the `lib/<deviceAbi>/<lib>.so` entry names the per-app-type injection step writes — GO_APP → `libgo_exec_loader.so`; NODEJS_APP → `libc++_shared.so`, `libnode_bridge.so`, `libnode.so`; PHP_APP/WORDPRESS → `libphp.so`; PYTHON_APP → `libpython3.so`, `libmusl-linker.so`.
- In `modifyApk`'s template-copy `lib/` handling, skip those device-ABI entries (the injection is the single, 16KB-aligned source); the template still supplies the other ABIs, so multi-ABI distribution is unaffected.
- PHP/Python inject libs that aren't in the template, so skipping them is a harmless no-op.

## Testing

- `./gradlew :app:testDebugUnitTest --tests "com.webtoapp.core.apkbuilder.ApkBuilderInjectedLibsTest"` → 5/5 pass (locks the exact skipped entry names per app type).
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
- Note: a full GO_APP/NODEJS_APP build to observe the duplicate is gone requires the runtime toolchain on-device; the skip logic and entry names are covered by the unit test.
