### PR TITLE
feat(activation): AES-256-GCM URL encryption for dynamic URL delivery (Phase 2)

### DIFF
--- a/.github/docs/remote-activation.md
+++ b/.github/docs/remote-activation.md
@@ -22,6 +22,9 @@ the activation-code section and fill in:
 | Verification endpoint | Your `https://…` URL. Plain `http://` is rejected. |
 | Signature public key | An **EC P-256** public key in Base64 (SPKI / `BEGIN PUBLIC KEY`). The app verifies every response with it. |
 | Offline policy | `ALLOW_CACHED` (default): allow the last successful result until it expires. `DENY`: block when offline. `ALLOW`: always allow when offline (insecure). |
+| Deliver target URL | When on, the target URL is delivered by the server at activation time (not packaged in the APK). See [Dynamic URL delivery](#dynamic-url-delivery). |
+| Encrypt target URL | When on (requires Deliver URL), the server must encrypt the URL with AES-256-GCM before signing. See [URL Encryption](#url-encryption-aes-256-gcm). |
+| AES-256 key | 32-byte Base64 key shared with the server. Required when encryption is enabled. |
 
 ## Request (app → your server)
 
@@ -69,7 +72,7 @@ Accept: application/json
 | `message` | string | Shown to the user on rejection. |
 | `nonce` | string | Must equal the request nonce. |
 | `sig` | string | Base64 ECDSA (`SHA256withECDSA`, DER-encoded) over the canonical payload below. |
-| `url` | string \| null | Optional. The target URL to load. Only used (and signature-bound) when the app has **Deliver target URL from server** enabled — see [Dynamic URL delivery](#dynamic-url-delivery). Omit otherwise. |
+| `url` | string \| null | Optional. The target URL to load. Only used (and signature-bound) when the app has **Deliver target URL from server** enabled — see [Dynamic URL delivery](#dynamic-url-delivery). When **Encrypt target URL** is also enabled, this field contains the AES-256-GCM ciphertext (see [URL Encryption](#url-encryption-aes-256-gcm)). Omit otherwise. |
 
 ### Canonical payload that gets signed
 
@@ -116,6 +119,64 @@ keeps the URL out of the APK so it cannot be extracted statically.
   This raises the bar against casual extraction but is not DRM-grade — a
   determined attacker can still recover it from the response or memory.
 
+## URL Encryption (AES-256-GCM)
+
+When both **Deliver target URL from server** and **Encrypt target URL** are
+enabled, the server must encrypt the URL with AES-256-GCM **before** signing.
+The ciphertext goes into the `url` field and the signed payload.
+
+| Parameter | Value |
+| --- | --- |
+| Algorithm | AES-256-GCM (authenticated encryption) |
+| Key | 32 bytes, shared between app config and server |
+| IV | 12 random bytes per encryption |
+| Wire format | `Base64(IV[12B] \|\| ciphertext \|\| GCM tag[16B])` |
+
+**Why encrypt the URL when the response is already over HTTPS and ECDSA-signed?**
+Defense in depth. If an attacker compromises the TLS layer (corporate MITM
+proxy with a user-installed CA, misconfigured certificate pinning bypass) or
+dumps the response from memory, the URL stays unreadable without the AES key.
+The signature still prevents tampering, and the encryption prevents reading.
+
+### Generating an AES-256 key
+
+```bash
+# Generate a 32-byte random key and Base64-encode it
+openssl rand -base64 32
+```
+
+Paste the same Base64 string into both the app's **AES-256 key** field and
+your server configuration.
+
+### Server-side encryption (Node.js)
+
+```js
+const crypto = require("crypto");
+
+function encryptUrl(plaintext, aesKeyBase64) {
+  const key = Buffer.from(aesKeyBase64, "base64"); // 32 bytes
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  let encrypted = cipher.update(plaintext, "utf8");
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+  const tag = cipher.getAuthTag(); // 16 bytes
+  // Wire format: IV || ciphertext || tag
+  return Buffer.concat([iv, encrypted, tag]).toString("base64");
+}
+```
+
+### Signing flow with encryption
+
+1. Encrypt the URL → Base64 ciphertext blob.
+2. Build the canonical payload with the ciphertext blob as the `url` value.
+3. Sign the canonical payload with ECDSA.
+4. Return the ciphertext blob in the response `url` field and the signature in `sig`.
+
+The client verifies the signature first (which covers the ciphertext), then
+decrypts `url` with the shared AES key to recover the plaintext URL. An
+attacker who tampers with the ciphertext breaks the signature; an attacker who
+reads the response sees only encrypted bytes.
+
 ## Generating a key pair
 
 ```bash
@@ -137,9 +198,26 @@ const privateKey = crypto.createPrivateKey(fs.readFileSync("ec_private.pem"));
 // Your own source of truth. Revoke by removing/flipping entries here.
 // `url` is optional: set it (and enable "Deliver target URL from server" in the
 // app) to deliver the target URL dynamically instead of packaging it.
+// When URL encryption is enabled, encrypt `url` with the shared AES key before
+// returning it (see the `encryptUrl` helper below).
 const CODES = {
   "ABC123": { expiresAt: 1735862400000, remainingUses: 5, url: "https://example.com/app" },
 };
+
+// ---- AES-256-GCM encryption (only needed when "Encrypt target URL" is on) ----
+const AES_KEY_BASE64 = process.env.AES_KEY_BASE64 || ""; // same as in the app config
+const AES_KEY = AES_KEY_BASE64 ? Buffer.from(AES_KEY_BASE64, "base64") : null;
+
+function encryptUrl(plaintext) {
+  if (!AES_KEY || AES_KEY.length !== 32) return plaintext; // passthrough if not configured
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", AES_KEY, iv);
+  let encrypted = cipher.update(plaintext, "utf8");
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, encrypted, tag]).toString("base64");
+}
+// -------------------------------------------------------------------------
 
 function signedPayload({ ok, expiresAt, remainingUses, nonce, url }) {
   // Must match the app's canonical order exactly.
@@ -150,6 +228,7 @@ function signedPayload({ ok, expiresAt, remainingUses, nonce, url }) {
     nonce,
   };
   // Include url only when delivering it; it becomes the fifth signed key.
+  // When encryption is on, `url` is already the ciphertext blob here.
   if (url !== undefined) {
     payload.url = url ?? "";
   }
@@ -180,13 +259,18 @@ http
       const entry = CODES[code];
 
       const result = entry
-        ? { ok: true, expiresAt: entry.expiresAt, remainingUses: entry.remainingUses, message: "", url: entry.url }
+        ? { ok: true, expiresAt: entry.expiresAt, remainingUses: entry.remainingUses, message: "" }
         : { ok: false, expiresAt: 0, remainingUses: -1, message: "Code not recognised" };
 
-      const sig = sign(signedPayload({ ...result, nonce }));
+      // Encrypt the URL if AES key is configured; the ciphertext goes into
+      // both the signed payload and the response.
+      const urlPlain = entry && entry.url ? entry.url : undefined;
+      const urlEnc = urlPlain ? encryptUrl(urlPlain) : undefined;
+
+      const sig = sign(signedPayload({ ...result, nonce, url: urlEnc }));
 
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ...result, nonce, sig }));
+      res.end(JSON.stringify({ ...result, nonce, sig, url: urlEnc }));
     });
   })
   .listen(8443);

--- a/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
@@ -93,7 +93,9 @@ class ActivationManager(private val context: Context) {
         verifyUrl: String,
         publicKeyBase64: String,
         offlinePolicy: com.webtoapp.data.model.RemoteActivationOfflinePolicy,
-        deliverUrl: Boolean = false
+        deliverUrl: Boolean = false,
+        encryptUrl: Boolean = false,
+        aesKeyBase64: String = ""
     ): RemoteActivationVerifier.RemoteRequest {
         return RemoteActivationVerifier.RemoteRequest(
             verifyUrl = verifyUrl,
@@ -102,7 +104,9 @@ class ActivationManager(private val context: Context) {
             code = "",
             deviceId = DeviceIdGenerator.getDeviceId(context),
             packageName = context.packageName,
-            deliverUrl = deliverUrl
+            deliverUrl = deliverUrl,
+            encryptUrl = encryptUrl,
+            aesKeyBase64 = aesKeyBase64
         )
     }
 

--- a/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
@@ -20,6 +20,9 @@ import java.security.SecureRandom
 import java.security.Signature
 import java.security.spec.X509EncodedKeySpec
 import java.util.concurrent.TimeUnit
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 class RemoteActivationVerifier(private val context: Context) {
 
@@ -27,6 +30,11 @@ class RemoteActivationVerifier(private val context: Context) {
         private const val TAG = "RemoteActivation"
         private const val NONCE_BYTES = 24
         private const val CACHE_GRACE_MS = 0L
+
+        // AES-256-GCM wire format: Base64(IV[12] || ciphertext || tag[16])
+        private const val AES_GCM_IV_BYTES = 12
+        private const val AES_GCM_TAG_BYTES = 16
+        private const val AES_KEY_BYTES = 32
     }
 
     data class RemoteRequest(
@@ -36,7 +44,9 @@ class RemoteActivationVerifier(private val context: Context) {
         val code: String,
         val deviceId: String,
         val packageName: String,
-        val deliverUrl: Boolean = false
+        val deliverUrl: Boolean = false,
+        val encryptUrl: Boolean = false,
+        val aesKeyBase64: String = ""
     )
 
     private val secureRandom = SecureRandom()
@@ -52,6 +62,10 @@ class RemoteActivationVerifier(private val context: Context) {
     suspend fun verify(appId: Long, request: RemoteRequest): ActivationResult {
         val urlValidation = validateUrl(request.verifyUrl)
         if (urlValidation != null) return urlValidation
+
+        if (request.encryptUrl && decodeAesKey(request.aesKeyBase64) == null) {
+            return ActivationResult.Invalid(remoteMisconfiguredMessage())
+        }
 
         val publicKey = parsePublicKey(request.publicKeyBase64)
             ?: return ActivationResult.Invalid(remoteMisconfiguredMessage())
@@ -76,6 +90,8 @@ class RemoteActivationVerifier(private val context: Context) {
         val parsed = parseResponse(response)
             ?: return ActivationResult.Invalid(remoteRejectedMessage())
 
+        // When deliverUrl is enabled, the url field is part of the signed payload
+        // (whether it is plaintext or AES-encrypted). verifySignature checks it accordingly.
         if (!verifySignature(publicKey, parsed, nonce, request.deliverUrl)) {
             AppLogger.w(TAG, "Remote verification signature mismatch: app=$appId")
             return ActivationResult.Invalid(remoteSignatureFailedMessage())
@@ -91,9 +107,25 @@ class RemoteActivationVerifier(private val context: Context) {
             return ActivationResult.Expired
         }
 
-        saveCache(appId, request, parsed)
+        // Decrypt the URL if encryption is enabled. The decrypted plaintext is cached and
+        // returned, so the cache layer never stores ciphertext.
+        val plaintextUrl = if (request.deliverUrl && request.encryptUrl) {
+            val decrypted = decryptUrl(parsed.url ?: "", request.aesKeyBase64)
+            if (decrypted == null) {
+                AppLogger.w(TAG, "URL decryption failed: app=$appId")
+                return ActivationResult.Invalid(remoteDecryptFailedMessage())
+            }
+            decrypted
+        } else if (request.deliverUrl) {
+            parsed.url
+        } else {
+            null
+        }
+
+        // saveCache stores the plaintext URL regardless of whether it arrived encrypted.
+        saveCache(appId, request, parsed, plaintextUrl)
         AppLogger.i(TAG, "Remote verification success: app=$appId")
-        return ActivationResult.Success(if (request.deliverUrl) parsed.url else null)
+        return ActivationResult.Success(plaintextUrl)
     }
 
     suspend fun resolveCachedStartup(appId: Long, request: RemoteRequest): Boolean {
@@ -242,6 +274,55 @@ class RemoteActivationVerifier(private val context: Context) {
         return obj.toString()
     }
 
+    /**
+     * Decrypts an AES-256-GCM encrypted URL.
+     *
+     * Wire format: Base64(IV[12 bytes] || ciphertext || GCM tag[16 bytes]).
+     * Returns the plaintext URL or null on any decryption failure.
+     */
+    internal fun decryptUrl(encryptedBase64: String, aesKeyBase64: String): String? {
+        if (encryptedBase64.isBlank() || aesKeyBase64.isBlank()) return null
+        return try {
+            val keyBytes = decodeAesKey(aesKeyBase64) ?: return null
+            val combined = android.util.Base64.decode(encryptedBase64, android.util.Base64.DEFAULT)
+
+            if (combined.size < AES_GCM_IV_BYTES + AES_GCM_TAG_BYTES) return null
+
+            val iv = combined.copyOfRange(0, AES_GCM_IV_BYTES)
+            val tag = combined.copyOfRange(combined.size - AES_GCM_TAG_BYTES, combined.size)
+            val ciphertext = combined.copyOfRange(AES_GCM_IV_BYTES, combined.size - AES_GCM_TAG_BYTES)
+
+            // Concatenate ciphertext + tag for javax.crypto GCM decryption
+            val ciphertextWithTag = ciphertext + tag
+
+            val keySpec = SecretKeySpec(keyBytes, "AES")
+            val gcmSpec = GCMParameterSpec(AES_GCM_TAG_BYTES * 8, iv)
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmSpec)
+            val plaintext = cipher.doFinal(ciphertextWithTag)
+            String(plaintext, Charsets.UTF_8)
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "URL decryption failed: ${e.message}")
+            null
+        }
+    }
+
+    internal fun decodeAesKey(aesKeyBase64: String): ByteArray? {
+        if (aesKeyBase64.isBlank()) return null
+        return try {
+            val keyBytes = android.util.Base64.decode(aesKeyBase64.trim(), android.util.Base64.DEFAULT)
+            if (keyBytes.size != AES_KEY_BYTES) {
+                AppLogger.w(TAG, "AES key has incorrect length: ${keyBytes.size} (expected $AES_KEY_BYTES)")
+                null
+            } else {
+                keyBytes
+            }
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "AES key decode failed: ${e.message}")
+            null
+        }
+    }
+
     private suspend fun readValidCache(appId: Long, request: RemoteRequest): Long? {
         val prefs = context.activationDataStore.data.first()
         val cachedCode = prefs[stringPreferencesKey("remote_code_$appId")] ?: return null
@@ -251,13 +332,13 @@ class RemoteActivationVerifier(private val context: Context) {
         return expiresAt
     }
 
-    private suspend fun saveCache(appId: Long, request: RemoteRequest, response: RemoteResponse) {
+    private suspend fun saveCache(appId: Long, request: RemoteRequest, response: RemoteResponse, plaintextUrl: String?) {
         context.activationDataStore.edit { prefs ->
             prefs[stringPreferencesKey("remote_code_$appId")] = request.code
             prefs[longPreferencesKey("remote_expires_$appId")] = response.expiresAt ?: 0L
             prefs[longPreferencesKey("remote_verified_at_$appId")] = System.currentTimeMillis()
-            if (request.deliverUrl) {
-                prefs[stringPreferencesKey("remote_url_$appId")] = response.url ?: ""
+            if (request.deliverUrl && !plaintextUrl.isNullOrBlank()) {
+                prefs[stringPreferencesKey("remote_url_$appId")] = plaintextUrl
             }
         }
     }
@@ -295,4 +376,7 @@ class RemoteActivationVerifier(private val context: Context) {
 
     private fun remoteOfflineNoCacheMessage(): String =
         com.webtoapp.core.i18n.Strings.remoteActivationOfflineNoCache
+
+    private fun remoteDecryptFailedMessage(): String =
+        com.webtoapp.core.i18n.Strings.remoteActivationDecryptFailed
 }

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3423,7 +3423,9 @@ private fun WebApp.buildActivationBlock(): ActivationBlock = ActivationBlock(
     remoteVerifyUrl = activationRemoteConfig?.verifyUrl ?: "",
     remotePublicKey = activationRemoteConfig?.publicKeyBase64 ?: "",
     remoteOfflinePolicy = activationRemoteConfig?.offlinePolicy?.name ?: "ALLOW_CACHED",
-    remoteDeliverUrl = activationRemoteConfig?.deliverUrl ?: false
+    remoteDeliverUrl = activationRemoteConfig?.deliverUrl ?: false,
+    remoteEncryptUrl = activationRemoteConfig?.encryptUrl ?: false,
+    remoteAesKey = activationRemoteConfig?.aesKeyBase64 ?: ""
 )
 
 private fun WebApp.buildAdBlockBlock(): AdBlockBlock = AdBlockBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -65,6 +65,8 @@ data class ApkConfig(
     val activationRemotePublicKey: String get() = activation.remotePublicKey
     val activationRemoteOfflinePolicy: String get() = activation.remoteOfflinePolicy
     val activationRemoteDeliverUrl: Boolean get() = activation.remoteDeliverUrl
+    val activationRemoteEncryptUrl: Boolean get() = activation.remoteEncryptUrl
+    val activationRemoteAesKey: String get() = activation.remoteAesKey
 
     val adBlockEnabled: Boolean get() = adBlock.enabled
     val adBlockRules: List<String> get() = adBlock.rules
@@ -414,7 +416,9 @@ data class ActivationBlock(
     val remoteVerifyUrl: String = "",
     val remotePublicKey: String = "",
     val remoteOfflinePolicy: String = "ALLOW_CACHED",
-    val remoteDeliverUrl: Boolean = false
+    val remoteDeliverUrl: Boolean = false,
+    val remoteEncryptUrl: Boolean = false,
+    val remoteAesKey: String = ""
 )
 
 data class AdBlockBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -42,6 +42,8 @@ internal object ApkConfigJsonFactory {
         "activationRemotePublicKey" to activation.remotePublicKey,
         "activationRemoteOfflinePolicy" to activation.remoteOfflinePolicy,
         "activationRemoteDeliverUrl" to activation.remoteDeliverUrl,
+        "activationRemoteEncryptUrl" to activation.remoteEncryptUrl,
+        "activationRemoteAesKey" to activation.remoteAesKey,
         "adBlockEnabled" to adBlock.enabled,
         "adBlockRules" to adBlock.rules,
         "adBlockSubscriptions" to adBlock.subscriptions,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -881,6 +881,12 @@ object Strings {
     val remoteActivationPrivacyNote: String get() = StringsA.remoteActivationPrivacyNote
     val remoteActivationDeliverUrlTitle: String get() = StringsA.remoteActivationDeliverUrlTitle
     val remoteActivationDeliverUrlHint: String get() = StringsA.remoteActivationDeliverUrlHint
+    val remoteActivationEncryptUrlTitle: String get() = StringsA.remoteActivationEncryptUrlTitle
+    val remoteActivationEncryptUrlHint: String get() = StringsA.remoteActivationEncryptUrlHint
+    val remoteActivationAesKeyLabel: String get() = StringsA.remoteActivationAesKeyLabel
+    val remoteActivationAesKeyHint: String get() = StringsA.remoteActivationAesKeyHint
+    val remoteActivationEncryptUrlNeedsKey: String get() = StringsA.remoteActivationEncryptUrlNeedsKey
+    val remoteActivationDecryptFailed: String get() = StringsA.remoteActivationDecryptFailed
     val remoteActivationMisconfigured: String get() = StringsA.remoteActivationMisconfigured
     val remoteActivationInsecureUrl: String get() = StringsA.remoteActivationInsecureUrl
     val remoteActivationRejected: String get() = StringsA.remoteActivationRejected
@@ -15874,6 +15880,79 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Если включено, целевой URL доставляется сервером проверки после успешной активации вместо упаковки (URL можно оставить пустым). Сервер должен включать подписанное поле url в ответ."
         AppLanguage.JAPANESE -> "有効にすると、ターゲットURLはパッケージ化される代わりに、アクティベーション成功後に検証サーバーから配信されます（URLは空欄可）。サーバーは応答に署名付きのurlフィールドを含める必要があります。"
         AppLanguage.KOREAN -> "활성화 시, 대상 URL이 패키징되는 대신 활성화 성공 후 검증 서버에서 전달됩니다(URL은 비워둘 수 있음). 서버는 응답에 서명된 url 필드를 포함해야 합니다."
+    }
+
+    val remoteActivationEncryptUrlTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "加密目标网址 (AES-256-GCM)"
+        AppLanguage.ENGLISH -> "Encrypt target URL (AES-256-GCM)"
+        AppLanguage.ARABIC -> "تشفير عنوان URL المستهدف (AES-256-GCM)"
+        AppLanguage.PORTUGUESE -> "Criptografar URL de destino (AES-256-GCM)"
+        AppLanguage.SPANISH -> "Cifrar URL de destino (AES-256-GCM)"
+        AppLanguage.FRENCH -> "Chiffrer l'URL cible (AES-256-GCM)"
+        AppLanguage.GERMAN -> "Ziel-URL verschlüsseln (AES-256-GCM)"
+        AppLanguage.RUSSIAN -> "Шифровать целевой URL (AES-256-GCM)"
+        AppLanguage.JAPANESE -> "ターゲットURLを暗号化 (AES-256-GCM)"
+        AppLanguage.KOREAN -> "대상 URL 암호화 (AES-256-GCM)"
+    }
+    val remoteActivationEncryptUrlHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "开启后，服务器须用下方 AES-256 密钥加密网址。响应中的 url 字段为 Base64(IV[12B] || 密文 || GCM_Tag[16B])。"
+        AppLanguage.ENGLISH -> "When enabled, the server must encrypt the URL with the AES-256 key below. The url field in the response is Base64(IV[12B] || ciphertext || GCM tag[16B])."
+        AppLanguage.ARABIC -> "عند التمكين، يجب على الخادم تشفير عنوان URL باستخدام مفتاح AES-256 أدناه. حقل url في الاستجابة هو Base64(IV[12B] || النص المشفر || علامة GCM[16B])."
+        AppLanguage.PORTUGUESE -> "Quando ativado, o servidor deve criptografar a URL com a chave AES-256 abaixo. O campo url na resposta é Base64(IV[12B] || texto cifrado || tag GCM[16B])."
+        AppLanguage.SPANISH -> "Cuando está activado, el servidor debe cifrar la URL con la clave AES-256 a continuación. El campo url en la respuesta es Base64(IV[12B] || texto cifrado || etiqueta GCM[16B])."
+        AppLanguage.FRENCH -> "Lorsqu'activé, le serveur doit chiffrer l'URL avec la clé AES-256 ci-dessous. Le champ url dans la réponse est Base64(IV[12B] || texte chiffré || étiquette GCM[16B])."
+        AppLanguage.GERMAN -> "Wenn aktiviert, muss der Server die URL mit dem AES-256-Schlüssel unten verschlüsseln. Das url-Feld in der Antwort ist Base64(IV[12B] || Chiffrat || GCM-Tag[16B])."
+        AppLanguage.RUSSIAN -> "Если включено, сервер должен шифровать URL с помощью ключа AES-256 ниже. Поле url в ответе — Base64(IV[12B] || шифротекст || тег GCM[16B])."
+        AppLanguage.JAPANESE -> "有効にすると、サーバーは以下のAES-256キーでURLを暗号化する必要があります。応答のurlフィールドはBase64(IV[12B] || 暗号文 || GCMタグ[16B])です。"
+        AppLanguage.KOREAN -> "활성화 시, 서버는 아래 AES-256 키로 URL을 암호화해야 합니다. 응답의 url 필드는 Base64(IV[12B] || 암호문 || GCM 태그[16B])입니다."
+    }
+    val remoteActivationAesKeyLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "AES-256 密钥 (Base64)"
+        AppLanguage.ENGLISH -> "AES-256 key (Base64)"
+        AppLanguage.ARABIC -> "مفتاح AES-256 (Base64)"
+        AppLanguage.PORTUGUESE -> "Chave AES-256 (Base64)"
+        AppLanguage.SPANISH -> "Clave AES-256 (Base64)"
+        AppLanguage.FRENCH -> "Clé AES-256 (Base64)"
+        AppLanguage.GERMAN -> "AES-256-Schlüssel (Base64)"
+        AppLanguage.RUSSIAN -> "Ключ AES-256 (Base64)"
+        AppLanguage.JAPANESE -> "AES-256キー (Base64)"
+        AppLanguage.KOREAN -> "AES-256 키 (Base64)"
+    }
+    val remoteActivationAesKeyHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "32 字节随机密钥的 Base64 编码。生成：openssl rand -base64 32"
+        AppLanguage.ENGLISH -> "Base64 encoding of a 32-byte random key. Generate: openssl rand -base64 32"
+        AppLanguage.ARABIC -> "ترميز Base64 لمفتاح عشوائي 32 بايت. للتوليد: openssl rand -base64 32"
+        AppLanguage.PORTUGUESE -> "Codificação Base64 de uma chave aleatória de 32 bytes. Gerar: openssl rand -base64 32"
+        AppLanguage.SPANISH -> "Codificación Base64 de una clave aleatoria de 32 bytes. Generar: openssl rand -base64 32"
+        AppLanguage.FRENCH -> "Encodage Base64 d'une clé aléatoire de 32 octets. Générer : openssl rand -base64 32"
+        AppLanguage.GERMAN -> "Base64-Kodierung eines 32-Byte-Zufallsschlüssels. Erzeugen: openssl rand -base64 32"
+        AppLanguage.RUSSIAN -> "Base64-кодировка 32-байтового случайного ключа. Генерация: openssl rand -base64 32"
+        AppLanguage.JAPANESE -> "32バイトのランダムキーのBase64エンコード。生成：openssl rand -base64 32"
+        AppLanguage.KOREAN -> "32바이트 랜덤 키의 Base64 인코딩. 생성: openssl rand -base64 32"
+    }
+    val remoteActivationEncryptUrlNeedsKey: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "开启网址加密后必须提供 AES-256 密钥"
+        AppLanguage.ENGLISH -> "AES-256 key is required when URL encryption is enabled"
+        AppLanguage.ARABIC -> "مفتاح AES-256 مطلوب عند تمكين تشفير عنوان URL"
+        AppLanguage.PORTUGUESE -> "A chave AES-256 é obrigatória quando a criptografia de URL está ativada"
+        AppLanguage.SPANISH -> "Se requiere clave AES-256 cuando el cifrado de URL está activado"
+        AppLanguage.FRENCH -> "La clé AES-256 est requise lorsque le chiffrement de l'URL est activé"
+        AppLanguage.GERMAN -> "AES-256-Schlüssel ist erforderlich, wenn URL-Verschlüsselung aktiviert ist"
+        AppLanguage.RUSSIAN -> "Требуется ключ AES-256 при включенном шифровании URL"
+        AppLanguage.JAPANESE -> "URL暗号化が有効な場合、AES-256キーが必要です"
+        AppLanguage.KOREAN -> "URL 암호화가 활성화된 경우 AES-256 키가 필요합니다"
+    }
+    val remoteActivationDecryptFailed: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "服务器返回的网址解密失败，请检查 AES 密钥配置"
+        AppLanguage.ENGLISH -> "Failed to decrypt the URL from the server, please check the AES key configuration"
+        AppLanguage.ARABIC -> "فشل فك تشفير عنوان URL من الخادم، يرجى التحقق من تكوين مفتاح AES"
+        AppLanguage.PORTUGUESE -> "Falha ao descriptografar a URL do servidor, verifique a configuração da chave AES"
+        AppLanguage.SPANISH -> "Error al descifrar la URL del servidor, verifique la configuración de la clave AES"
+        AppLanguage.FRENCH -> "Échec du déchiffrement de l'URL du serveur, vérifiez la configuration de la clé AES"
+        AppLanguage.GERMAN -> "Fehler beim Entschlüsseln der URL vom Server, bitte die AES-Schlüsselkonfiguration prüfen"
+        AppLanguage.RUSSIAN -> "Не удалось расшифровать URL с сервера, проверьте конфигурацию ключа AES"
+        AppLanguage.JAPANESE -> "サーバーからのURLの復号に失敗しました。AESキー設定を確認してください"
+        AppLanguage.KOREAN -> "서버에서 URL을 복호화하지 못했습니다. AES 키 구성을 확인하세요"
     }
 
     val remoteActivationMisconfigured: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -185,6 +185,12 @@ data class ShellConfig(
     @SerializedName("activationRemoteDeliverUrl")
     val activationRemoteDeliverUrl: Boolean = false,
 
+    @SerializedName("activationRemoteEncryptUrl")
+    val activationRemoteEncryptUrl: Boolean = false,
+
+    @SerializedName("activationRemoteAesKey")
+    val activationRemoteAesKey: String = "",
+
     @SerializedName("adBlockEnabled")
     val adBlockEnabled: Boolean = false,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -1262,7 +1262,9 @@ data class RemoteActivationConfig(
     val verifyUrl: String = "",
     val publicKeyBase64: String = "",
     val offlinePolicy: RemoteActivationOfflinePolicy = RemoteActivationOfflinePolicy.ALLOW_CACHED,
-    val deliverUrl: Boolean = false
+    val deliverUrl: Boolean = false,
+    val encryptUrl: Boolean = false,
+    val aesKeyBase64: String = ""
 )
 
 data class AutoStartConfig(

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -683,6 +683,47 @@ private fun RemoteActivationSection(
                     )
                 }
 
+                // AES encryption controls – only relevant when URL delivery is enabled
+                if (remoteConfig.deliverUrl) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
+                            Text(
+                                text = Strings.remoteActivationEncryptUrlTitle,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                text = Strings.remoteActivationEncryptUrlHint,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        WtaSwitch(
+                            checked = remoteConfig.encryptUrl,
+                            onCheckedChange = {
+                                onRemoteConfigChange(remoteConfig.copy(encryptUrl = it))
+                            }
+                        )
+                    }
+
+                    if (remoteConfig.encryptUrl) {
+                        PremiumTextField(
+                            value = remoteConfig.aesKeyBase64,
+                            onValueChange = {
+                                onRemoteConfigChange(remoteConfig.copy(aesKeyBase64 = it.trim()))
+                            },
+                            label = { Text(Strings.remoteActivationAesKeyLabel) },
+                            placeholder = { Text("openssl rand -base64 32") },
+                            supportingText = { Text(Strings.remoteActivationAesKeyHint) },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+
                 Text(
                     text = Strings.remoteActivationPrivacyNote,
                     style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -51,7 +51,9 @@ fun ShellActivationDialog(
                             verifyUrl = config.activationRemoteVerifyUrl,
                             publicKeyBase64 = config.activationRemotePublicKey,
                             offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
-                            deliverUrl = config.activationRemoteDeliverUrl
+                            deliverUrl = config.activationRemoteDeliverUrl,
+                            encryptUrl = config.activationRemoteEncryptUrl,
+                            aesKeyBase64 = config.activationRemoteAesKey
                         )
                     )
                 } else {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -167,7 +167,9 @@ fun ShellScreen(
                                 verifyUrl = config.activationRemoteVerifyUrl,
                                 publicKeyBase64 = config.activationRemotePublicKey,
                                 offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
-                                deliverUrl = config.activationRemoteDeliverUrl
+                                deliverUrl = config.activationRemoteDeliverUrl,
+                                encryptUrl = config.activationRemoteEncryptUrl,
+                                aesKeyBase64 = config.activationRemoteAesKey
                             )
                         )
                 } else {

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
@@ -519,6 +519,13 @@ class MainViewModel(
                 false
             }
 
+            state.activationEnabled &&
+                state.activationRemoteConfig?.encryptUrl == true &&
+                state.activationRemoteConfig?.aesKeyBase64.isNullOrBlank() -> {
+                _uiState.value = UiState.Error(Strings.remoteActivationEncryptUrlNeedsKey)
+                false
+            }
+
             state.appType == AppType.HTML && (state.htmlConfig?.files?.isEmpty() != false) -> {
                 _uiState.value = UiState.Error(Strings.pleaseSelectHtmlFile)
                 false

--- a/app/src/test/java/com/webtoapp/core/activation/RemoteActivationVerifierTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/RemoteActivationVerifierTest.kt
@@ -10,6 +10,9 @@ import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.Signature
 import java.security.spec.ECGenParameterSpec
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 /**
  * Guards the dynamic-URL delivery contract (issue #314): when deliverUrl is enabled the delivered
@@ -36,6 +39,28 @@ class RemoteActivationVerifierTest {
         sig.initSign(privateKey)
         sig.update(payload.toByteArray(Charsets.UTF_8))
         return Base64.encodeToString(sig.sign(), Base64.DEFAULT)
+    }
+
+    // -- AES-256-GCM helpers for encryption tests --
+
+    private fun randomAesKeyBase64(): String {
+        val key = ByteArray(32)
+        java.security.SecureRandom().nextBytes(key)
+        return Base64.encodeToString(key, Base64.DEFAULT)
+    }
+
+    private fun encryptUrl(plaintext: String, aesKeyBase64: String): String {
+        val keyBytes = Base64.decode(aesKeyBase64, Base64.DEFAULT)
+        val iv = ByteArray(12)
+        java.security.SecureRandom().nextBytes(iv)
+        val keySpec = SecretKeySpec(keyBytes, "AES")
+        val gcmSpec = GCMParameterSpec(128, iv)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec)
+        val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+        // Wire format: IV[12] || ciphertext || tag[16] (tag is appended by doFinal in GCM mode)
+        val combined = iv + ciphertext
+        return Base64.encodeToString(combined, Base64.DEFAULT)
     }
 
     @Test
@@ -77,5 +102,92 @@ class RemoteActivationVerifierTest {
 
         val resp = response(url = null, sig = sig)
         assertThat(verifier.verifySignature(keyPair.public, resp, "nonce123", includeUrl = false)).isTrue()
+    }
+
+    // -- AES-256-GCM URL encryption tests (Phase 2) --
+
+    @Test
+    fun `decryptUrl roundtrip works with valid key`() {
+        val aesKey = randomAesKeyBase64()
+        val plaintext = "https://example.com/app/dashboard"
+        val encrypted = encryptUrl(plaintext, aesKey)
+
+        val decrypted = verifier.decryptUrl(encrypted, aesKey)
+        assertThat(decrypted).isEqualTo(plaintext)
+    }
+
+    @Test
+    fun `decryptUrl returns null with blank inputs`() {
+        assertThat(verifier.decryptUrl("", randomAesKeyBase64())).isNull()
+        assertThat(verifier.decryptUrl("notblank", "")).isNull()
+    }
+
+    @Test
+    fun `decryptUrl returns null when key length is wrong`() {
+        val shortKey = Base64.encodeToString(ByteArray(16), Base64.DEFAULT) // 16 bytes, not 32
+        val encrypted = encryptUrl("https://example.com", randomAesKeyBase64())
+        assertThat(verifier.decryptUrl(encrypted, shortKey)).isNull()
+    }
+
+    @Test
+    fun `decryptUrl returns null for corrupted ciphertext`() {
+        val aesKey = randomAesKeyBase64()
+        val encrypted = encryptUrl("https://example.com", aesKey)
+        // Flip a byte in the middle of the ciphertext
+        val corruptedBytes = Base64.decode(encrypted, Base64.DEFAULT)
+        corruptedBytes[corruptedBytes.size / 2] = (corruptedBytes[corruptedBytes.size / 2].toInt() xor 0xFF).toByte()
+        val corrupted = Base64.encodeToString(corruptedBytes, Base64.DEFAULT)
+        assertThat(verifier.decryptUrl(corrupted, aesKey)).isNull()
+    }
+
+    @Test
+    fun `signature verifies with encrypted url and fails on tampered encrypted blob`() {
+        val kpg = KeyPairGenerator.getInstance("EC").apply { initialize(ECGenParameterSpec("secp256r1")) }
+        val keyPair = kpg.generateKeyPair()
+        val aesKey = randomAesKeyBase64()
+
+        val plainUrl = "https://good.example.com/secret"
+        val encryptedUrl = encryptUrl(plainUrl, aesKey)
+
+        // Server signs the canonical payload that includes the encrypted blob
+        val payload = verifier.canonicalSignedPayload(response(url = encryptedUrl), includeUrl = true)
+        val sig = sign(payload, keyPair.private)
+
+        val goodResponse = response(url = encryptedUrl, sig = sig)
+        assertThat(verifier.verifySignature(keyPair.public, goodResponse, "nonce123", includeUrl = true)).isTrue()
+
+        // Tampering the encrypted blob should break the signature
+        val tamperedEncrypted = encryptUrl("https://evil.example.com", aesKey)
+        val tamperedResponse = response(url = tamperedEncrypted, sig = sig)
+        assertThat(verifier.verifySignature(keyPair.public, tamperedResponse, "nonce123", includeUrl = true)).isFalse()
+    }
+
+    @Test
+    fun `legacy plaintext url still works when encryptUrl is not used`() {
+        val kpg = KeyPairGenerator.getInstance("EC").apply { initialize(ECGenParameterSpec("secp256r1")) }
+        val keyPair = kpg.generateKeyPair()
+
+        val plainUrl = "https://example.com/legacy"
+        val payload = verifier.canonicalSignedPayload(response(url = plainUrl), includeUrl = true)
+        val sig = sign(payload, keyPair.private)
+
+        val resp = response(url = plainUrl, sig = sig)
+        assertThat(verifier.verifySignature(keyPair.public, resp, "nonce123", includeUrl = true)).isTrue()
+    }
+
+    @Test
+    fun `decodeAesKey rejects wrong length keys`() {
+        val goodKey = randomAesKeyBase64()
+        assertThat(verifier.decodeAesKey(goodKey)).isNotNull()
+        assertThat(verifier.decodeAesKey(goodKey)!!.size).isEqualTo(32)
+
+        val shortKey = Base64.encodeToString(ByteArray(16), Base64.DEFAULT)
+        assertThat(verifier.decodeAesKey(shortKey)).isNull()
+
+        val longKey = Base64.encodeToString(ByteArray(64), Base64.DEFAULT)
+        assertThat(verifier.decodeAesKey(longKey)).isNull()
+
+        assertThat(verifier.decodeAesKey("")).isNull()
+        assertThat(verifier.decodeAesKey("not-valid-base64!!!")).isNull()
     }
 }


### PR DESCRIPTION
## Summary

Closes #347. Adds an optional **AES-256-GCM encryption layer** on top of Phase 1 dynamic URL delivery (#345). When enabled, the server encrypts the target URL before signing; the client decrypts after signature verification. Even if the HTTPS response is intercepted, the URL stays unreadable without the AES key.

### What changed (14 files, +448/-17)

| Layer | Files | Change |
|-------|-------|--------|
| Config model | `WebApp.kt`, `ApkConfig.kt` | `encryptUrl` + `aesKeyBase64` |
| Config chain | `ApkBuilder`, `ApkConfigJsonFactory`, `ShellModeManager` | Full wiring, `@SerializedName`, drift-safe |
| Core crypto | `RemoteActivationVerifier.kt` | `decryptUrl()`, `decodeAesKey()`, verify flow |
| Manager | `ActivationManager.kt` | `buildRemoteRequest` params |
| Editor UI | `ActivationCodeCard.kt` | encryptUrl switch + AES key field |
| Validation | `MainViewModel.kt` | AES key required when encryption on |
| Runtime | `ShellScreen.kt`, `ShellDialogs.kt` | Pass encryptUrl/aesKey params |
| i18n | `Strings.kt` | 6 keys × 10 languages |
| Docs | `remote-activation.md` | URL Encryption section + reference server |
| Tests | `RemoteActivationVerifierTest.kt` | 7 new cases |

### Encryption details
- **AES-256-GCM**: IV[12B] || ciphertext || GCM tag[16B], then Base64
- Ciphertext goes into the `url` response field *and* the ECDSA signed payload
- Signature verification happens first (covers ciphertext), then decryption
- Cache stores plaintext (unchanged from Phase 1)

### Backward compatibility
- `encryptUrl` defaults to `false` — Phase 1 servers/clients unaffected
- When enabled, app and server must share the same 32-byte AES key

### Verification
- [x] `:app:compileDebugKotlin` ✅
- [x] `:app:checkConfigFieldDrift` ✅
- [x] `RemoteActivationVerifierTest` (10 tests) ✅
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` ✅