### PR TITLE
fix(engine): support file upload (<input type=file>) in the GeckoView engine

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
@@ -33,6 +33,17 @@ interface BrowserEngineCallback {
         contentLength: Long
     )
 
+    /**
+     * File upload request (`<input type="file">`). Engines that surface uploads through a
+     * different mechanism (System WebView uses its WebChromeClient directly) can ignore this;
+     * GeckoView routes its PromptDelegate file prompts here. Returns true if the chooser was
+     * launched, false if the prompt should be dismissed.
+     */
+    fun onShowFileChooser(
+        filePathCallback: android.webkit.ValueCallback<Array<android.net.Uri>>?,
+        fileChooserParams: android.webkit.WebChromeClient.FileChooserParams?
+    ): Boolean = false
+
     fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {}
 
     fun onNewWindow(resultMsg: android.os.Message?) {}

--- a/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
@@ -189,6 +189,11 @@ fun WebViewCallbacks.toBrowserEngineCallback(): BrowserEngineCallback {
             contentLength: Long
         ) = source.onDownloadStart(url, userAgent, contentDisposition, mimeType, contentLength)
 
+        override fun onShowFileChooser(
+            filePathCallback: android.webkit.ValueCallback<Array<android.net.Uri>>?,
+            fileChooserParams: android.webkit.WebChromeClient.FileChooserParams?
+        ): Boolean = source.onShowFileChooser(filePathCallback, fileChooserParams)
+
         override fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {
             source.onConsoleMessage(level, message, sourceId, lineNumber)
         }

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -445,6 +445,7 @@ class GeckoViewEngine(
         setupNavigationDelegate(session, callback)
         setupProgressDelegate(session, callback)
         setupPermissionDelegate(session)
+        setupPromptDelegate(session, callback)
     }
 
     private fun setupContentDelegate(session: GeckoSession, callback: BrowserEngineCallback) {
@@ -486,6 +487,48 @@ class GeckoViewEngine(
                 AppLogger.e(TAG, "GeckoView session crashed, attempting recovery...")
                 callback.onError(-1, "Engine crash — recovering...")
                 attemptCrashRecovery()
+            }
+        }
+    }
+
+    private fun setupPromptDelegate(session: GeckoSession, callback: BrowserEngineCallback) {
+        session.promptDelegate = object : GeckoSession.PromptDelegate {
+            override fun onFilePrompt(
+                session: GeckoSession,
+                prompt: GeckoSession.PromptDelegate.FilePrompt
+            ): GeckoResult<GeckoSession.PromptDelegate.PromptResponse>? {
+                val result = GeckoResult<GeckoSession.PromptDelegate.PromptResponse>()
+                var completed = false
+                fun finish(response: GeckoSession.PromptDelegate.PromptResponse) {
+                    if (!completed) {
+                        completed = true
+                        result.complete(response)
+                    }
+                }
+
+                // Bridge GeckoView's FilePrompt onto the same ValueCallback/FileChooserParams
+                // contract the System WebView path uses, so the shell's existing SAF + camera
+                // chooser (ShellPermissionDelegate.handleFileChooser) handles the actual pick.
+                val valueCallback = android.webkit.ValueCallback<Array<android.net.Uri>> { uris ->
+                    when {
+                        uris.isNullOrEmpty() -> finish(prompt.dismiss())
+                        prompt.type == GeckoSession.PromptDelegate.FilePrompt.Type.MULTIPLE ->
+                            finish(prompt.confirm(context, uris))
+                        else -> finish(prompt.confirm(context, uris[0]))
+                    }
+                }
+
+                val params = GeckoFileChooserParams(
+                    acceptTypes = prompt.mimeTypes,
+                    multiple = prompt.type == GeckoSession.PromptDelegate.FilePrompt.Type.MULTIPLE,
+                    captureEnabled = prompt.capture != GeckoSession.PromptDelegate.FilePrompt.Capture.NONE
+                )
+
+                val handled = callback.onShowFileChooser(valueCallback, params)
+                if (!handled) {
+                    finish(prompt.dismiss())
+                }
+                return result
             }
         }
     }
@@ -748,4 +791,35 @@ class GeckoViewEngine(
         }
     }
 
+}
+
+/**
+ * Adapts a GeckoView `FilePrompt` onto the `WebChromeClient.FileChooserParams` contract so the
+ * shell's existing System-WebView file chooser logic (SAF picker + camera capture) can serve
+ * GeckoView uploads unchanged. Only the accessors the chooser reads are meaningful; the rest
+ * return inert defaults.
+ */
+private class GeckoFileChooserParams(
+    private val acceptTypes: Array<String>?,
+    private val multiple: Boolean,
+    private val captureEnabled: Boolean
+) : android.webkit.WebChromeClient.FileChooserParams() {
+
+    override fun getMode(): Int =
+        if (multiple) MODE_OPEN_MULTIPLE else MODE_OPEN
+
+    override fun getAcceptTypes(): Array<String> =
+        acceptTypes?.takeIf { it.isNotEmpty() } ?: arrayOf("*/*")
+
+    override fun isCaptureEnabled(): Boolean = captureEnabled
+
+    override fun getTitle(): CharSequence = ""
+
+    override fun getFilenameHint(): String? = null
+
+    override fun createIntent(): android.content.Intent =
+        android.content.Intent(android.content.Intent.ACTION_GET_CONTENT).apply {
+            addCategory(android.content.Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+        }
 }


### PR DESCRIPTION
## Summary

Refs #321. Fixes a concrete bug found while investigating that report: the **GeckoView engine did not support file uploads**.

### Root cause
`GeckoViewEngine.setupDelegates()` wired content / navigation / progress / permission delegates but **no `PromptDelegate`**. GeckoView delivers `<input type="file">` through `PromptDelegate.onFilePrompt()`, so without a delegate the file chooser never opened and uploads were **silently dropped** (no error, no crash — just nothing happens). Downloads already worked via `onExternalResponse → onDownloadStart`; only uploads were broken.

### Fix (3 files, +90)
| File | Change |
|------|--------|
| `BrowserEngineCallback.kt` | Add `onShowFileChooser` (default no-op, so the System WebView path — which uses its WebChromeClient directly — is unaffected) |
| `EngineViewFactory.kt` | Forward `onShowFileChooser` in `toBrowserEngineCallback()` to the existing `WebViewCallbacks` file chooser |
| `GeckoViewEngine.kt` | `setupPromptDelegate` bridges `onFilePrompt` onto the same `ValueCallback`/`FileChooserParams` contract the System WebView uses, so the shell's existing SAF + camera chooser (`ShellPermissionDelegate.handleFileChooser`) serves GeckoView uploads unchanged; `GeckoFileChooserParams` adapts the prompt's `mimeTypes`/`multiple`/`capture` |

### No storage permission needed
Uploads use the Storage Access Framework (`ACTION_GET_CONTENT`), which the system mediates on every Android version — this is why the literal request in #321 ("add read/write storage permission") is not the mechanism on modern Android.

### Verification
- [x] `:app:compileDebugKotlin` ✅
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` ✅ (synced copy contains the new delegate)
- [x] `:app:checkConfigFieldDrift` ✅

### Note on #321
This fixes the GeckoView upload gap, which is one plausible cause of the reporter's symptom. The reporter's exact engine/Android version is unknown, so #321 is left open pending their reply (details requested in the issue).