### PR TITLE
feat(webview): prefer algorithmic darkening over deprecated FORCE_DARK

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1423,10 +1423,19 @@ class WebViewManager(
                 allowUniversalAccessFromFileURLs = config.allowUniversalAccessFromFileURLs
 
                 if (config.followSystemDarkMode) {
-                    val systemInDarkMode = (context.resources.configuration.uiMode and
-                        android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-                        android.content.res.Configuration.UI_MODE_NIGHT_YES
-                    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                    if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+                        // Modern WebView (API 33+): algorithmic darkening follows the system dark
+                        // mode automatically and respects the page's own prefers-color-scheme theme,
+                        // so it keeps responding to system theme changes at runtime.
+                        WebSettingsCompat.setAlgorithmicDarkeningAllowed(this, true)
+                        AppLogger.d("WebViewManager", "Follow system dark mode: algorithmic darkening allowed")
+                    } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                        // Legacy WebView: FORCE_DARK is a fixed setting, so derive it from the
+                        // current system state (on these older devices the activity is recreated on
+                        // a uiMode change, which re-applies it).
+                        val systemInDarkMode = (context.resources.configuration.uiMode and
+                            android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                            android.content.res.Configuration.UI_MODE_NIGHT_YES
                         @Suppress("DEPRECATION")
                         WebSettingsCompat.setForceDark(
                             this,
@@ -1440,9 +1449,6 @@ class WebViewManager(
                             )
                         }
                         AppLogger.d("WebViewManager", "Follow system dark mode: FORCE_DARK ${if (systemInDarkMode) "ON" else "OFF"}")
-                    } else if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-                        WebSettingsCompat.setAlgorithmicDarkeningAllowed(this, true)
-                        AppLogger.d("WebViewManager", "Follow system dark mode: algorithmic darkening allowed")
                     }
                 }
 


### PR DESCRIPTION
Fixes #341 (follow-up to #301)

## What this changes

When "follow system dark mode" is enabled, prefer the modern `setAlgorithmicDarkeningAllowed(true)` over the deprecated `FORCE_DARK`.

## Why

`FORCE_DARK` is a fixed setting derived from the system state at WebView-setup time; on its own it does not track later system theme changes for pages that rely on forced darkening (pages without their own `prefers-color-scheme` dark theme). #301 fixed the common case (pages with their own dark theme) by adding `uiMode` to the shell's `configChanges`; this makes dark-mode following robust for the remaining case too.

`setAlgorithmicDarkeningAllowed(true)` (API 33+ / modern WebView) is the recommended approach: the WebView darkens content based on the system theme automatically and respects the page's own `prefers-color-scheme`, so it keeps responding to system theme changes at runtime for all pages.

## Change (`WebViewManager.kt`)

Check `ALGORITHMIC_DARKENING` first and use `setAlgorithmicDarkeningAllowed(true)`; fall back to the existing `FORCE_DARK` path only on older WebViews that don't support algorithmic darkening (those devices recreate the activity on a `uiMode` change, which re-applies `FORCE_DARK`).

## Testing

- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
- `./gradlew :shell:assembleRelease :app:syncShellTemplateApk` → BUILD SUCCESSFUL; shell copy and template APK contain the change.
- Note: dark-mode rendering is runtime behavior best confirmed on-device (toggle system dark mode in an app whose page has no dark theme of its own); the change only swaps the preferred API and keeps the legacy fallback.
