### PR TITLE
feat(activation): deliver target URL from verification server (dynamic URL, phase 1)

### DIFF
--- a/.github/docs/remote-activation.md
+++ b/.github/docs/remote-activation.md
@@ -56,7 +56,8 @@ Accept: application/json
   "remainingUses": 5,
   "message": "",
   "nonce": "Base64-random-24-bytes",
-  "sig": "Base64-ECDSA-signature"
+  "sig": "Base64-ECDSA-signature",
+  "url": "https://example.com/app"
 }
 ```
 
@@ -68,6 +69,7 @@ Accept: application/json
 | `message` | string | Shown to the user on rejection. |
 | `nonce` | string | Must equal the request nonce. |
 | `sig` | string | Base64 ECDSA (`SHA256withECDSA`, DER-encoded) over the canonical payload below. |
+| `url` | string \| null | Optional. The target URL to load. Only used (and signature-bound) when the app has **Deliver target URL from server** enabled — see [Dynamic URL delivery](#dynamic-url-delivery). Omit otherwise. |
 
 ### Canonical payload that gets signed
 
@@ -83,11 +85,36 @@ this order:
 - `remainingUses` falls back to `-1` when you omit it.
 - No spaces, booleans unquoted, numbers unquoted.
 
+When **Deliver target URL from server** is enabled, a fifth key `url` is
+appended (after `nonce`), and the signature must cover it too:
+
+```
+{"ok":<true|false>,"expiresAt":<number>,"remainingUses":<number>,"nonce":"<nonce>","url":"<url>"}
+```
+
+`url` falls back to `""` when you omit it. Apps that do not enable URL delivery
+verify the legacy four-key payload, so existing servers keep working unchanged.
+
 Example of the precise bytes to sign:
 
 ```
 {"ok":true,"expiresAt":1735862400000,"remainingUses":5,"nonce":"k7Q…"}
 ```
+
+## Dynamic URL delivery
+
+When **Deliver target URL from server** is enabled in the app, the target URL
+is not packaged into the APK. Instead the app loads the URL you return in the
+`url` field after a successful activation (and caches it for offline launches
+under `ALLOW_CACHED`). This lets you change the URL without repackaging, and
+keeps the URL out of the APK so it cannot be extracted statically.
+
+- Return the URL in `url` and include it in the signed payload (fifth key).
+- The URL is cached on the device after a successful online activation; offline
+  launches reuse the cached URL per the offline policy.
+- The URL is delivered in the clear inside the signed response (over HTTPS).
+  This raises the bar against casual extraction but is not DRM-grade — a
+  determined attacker can still recover it from the response or memory.
 
 ## Generating a key pair
 
@@ -108,18 +135,25 @@ const fs = require("fs");
 const privateKey = crypto.createPrivateKey(fs.readFileSync("ec_private.pem"));
 
 // Your own source of truth. Revoke by removing/flipping entries here.
+// `url` is optional: set it (and enable "Deliver target URL from server" in the
+// app) to deliver the target URL dynamically instead of packaging it.
 const CODES = {
-  "ABC123": { expiresAt: 1735862400000, remainingUses: 5 },
+  "ABC123": { expiresAt: 1735862400000, remainingUses: 5, url: "https://example.com/app" },
 };
 
-function signedPayload({ ok, expiresAt, remainingUses, nonce }) {
+function signedPayload({ ok, expiresAt, remainingUses, nonce, url }) {
   // Must match the app's canonical order exactly.
-  return JSON.stringify({
+  const payload = {
     ok,
     expiresAt: expiresAt ?? 0,
     remainingUses: remainingUses ?? -1,
     nonce,
-  });
+  };
+  // Include url only when delivering it; it becomes the fifth signed key.
+  if (url !== undefined) {
+    payload.url = url ?? "";
+  }
+  return JSON.stringify(payload);
 }
 
 function sign(payloadString) {
@@ -146,7 +180,7 @@ http
       const entry = CODES[code];
 
       const result = entry
-        ? { ok: true, expiresAt: entry.expiresAt, remainingUses: entry.remainingUses, message: "" }
+        ? { ok: true, expiresAt: entry.expiresAt, remainingUses: entry.remainingUses, message: "", url: entry.url }
         : { ok: false, expiresAt: 0, remainingUses: -1, message: "Code not recognised" };
 
       const sig = sign(signedPayload({ ...result, nonce }));

--- a/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
@@ -92,7 +92,8 @@ class ActivationManager(private val context: Context) {
     fun buildRemoteRequest(
         verifyUrl: String,
         publicKeyBase64: String,
-        offlinePolicy: com.webtoapp.data.model.RemoteActivationOfflinePolicy
+        offlinePolicy: com.webtoapp.data.model.RemoteActivationOfflinePolicy,
+        deliverUrl: Boolean = false
     ): RemoteActivationVerifier.RemoteRequest {
         return RemoteActivationVerifier.RemoteRequest(
             verifyUrl = verifyUrl,
@@ -100,8 +101,13 @@ class ActivationManager(private val context: Context) {
             offlinePolicy = offlinePolicy,
             code = "",
             deviceId = DeviceIdGenerator.getDeviceId(context),
-            packageName = context.packageName
+            packageName = context.packageName,
+            deliverUrl = deliverUrl
         )
+    }
+
+    suspend fun getCachedRemoteUrl(appId: Long): String? {
+        return remoteVerifier.getCachedRemoteUrl(appId)
     }
 
     suspend fun verifyActivationCode(
@@ -239,7 +245,7 @@ class ActivationManager(private val context: Context) {
             }
         }
 
-        return ActivationResult.Success
+        return ActivationResult.Success()
     }
 
     fun isActivated(appId: Long): Flow<Boolean> {
@@ -485,7 +491,7 @@ class ActivationManager(private val context: Context) {
 }
 
 sealed class ActivationResult {
-    data object Success : ActivationResult()
+    data class Success(val url: String? = null) : ActivationResult()
     data class Invalid(val message: String = "") : ActivationResult()
     data object Empty : ActivationResult()
     data object AlreadyActivated : ActivationResult()

--- a/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
@@ -35,7 +35,8 @@ class RemoteActivationVerifier(private val context: Context) {
         val offlinePolicy: RemoteActivationOfflinePolicy,
         val code: String,
         val deviceId: String,
-        val packageName: String
+        val packageName: String,
+        val deliverUrl: Boolean = false
     )
 
     private val secureRandom = SecureRandom()
@@ -75,7 +76,7 @@ class RemoteActivationVerifier(private val context: Context) {
         val parsed = parseResponse(response)
             ?: return ActivationResult.Invalid(remoteRejectedMessage())
 
-        if (!verifySignature(publicKey, parsed, nonce)) {
+        if (!verifySignature(publicKey, parsed, nonce, request.deliverUrl)) {
             AppLogger.w(TAG, "Remote verification signature mismatch: app=$appId")
             return ActivationResult.Invalid(remoteSignatureFailedMessage())
         }
@@ -92,7 +93,7 @@ class RemoteActivationVerifier(private val context: Context) {
 
         saveCache(appId, request, parsed)
         AppLogger.i(TAG, "Remote verification success: app=$appId")
-        return ActivationResult.Success
+        return ActivationResult.Success(if (request.deliverUrl) parsed.url else null)
     }
 
     suspend fun resolveCachedStartup(appId: Long, request: RemoteRequest): Boolean {
@@ -103,11 +104,11 @@ class RemoteActivationVerifier(private val context: Context) {
 
     private suspend fun handleOffline(appId: Long, request: RemoteRequest): ActivationResult {
         return when (request.offlinePolicy) {
-            RemoteActivationOfflinePolicy.ALLOW -> ActivationResult.Success
+            RemoteActivationOfflinePolicy.ALLOW -> ActivationResult.Success(getCachedRemoteUrl(appId))
             RemoteActivationOfflinePolicy.DENY -> ActivationResult.Invalid(remoteOfflineDeniedMessage())
             RemoteActivationOfflinePolicy.ALLOW_CACHED -> {
                 if (readValidCache(appId, request) != null) {
-                    ActivationResult.Success
+                    ActivationResult.Success(getCachedRemoteUrl(appId))
                 } else {
                     ActivationResult.Invalid(remoteOfflineNoCacheMessage())
                 }
@@ -158,13 +159,14 @@ class RemoteActivationVerifier(private val context: Context) {
         }
     }
 
-    private data class RemoteResponse(
+    internal data class RemoteResponse(
         val ok: Boolean,
         val expiresAt: Long?,
         val remainingUses: Int?,
         val message: String,
         val nonce: String,
-        val signature: String
+        val signature: String,
+        val url: String?
     )
 
     private fun parseResponse(raw: String): RemoteResponse? {
@@ -178,7 +180,8 @@ class RemoteActivationVerifier(private val context: Context) {
                 remainingUses = obj.get("remainingUses")?.takeIf { !it.isJsonNull }?.asInt,
                 message = obj.get("message")?.takeIf { !it.isJsonNull }?.asString ?: "",
                 nonce = obj.get("nonce")?.takeIf { !it.isJsonNull }?.asString ?: "",
-                signature = obj.get("sig")?.takeIf { !it.isJsonNull }?.asString ?: ""
+                signature = obj.get("sig")?.takeIf { !it.isJsonNull }?.asString ?: "",
+                url = obj.get("url")?.takeIf { !it.isJsonNull }?.asString
             )
         } catch (e: Exception) {
             AppLogger.w(TAG, "Remote response parse failure: ${e.message}")
@@ -203,15 +206,16 @@ class RemoteActivationVerifier(private val context: Context) {
         }
     }
 
-    private fun verifySignature(
+    internal fun verifySignature(
         publicKey: java.security.PublicKey,
         response: RemoteResponse,
-        expectedNonce: String
+        expectedNonce: String,
+        includeUrl: Boolean
     ): Boolean {
         if (response.signature.isBlank()) return false
         if (response.nonce != expectedNonce) return false
         return try {
-            val signed = canonicalSignedPayload(response)
+            val signed = canonicalSignedPayload(response, includeUrl)
             val sigBytes = android.util.Base64.decode(response.signature, android.util.Base64.DEFAULT)
             val verifier = Signature.getInstance("SHA256withECDSA")
             verifier.initVerify(publicKey)
@@ -223,12 +227,18 @@ class RemoteActivationVerifier(private val context: Context) {
         }
     }
 
-    private fun canonicalSignedPayload(response: RemoteResponse): String {
+    internal fun canonicalSignedPayload(response: RemoteResponse, includeUrl: Boolean): String {
         val obj = JsonObject()
         obj.addProperty("ok", response.ok)
         obj.addProperty("expiresAt", response.expiresAt ?: 0L)
         obj.addProperty("remainingUses", response.remainingUses ?: -1)
         obj.addProperty("nonce", response.nonce)
+        // When deliverUrl is enabled the delivered URL is part of the signed payload, so a MITM
+        // cannot swap it while keeping a valid signature. Servers that don't deliver a URL sign
+        // the legacy payload (without url), which stays backward compatible.
+        if (includeUrl) {
+            obj.addProperty("url", response.url ?: "")
+        }
         return obj.toString()
     }
 
@@ -246,7 +256,15 @@ class RemoteActivationVerifier(private val context: Context) {
             prefs[stringPreferencesKey("remote_code_$appId")] = request.code
             prefs[longPreferencesKey("remote_expires_$appId")] = response.expiresAt ?: 0L
             prefs[longPreferencesKey("remote_verified_at_$appId")] = System.currentTimeMillis()
+            if (request.deliverUrl) {
+                prefs[stringPreferencesKey("remote_url_$appId")] = response.url ?: ""
+            }
         }
+    }
+
+    suspend fun getCachedRemoteUrl(appId: Long): String? {
+        val url = context.activationDataStore.data.first()[stringPreferencesKey("remote_url_$appId")]
+        return url?.takeIf { it.isNotBlank() }
     }
 
     private suspend fun clearCache(appId: Long) {
@@ -254,6 +272,7 @@ class RemoteActivationVerifier(private val context: Context) {
             prefs.remove(stringPreferencesKey("remote_code_$appId"))
             prefs.remove(longPreferencesKey("remote_expires_$appId"))
             prefs.remove(longPreferencesKey("remote_verified_at_$appId"))
+            prefs.remove(stringPreferencesKey("remote_url_$appId"))
         }
     }
 

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3422,7 +3422,8 @@ private fun WebApp.buildActivationBlock(): ActivationBlock = ActivationBlock(
     remoteEnabled = activationRemoteConfig?.enabled ?: false,
     remoteVerifyUrl = activationRemoteConfig?.verifyUrl ?: "",
     remotePublicKey = activationRemoteConfig?.publicKeyBase64 ?: "",
-    remoteOfflinePolicy = activationRemoteConfig?.offlinePolicy?.name ?: "ALLOW_CACHED"
+    remoteOfflinePolicy = activationRemoteConfig?.offlinePolicy?.name ?: "ALLOW_CACHED",
+    remoteDeliverUrl = activationRemoteConfig?.deliverUrl ?: false
 )
 
 private fun WebApp.buildAdBlockBlock(): AdBlockBlock = AdBlockBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -64,6 +64,7 @@ data class ApkConfig(
     val activationRemoteVerifyUrl: String get() = activation.remoteVerifyUrl
     val activationRemotePublicKey: String get() = activation.remotePublicKey
     val activationRemoteOfflinePolicy: String get() = activation.remoteOfflinePolicy
+    val activationRemoteDeliverUrl: Boolean get() = activation.remoteDeliverUrl
 
     val adBlockEnabled: Boolean get() = adBlock.enabled
     val adBlockRules: List<String> get() = adBlock.rules
@@ -412,7 +413,8 @@ data class ActivationBlock(
     val remoteEnabled: Boolean = false,
     val remoteVerifyUrl: String = "",
     val remotePublicKey: String = "",
-    val remoteOfflinePolicy: String = "ALLOW_CACHED"
+    val remoteOfflinePolicy: String = "ALLOW_CACHED",
+    val remoteDeliverUrl: Boolean = false
 )
 
 data class AdBlockBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -41,6 +41,7 @@ internal object ApkConfigJsonFactory {
         "activationRemoteVerifyUrl" to activation.remoteVerifyUrl,
         "activationRemotePublicKey" to activation.remotePublicKey,
         "activationRemoteOfflinePolicy" to activation.remoteOfflinePolicy,
+        "activationRemoteDeliverUrl" to activation.remoteDeliverUrl,
         "adBlockEnabled" to adBlock.enabled,
         "adBlockRules" to adBlock.rules,
         "adBlockSubscriptions" to adBlock.subscriptions,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -879,6 +879,8 @@ object Strings {
     val remoteActivationOfflineDeny: String get() = StringsA.remoteActivationOfflineDeny
     val remoteActivationOfflineAllow: String get() = StringsA.remoteActivationOfflineAllow
     val remoteActivationPrivacyNote: String get() = StringsA.remoteActivationPrivacyNote
+    val remoteActivationDeliverUrlTitle: String get() = StringsA.remoteActivationDeliverUrlTitle
+    val remoteActivationDeliverUrlHint: String get() = StringsA.remoteActivationDeliverUrlHint
     val remoteActivationMisconfigured: String get() = StringsA.remoteActivationMisconfigured
     val remoteActivationInsecureUrl: String get() = StringsA.remoteActivationInsecureUrl
     val remoteActivationRejected: String get() = StringsA.remoteActivationRejected
@@ -15847,6 +15849,31 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Если включено, приложение отправляет код активации и идентификатор устройства на настроенный вами сервер. Сообщите об этом пользователям."
         AppLanguage.JAPANESE -> "有効にすると、アプリはアクティベーションコードとデバイス識別子を設定したサーバーに送信します。ユーザーにこれを明示してください。"
         AppLanguage.KOREAN -> "활성화 시, 앱이 활성화 코드와 기기 식별자를 구성한 서버로 전송합니다. 사용자에게 이를 알리세요."
+    }
+
+    val remoteActivationDeliverUrlTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "由服务器下发目标网址"
+        AppLanguage.ENGLISH -> "Deliver target URL from server"
+        AppLanguage.ARABIC -> "تسليم عنوان URL المستهدف من الخادم"
+        AppLanguage.PORTUGUESE -> "Entregar URL de destino do servidor"
+        AppLanguage.SPANISH -> "Entregar URL de destino desde el servidor"
+        AppLanguage.FRENCH -> "Fournir l'URL cible depuis le serveur"
+        AppLanguage.GERMAN -> "Ziel-URL vom Server bereitstellen"
+        AppLanguage.RUSSIAN -> "Доставлять целевой URL с сервера"
+        AppLanguage.JAPANESE -> "サーバーからターゲットURLを配信"
+        AppLanguage.KOREAN -> "서버에서 대상 URL 전달"
+    }
+    val remoteActivationDeliverUrlHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "开启后，目标网址在激活成功后由验证服务器下发，无需打包进应用（网址可留空，即空壳）。服务器需在签名响应中加入 url 字段。"
+        AppLanguage.ENGLISH -> "When enabled, the target URL is delivered by the verification server after successful activation instead of being packaged (the URL can be left empty). The server must include a signed url field in its response."
+        AppLanguage.ARABIC -> "عند التمكين، يتم تسليم عنوان URL المستهدف من خادم التحقق بعد نجاح التفعيل بدلاً من تعبئته (يمكن ترك عنوان URL فارغاً). يجب أن يتضمن الخادم حقل url موقّعاً في استجابته."
+        AppLanguage.PORTUGUESE -> "Quando ativado, o URL de destino é entregue pelo servidor de verificação após ativação bem-sucedida, em vez de ser empacotado (o URL pode ser deixado vazio). O servidor deve incluir um campo url assinado na resposta."
+        AppLanguage.SPANISH -> "Cuando está activado, el servidor de verificación entrega la URL de destino tras una activación correcta, en lugar de empaquetarla (la URL puede dejarse vacía). El servidor debe incluir un campo url firmado en su respuesta."
+        AppLanguage.FRENCH -> "Lorsqu'activé, l'URL cible est fournie par le serveur de vérification après une activation réussie, au lieu d'être empaquetée (l'URL peut être laissée vide). Le serveur doit inclure un champ url signé dans sa réponse."
+        AppLanguage.GERMAN -> "Wenn aktiviert, wird die Ziel-URL nach erfolgreicher Aktivierung vom Verifizierungsserver bereitgestellt, statt verpackt zu werden (die URL kann leer bleiben). Der Server muss ein signiertes url-Feld in seiner Antwort enthalten."
+        AppLanguage.RUSSIAN -> "Если включено, целевой URL доставляется сервером проверки после успешной активации вместо упаковки (URL можно оставить пустым). Сервер должен включать подписанное поле url в ответ."
+        AppLanguage.JAPANESE -> "有効にすると、ターゲットURLはパッケージ化される代わりに、アクティベーション成功後に検証サーバーから配信されます（URLは空欄可）。サーバーは応答に署名付きのurlフィールドを含める必要があります。"
+        AppLanguage.KOREAN -> "활성화 시, 대상 URL이 패키징되는 대신 활성화 성공 후 검증 서버에서 전달됩니다(URL은 비워둘 수 있음). 서버는 응답에 서명된 url 필드를 포함해야 합니다."
     }
 
     val remoteActivationMisconfigured: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -86,7 +86,8 @@ class ShellModeManager(private val context: Context) {
                     entryFile.isNotBlank() && entryFile.substringBeforeLast(".").isNotBlank()
                 }
                 normalizedAppType in listOf("IMAGE", "VIDEO", "GALLERY", "WORDPRESS", "NODEJS_APP", "PHP_APP", "PYTHON_APP", "GO_APP", "MULTI_WEB") -> true
-                else -> !config?.targetUrl.isNullOrBlank()
+                else -> !config?.targetUrl.isNullOrBlank() ||
+                    (config?.activationRemoteEnabled == true && config.activationRemoteDeliverUrl)
             }
             if (!isValid) {
                 AppLogger.w(TAG, "配置无效: appType=${config?.appType}, targetUrl=${config?.targetUrl}")
@@ -180,6 +181,9 @@ data class ShellConfig(
 
     @SerializedName("activationRemoteOfflinePolicy")
     val activationRemoteOfflinePolicy: String = "ALLOW_CACHED",
+
+    @SerializedName("activationRemoteDeliverUrl")
+    val activationRemoteDeliverUrl: Boolean = false,
 
     @SerializedName("adBlockEnabled")
     val adBlockEnabled: Boolean = false,

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -1261,7 +1261,8 @@ data class RemoteActivationConfig(
     val enabled: Boolean = false,
     val verifyUrl: String = "",
     val publicKeyBase64: String = "",
-    val offlinePolicy: RemoteActivationOfflinePolicy = RemoteActivationOfflinePolicy.ALLOW_CACHED
+    val offlinePolicy: RemoteActivationOfflinePolicy = RemoteActivationOfflinePolicy.ALLOW_CACHED,
+    val deliverUrl: Boolean = false
 )
 
 data class AutoStartConfig(

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -661,6 +661,28 @@ private fun RemoteActivationSection(
                     }
                 }
 
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
+                        Text(
+                            text = Strings.remoteActivationDeliverUrlTitle,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = Strings.remoteActivationDeliverUrlHint,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    WtaSwitch(
+                        checked = remoteConfig.deliverUrl,
+                        onCheckedChange = { onRemoteConfigChange(remoteConfig.copy(deliverUrl = it)) }
+                    )
+                }
+
                 Text(
                     text = Strings.remoteActivationPrivacyNote,
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 fun ShellActivationDialog(
     config: ShellConfig,
     onDismiss: () -> Unit,
-    onActivated: () -> Unit
+    onActivated: (String?) -> Unit
 ) {
     val context = LocalContext.current
     val activation = WebToAppApplication.activation
@@ -50,7 +50,8 @@ fun ShellActivationDialog(
                         activation.buildRemoteRequest(
                             verifyUrl = config.activationRemoteVerifyUrl,
                             publicKeyBase64 = config.activationRemotePublicKey,
-                            offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy)
+                            offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
+                            deliverUrl = config.activationRemoteDeliverUrl
                         )
                     )
                 } else {
@@ -62,7 +63,7 @@ fun ShellActivationDialog(
                 }
                 when (result) {
                     is ActivationResult.Success -> {
-                        onActivated()
+                        onActivated(result.url)
                     }
                     is ActivationResult.Invalid -> {
                         activationError = result.message.ifBlank {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -81,6 +81,10 @@ fun ShellScreen(
 
     var isActivationChecked by remember { mutableStateOf(!config.activationEnabled) }
 
+    // Target URL delivered by the remote activation server (dynamic URL mode). Takes precedence
+    // over the packaged targetUrl so the URL need not be hardcoded in the APK.
+    var dynamicUrl by remember { mutableStateOf<String?>(null) }
+
     var webViewRecreationKey by remember { mutableIntStateOf(0) }
     var canGoBack by remember { mutableStateOf(false) }
     var canGoForward by remember { mutableStateOf(false) }
@@ -162,7 +166,8 @@ fun ShellScreen(
                             activation.buildRemoteRequest(
                                 verifyUrl = config.activationRemoteVerifyUrl,
                                 publicKeyBase64 = config.activationRemotePublicKey,
-                                offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy)
+                                offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
+                                deliverUrl = config.activationRemoteDeliverUrl
                             )
                         )
                 } else {
@@ -170,6 +175,9 @@ fun ShellScreen(
                 }
                 isActivated = activated
                 isActivationChecked = true
+                if (activated && config.activationRemoteEnabled && config.activationRemoteDeliverUrl) {
+                    dynamicUrl = activation.getCachedRemoteUrl(-1L)
+                }
                 if (!activated) {
                     showActivationDialog = true
                 }
@@ -400,7 +408,7 @@ fun ShellScreen(
         webViewConfig = webViewConfig,
         webViewCallbacks = webViewCallbacks,
         webViewManager = webViewManager,
-        deepLinkUrl = deepLinkUrl,
+        deepLinkUrl = deepLinkUrl ?: dynamicUrl,
         bgmState = bgmState,
         swipeRefreshEnabled = swipeRefreshEnabled,
         isRefreshing = isRefreshing,
@@ -418,9 +426,12 @@ fun ShellScreen(
         ShellActivationDialog(
             config = config,
             onDismiss = { showActivationDialog = false },
-            onActivated = {
+            onActivated = { url ->
                 isActivated = true
                 showActivationDialog = false
+                if (config.activationRemoteEnabled && config.activationRemoteDeliverUrl) {
+                    dynamicUrl = url
+                }
 
                 if (config.announcementEnabled && config.announcementTitle.isNotEmpty()) {
                     val ann = Announcement(

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
@@ -507,11 +507,14 @@ class MainViewModel(
                 false
             }
 
-            state.appType == AppType.WEB && state.url.isBlank() -> {
+            state.appType == AppType.WEB && state.url.isBlank() &&
+                !(state.activationEnabled &&
+                    state.activationRemoteConfig?.enabled == true &&
+                    state.activationRemoteConfig?.deliverUrl == true) -> {
                 _uiState.value = UiState.Error(Strings.pleaseEnterWebsiteUrl)
                 false
             }
-            state.appType == AppType.WEB && !isValidUrl(state.url) -> {
+            state.appType == AppType.WEB && state.url.isNotBlank() && !isValidUrl(state.url) -> {
                 _uiState.value = UiState.Error(Strings.pleaseEnterValidUrl)
                 false
             }

--- a/app/src/test/java/com/webtoapp/core/activation/RemoteActivationVerifierTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/RemoteActivationVerifierTest.kt
@@ -1,0 +1,81 @@
+package com.webtoapp.core.activation
+
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+
+/**
+ * Guards the dynamic-URL delivery contract (issue #314): when deliverUrl is enabled the delivered
+ * URL is part of the signed payload, so a MITM cannot swap it while keeping a valid signature.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RemoteActivationVerifierTest {
+
+    private val verifier = RemoteActivationVerifier(ApplicationProvider.getApplicationContext())
+
+    private fun response(url: String?, sig: String = "", nonce: String = "nonce123") =
+        RemoteActivationVerifier.RemoteResponse(
+            ok = true,
+            expiresAt = 1735862400000L,
+            remainingUses = 5,
+            message = "",
+            nonce = nonce,
+            signature = sig,
+            url = url
+        )
+
+    private fun sign(payload: String, privateKey: PrivateKey): String {
+        val sig = Signature.getInstance("SHA256withECDSA")
+        sig.initSign(privateKey)
+        sig.update(payload.toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(sig.sign(), Base64.DEFAULT)
+    }
+
+    @Test
+    fun `canonical payload includes url only when deliverUrl enabled`() {
+        val resp = response(url = "https://example.com/app")
+        val withUrl = verifier.canonicalSignedPayload(resp, includeUrl = true)
+        val withoutUrl = verifier.canonicalSignedPayload(resp, includeUrl = false)
+
+        assertThat(withUrl).contains("\"url\":\"https://example.com/app\"")
+        assertThat(withoutUrl).doesNotContain("url")
+        // url is the fifth key, appended after nonce
+        assertThat(withUrl).endsWith("\"nonce\":\"nonce123\",\"url\":\"https://example.com/app\"}")
+    }
+
+    @Test
+    fun `signature verifies when url matches and fails when tampered`() {
+        val kpg = KeyPairGenerator.getInstance("EC").apply { initialize(ECGenParameterSpec("secp256r1")) }
+        val keyPair = kpg.generateKeyPair()
+
+        val goodUrl = "https://good.example.com"
+        val payload = verifier.canonicalSignedPayload(response(url = goodUrl), includeUrl = true)
+        val sig = sign(payload, keyPair.private)
+
+        val goodResponse = response(url = goodUrl, sig = sig)
+        assertThat(verifier.verifySignature(keyPair.public, goodResponse, "nonce123", includeUrl = true)).isTrue()
+
+        // Swapping the URL while keeping the signature must fail verification.
+        val tampered = response(url = "https://evil.example.com", sig = sig)
+        assertThat(verifier.verifySignature(keyPair.public, tampered, "nonce123", includeUrl = true)).isFalse()
+    }
+
+    @Test
+    fun `legacy payload without url still verifies for servers not delivering a url`() {
+        val kpg = KeyPairGenerator.getInstance("EC").apply { initialize(ECGenParameterSpec("secp256r1")) }
+        val keyPair = kpg.generateKeyPair()
+
+        val payload = verifier.canonicalSignedPayload(response(url = null), includeUrl = false)
+        val sig = sign(payload, keyPair.private)
+
+        val resp = response(url = null, sig = sig)
+        assertThat(verifier.verifySignature(keyPair.public, resp, "nonce123", includeUrl = false)).isTrue()
+    }
+}


### PR DESCRIPTION
Fixes #345 (feature request #314, phase 1)

## What this adds

A **Deliver target URL from server** option for online card verification. When enabled, the target URL is not packaged into the APK; after a successful activation the verification server returns it in a signed `url` field, the app caches it (for offline launches under `ALLOW_CACHED`) and loads it. This enables hot-updating the URL without repackaging and keeps the URL out of the APK (cannot be extracted statically).

## Changes

**Config chain** (passes `checkConfigFieldDrift`):
- `RemoteActivationConfig.deliverUrl` → `ActivationBlock.remoteDeliverUrl` → `ApkConfig` getter → `ApkConfigJsonFactory` (`activationRemoteDeliverUrl`) → `ShellModeManager` (`@SerializedName`).

**Protocol** (`RemoteActivationVerifier`):
- Response gains an optional `url` field. When `deliverUrl` is enabled, `url` is appended to the canonical signed payload (fifth key) so it is signature-bound (a MITM cannot swap it); when disabled, the legacy four-key payload is verified, so existing servers keep working.
- `ActivationResult.Success` now carries the delivered URL; verified/cached URLs are persisted (`remote_url_<appId>`) and surfaced for offline startups.

**Editor UI**:
- New "Deliver target URL from server" toggle in the remote-activation section (10 languages); the URL may be left empty (empty shell) when enabled, and the editor's empty-URL validation is relaxed accordingly.

**Runtime (shell)**:
- `ShellScreen` tracks a `dynamicUrl` (from the live verify result or the offline cache); `ShellContentRouter` loads `deepLinkUrl ?: dynamicUrl ?: config.targetUrl`. The shell validity gate accepts an empty `targetUrl` when delivery is enabled.

**Docs**: `remote-activation.md` documents the `url` field, the conditional signed payload, a "Dynamic URL delivery" section, and the reference-server change.

## Security note

The URL is delivered inside the signed response over HTTPS — this raises the bar against casual extraction but is not DRM-grade. URL payload encryption (AES) is deferred to phase 2.

## Testing

- New `RemoteActivationVerifierTest` (3 cases): url included in the signed payload only when enabled; signature fails on a tampered url; legacy payload still verifies.
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
- `./gradlew :app:checkConfigFieldDrift` → OK.
- `./gradlew :shell:assembleRelease :app:syncShellTemplateApk` → BUILD SUCCESSFUL.
