### PR TITLE
fix(shell): don't re-parent an already-attached view on fullscreen (GeckoView crash)

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -407,14 +407,21 @@ object WindowHelper {
     ): Int {
         val originalOrientation = activity.requestedOrientation
 
-        val decorView = activity.window.decorView as FrameLayout
-        decorView.addView(
-            view,
-            FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
+        // Only re-parent the view if it isn't already attached. System WebView hands us a
+        // detached video surface (add it to the decorView); GeckoView fullscreen passes the
+        // already-attached GeckoView itself, which must stay in its current container while we
+        // change orientation and hide the system bars — re-parenting it throws
+        // "The specified child already has a parent" (issue #298).
+        if (view.parent == null) {
+            val decorView = activity.window.decorView as FrameLayout
+            decorView.addView(
+                view,
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
             )
-        )
+        }
         return originalOrientation
     }
 
@@ -481,8 +488,13 @@ object WindowHelper {
         callback: WebChromeClient.CustomViewCallback?,
         originalOrientation: Int
     ) {
+        // Only remove the view if we were the ones who added it (to the decorView). A GeckoView
+        // fullscreen view stays attached to its original container (see showCustomView), so there
+        // is nothing to remove here.
         val decorView = activity.window.decorView as FrameLayout
-        decorView.removeView(view)
+        if (view.parent === decorView) {
+            decorView.removeView(view)
+        }
         callback?.onCustomViewHidden()
         activity.requestedOrientation = originalOrientation
     }


### PR DESCRIPTION
Fixes #298

## User-visible effect

GeckoView-based apps no longer crash when a playing video enters fullscreen. Previously, tapping the fullscreen button (e.g. in the Miruro player) crashed with:

> java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.

System WebView was unaffected and still works as before.

## Root cause

`GeckoViewEngine`'s `onFullScreen(true)` forwards the **GeckoView itself** to `onShowCustomView`, and `WindowHelper.showCustomView` unconditionally did `decorView.addView(view)`. Unlike System WebView — whose `onShowCustomView` hands over a *detached* video surface — the GeckoView is already attached to its content container, so re-parenting it threw `IllegalStateException`.

## Change (`WindowHelper.kt`)

Make the custom-view helpers idempotent for already-attached views:
- `showCustomView` only adds the view when `view.parent == null`; an already-attached view (GeckoView) stays in its current container while the caller changes orientation and hides the system bars — matching the expected behavior in the issue.
- `hideCustomView` only removes the view when its parent is the decorView (i.e. we added it), so the GeckoView case has nothing to remove.

System WebView fullscreen is unaffected: its detached custom view is added/removed exactly as before.

## Testing

- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
- `./gradlew :shell:assembleRelease :app:syncShellTemplateApk` → BUILD SUCCESSFUL; shell copy and template APK contain the fix.
- Note: end-to-end verification needs a GeckoView app playing a fullscreen video on-device (the crash path is a view re-parent that isn't unit-testable); the change is covered by compilation and review.
