### PR TITLE
fix(shell): follow system dark mode in exported apps (add uiMode to configChanges)

### DIFF
--- a/shell/src/main/AndroidManifest.xml
+++ b/shell/src/main/AndroidManifest.xml
@@ -192,7 +192,7 @@
         
         <activity
             android:name=".ui.shell.ShellActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
+            android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize|uiMode"
             android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTask"


### PR DESCRIPTION
Fixes #301

## User-visible effect

Exported apps now follow the system dark mode at runtime (the page switches dark/light when the system theme changes), matching the WebToApp preview. Previously the exported app did not respond to dark-mode changes — the page only went dark at launch.

## Root cause

The preview host `WebViewActivity` declares `uiMode` in its `android:configChanges`, so a system dark-mode change does **not** recreate the activity: the WebView stays attached, receives the configuration change, and the page's `prefers-color-scheme` updates live.

The shell's `ShellActivity` did **not** declare `uiMode`, so a dark-mode change recreated the activity. That recreation path did not reliably re-apply dark mode, so the exported app appeared not to respond to dark-mode changes (regression reported vs v2.2.0).

## Change

`shell/src/main/AndroidManifest.xml` — add `uiMode` to `ShellActivity`'s `android:configChanges`, so exported apps handle a system dark-mode change the same way as the preview: no recreation, the WebView stays attached and the page's `prefers-color-scheme` follows the system.

## Testing

- `./gradlew :shell:assembleRelease :app:syncShellTemplateApk` → BUILD SUCCESSFUL; the rebuilt shell template carries the updated manifest.
- Note: dark-mode following is runtime behavior that needs an on-device check (toggle system dark mode in an exported app and confirm the page switches); the change aligns the shell with the already-working preview path.
