### PR TITLE
fix(webview): load the new target when switching between app shortcuts

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -867,6 +867,20 @@ class WebViewActivity : AppCompatActivity() {
         }
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        // WebViewActivity is singleTask, so opening another shortcut/deep link reuses this
+        // instance and delivers the new intent here instead of creating a fresh activity.
+        // Recreate so the new target loads rather than keeping the previous app (issue #309 —
+        // users had to close one shortcut before the next would work). Re-opening the same app's
+        // shortcut (same app_id) just brings it to the foreground without restarting.
+        val newAppId = intent.getLongExtra(EXTRA_APP_ID, -1)
+        if (newAppId <= 0 || newAppId != trackedAppId) {
+            recreate()
+        }
+    }
+
     override fun onResume() {
         super.onResume()
         webView?.onResume()


### PR DESCRIPTION
Fixes #309

## User-visible effect

Opening a second WebToApp shortcut now loads its website directly, instead of requiring the user to close the previous shortcut first.

## Root cause

The shortcuts (created by `AppExporter.createShortcut`) launch `WebViewActivity` with an `app_id` extra and `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP`. `WebViewActivity` is `singleTask`, so opening another shortcut reuses the existing instance and delivers the new intent to `onNewIntent`. But `WebViewActivity` did not override `onNewIntent`, so the new `app_id` was ignored and the previous app stayed on screen — the user had to close it before the next shortcut would work.

## Change (`WebViewActivity.kt`)

Override `onNewIntent`: call `setIntent(intent)` and, when the new intent targets a different app (or a URL/deep link rather than the app already shown), `recreate()` the activity so the new target loads. Re-opening the same app's shortcut (same `app_id`) just brings it to the foreground without restarting.

## Testing

- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
- Note: shortcut switching is runtime behavior best confirmed on-device (create two app shortcuts, open one then the other without closing); the change is a standard `onNewIntent` + `recreate()` for the `singleTask` activity.
