### PR TITLE
feat(webview): add configurable Back button behavior (go back vs exit)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3615,6 +3615,7 @@ private fun com.webtoapp.data.model.WebViewConfig.toWebViewBlock(context: androi
         popupBlockerToggleEnabled = popupBlockerToggleEnabled,
         openExternalLinks = openExternalLinks,
         showFloatingBackButton = showFloatingBackButton,
+        backButtonBehavior = backButtonBehavior,
         swipeRefreshEnabled = swipeRefreshEnabled,
         fullscreenEnabled = fullscreenEnabled,
         performanceOptimization = performanceOptimization,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -489,6 +489,7 @@ data class WebViewBlock(
     val popupBlockerToggleEnabled: Boolean = false,
     val openExternalLinks: Boolean = false,
     val showFloatingBackButton: Boolean = false,
+    val backButtonBehavior: String = "GO_BACK",
     val swipeRefreshEnabled: Boolean = true,
     val fullscreenEnabled: Boolean = true,
     val performanceOptimization: Boolean = false,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -321,6 +321,7 @@ internal object ApkConfigJsonFactory {
         "tlsFingerprintCustomCiphers" to tlsFingerprint.customCipherSuites,
         "antiCapture" to webView.antiCapture,
         "showFloatingBackButton" to webView.showFloatingBackButton,
+        "backButtonBehavior" to webView.backButtonBehavior,
         "downloadEnabled" to webView.downloadEnabled,
         "downloadLocationMode" to webView.downloadLocationMode,
         "customDownloadDirUri" to webView.customDownloadDirUri,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -4060,6 +4060,10 @@ object Strings {
     val staticAssetPackMaxAgeLabel: String get() = StringsE.staticAssetPackMaxAgeLabel
     val staticAssetPackIncludeImagesTitle: String get() = StringsE.staticAssetPackIncludeImagesTitle
     val staticAssetPackIncludeCdnTitle: String get() = StringsE.staticAssetPackIncludeCdnTitle
+    val backButtonBehaviorLabel: String get() = StringsE.backButtonBehaviorLabel
+    val backButtonBehaviorHint: String get() = StringsE.backButtonBehaviorHint
+    val backButtonGoBack: String get() = StringsE.backButtonGoBack
+    val backButtonExitApp: String get() = StringsE.backButtonExitApp
     val pwaStrategyNetworkFirst: String get() = StringsE.pwaStrategyNetworkFirst
     val pwaStrategyCacheFirst: String get() = StringsE.pwaStrategyCacheFirst
     val pwaStrategyStaleWhileRevalidate: String get() = StringsE.pwaStrategyStaleWhileRevalidate
@@ -55469,6 +55473,54 @@ object StringsE {
         AppLanguage.RUSSIAN -> "Включать ресурсы CDN"
         AppLanguage.JAPANESE -> "CDN リソースを含める"
         AppLanguage.KOREAN -> "CDN 리소스 포함"
+    }
+    val backButtonBehaviorLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "返回键行为"
+        AppLanguage.ENGLISH -> "Back Button Behavior"
+        AppLanguage.ARABIC -> "سلوك زر الرجوع"
+        AppLanguage.PORTUGUESE -> "Comportamento do Botão Voltar"
+        AppLanguage.SPANISH -> "Comportamiento del Botón Atrás"
+        AppLanguage.FRENCH -> "Comportement du Bouton Retour"
+        AppLanguage.GERMAN -> "Zurück-Button-Verhalten"
+        AppLanguage.RUSSIAN -> "Поведение кнопки назад"
+        AppLanguage.JAPANESE -> "戻るボタンの動作"
+        AppLanguage.KOREAN -> "뒤로 가기 버튼 동작"
+    }
+    val backButtonBehaviorHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "设置系统返回键的行为。"
+        AppLanguage.ENGLISH -> "Choose what the system Back button does."
+        AppLanguage.ARABIC -> "اختر ما يفعله زر الرجوع في النظام."
+        AppLanguage.PORTUGUESE -> "Escolha o que o botão Voltar do sistema faz."
+        AppLanguage.SPANISH -> "Elige lo que hace el botón Atrás del sistema."
+        AppLanguage.FRENCH -> "Choisissez ce que fait le bouton Retour du système."
+        AppLanguage.GERMAN -> "Wählen Sie, was die System-Zurück-Taste tut."
+        AppLanguage.RUSSIAN -> "Выберите, что делает системная кнопка назад."
+        AppLanguage.JAPANESE -> "システムの戻るボタンの動作を選択します。"
+        AppLanguage.KOREAN -> "시스템 뒤로 가기 버튼의 동작을 선택합니다."
+    }
+    val backButtonGoBack: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "返回上一页"
+        AppLanguage.ENGLISH -> "Go back in history"
+        AppLanguage.ARABIC -> "الرجوع في السجل"
+        AppLanguage.PORTUGUESE -> "Voltar no histórico"
+        AppLanguage.SPANISH -> "Retroceder en el historial"
+        AppLanguage.FRENCH -> "Reculer dans l'historique"
+        AppLanguage.GERMAN -> "Im Verlauf zurück"
+        AppLanguage.RUSSIAN -> "Назад по истории"
+        AppLanguage.JAPANESE -> "履歴を戻る"
+        AppLanguage.KOREAN -> "기록에서 뒤로"
+    }
+    val backButtonExitApp: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "直接退出应用"
+        AppLanguage.ENGLISH -> "Exit app"
+        AppLanguage.ARABIC -> "الخروج من التطبيق"
+        AppLanguage.PORTUGUESE -> "Sair do app"
+        AppLanguage.SPANISH -> "Salir de la app"
+        AppLanguage.FRENCH -> "Quitter l'application"
+        AppLanguage.GERMAN -> "App beenden"
+        AppLanguage.RUSSIAN -> "Выйти из приложения"
+        AppLanguage.JAPANESE -> "アプリを終了"
+        AppLanguage.KOREAN -> "앱 종료"
     }
     val pwaStrategyNetworkFirst: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "网络优先（推荐）— 优先使用最新内容，离线时用缓存"

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -1412,6 +1412,9 @@ data class WebViewShellConfig(
     @SerializedName("showFloatingBackButton")
     val showFloatingBackButton: Boolean = false,
 
+    @SerializedName("backButtonBehavior")
+    val backButtonBehavior: String = "GO_BACK",
+
     @SerializedName("downloadEnabled")
     val downloadEnabled: Boolean = true,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -381,6 +381,9 @@ data class WebViewConfig(
     val staticAssetPackMaxTotalSizeMb: Int = 50,
 
     val showFloatingBackButton: Boolean = false,
+    // System back button behavior: "GO_BACK" (default, walk web history then exit)
+    // or "EXIT" (leave the app immediately). See issue #151.
+    val backButtonBehavior: String = "GO_BACK",
     val floatingWindowConfig: FloatingWindowConfig = FloatingWindowConfig(),
     val proxyMode: String = "NONE",
     val proxyHost: String = "",

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1037,6 +1037,42 @@ fun BrowserAdvancedConfigCard(
                                 checked = config.showFloatingBackButton,
                                 onCheckedChange = { onConfigChange(config.copy(showFloatingBackButton = it)) }
                             )
+                            WtaSectionDivider()
+                            Text(
+                                text = Strings.backButtonBehaviorLabel,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(
+                                    horizontal = WtaSpacing.RowHorizontal,
+                                    vertical = WtaSpacing.ContentGap
+                                )
+                            )
+                            Text(
+                                text = Strings.backButtonBehaviorHint,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal)
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(
+                                        horizontal = WtaSpacing.RowHorizontal,
+                                        vertical = WtaSpacing.ContentGap
+                                    ),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                FilterChip(
+                                    selected = config.backButtonBehavior == "GO_BACK",
+                                    onClick = { onConfigChange(config.copy(backButtonBehavior = "GO_BACK")) },
+                                    label = { Text(Strings.backButtonGoBack) }
+                                )
+                                FilterChip(
+                                    selected = config.backButtonBehavior == "EXIT",
+                                    onClick = { onConfigChange(config.copy(backButtonBehavior = "EXIT")) },
+                                    label = { Text(Strings.backButtonExitApp) }
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivityInit.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivityInit.kt
@@ -215,6 +215,14 @@ object ShellActivityInit {
                     else -> {
 
                         val wv = getWebView()
+                        // "Exit app" back behavior (#151): leave immediately instead of walking
+                        // web history. Forced-run blocking and fullscreen-close above still take
+                        // precedence; this only replaces the history-navigation path.
+                        val backBehavior = getShellConfig()?.webViewConfig?.backButtonBehavior ?: "GO_BACK"
+                        if (backBehavior == "EXIT") {
+                            activity.finish()
+                            return
+                        }
                         if (wv != null) {
                             wv.evaluateJavascript("""
                                 (function() {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -192,6 +192,7 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         screenAwakeTimeoutMinutes = config.webViewConfig.screenAwakeTimeoutMinutes,
         screenBrightness = config.webViewConfig.screenBrightness,
         showFloatingBackButton = config.webViewConfig.showFloatingBackButton,
+        backButtonBehavior = config.webViewConfig.backButtonBehavior,
 
         keyboardAdjustMode = try {
             com.webtoapp.data.model.KeyboardAdjustMode.valueOf(config.webViewConfig.keyboardAdjustMode)

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -795,6 +795,12 @@ class WebViewActivity : AppCompatActivity() {
                     else -> {
 
                         val wv = webView
+                        // "Exit app" back behavior (#151): leave immediately instead of walking
+                        // web history (preview parity with the generated shell).
+                        if (previewApp?.webViewConfig?.backButtonBehavior == "EXIT") {
+                            finish()
+                            return
+                        }
                         if (wv != null) {
                             wv.evaluateJavascript("""
                                 (function() {

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/BackButtonBehaviorExportWiringTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/BackButtonBehaviorExportWiringTest.kt
@@ -1,0 +1,43 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.shell.ShellConfig
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.util.GsonProvider
+import org.junit.Test
+
+/**
+ * Guards the Back Button Behavior config chain (issue #151): editor model -> ApkConfig
+ * export block -> shell config JSON -> runtime ShellConfig. The runtime back handler reads
+ * this from ShellConfig, so a break here silently reverts generated apps to history-back.
+ */
+class BackButtonBehaviorExportWiringTest {
+
+    private fun roundTrip(app: WebApp): ShellConfig {
+        val apk = app.toApkConfig("com.example.test")
+        val json = ApkConfigJsonFactory.toShellConfigJson(apk)
+        return GsonProvider.gson.fromJson(json, ShellConfig::class.java)!!
+    }
+
+    @Test
+    fun `exit back behavior flows from model through ApkConfig into shell config`() {
+        val app = WebApp(
+            name = "Back",
+            url = "https://example.com",
+            webViewConfig = WebViewConfig(backButtonBehavior = "EXIT")
+        )
+
+        val config = app.toApkConfig("com.example.back")
+        assertThat(config.webView.backButtonBehavior).isEqualTo("EXIT")
+        assertThat(roundTrip(app).webViewConfig.backButtonBehavior).isEqualTo("EXIT")
+    }
+
+    @Test
+    fun `back behavior defaults to go-back`() {
+        val app = WebApp(name = "Default", url = "https://example.com")
+
+        assertThat(app.toApkConfig("com.example.default").webView.backButtonBehavior).isEqualTo("GO_BACK")
+        assertThat(roundTrip(app).webViewConfig.backButtonBehavior).isEqualTo("GO_BACK")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Back Button Behavior** option to the advanced settings, implementing the feature requested in #151. Developers can now choose what the system Back button does in a generated app:

- **Go back in history** (`GO_BACK`, default) — walk the web history first, exiting only at the bottom. The existing browser-like behavior, unchanged.
- **Exit app** (`EXIT`) — leave the app immediately instead of navigating back through history, for web apps that should feel more native.

Fixes #151

## What changed

| Layer | Change |
|---|---|
| Model | `WebViewConfig.backButtonBehavior` (`GO_BACK` default / `EXIT`) |
| Export config | `ApkConfig.WebViewBlock` + `toWebViewBlock` + `webViewConfigPayload` (`backButtonBehavior` key) |
| Shell config | `WebViewShellConfig` `@SerializedName` + `ShellWebViewConfig.buildWebViewConfig` mapping |
| Runtime | `ShellActivityInit` back callback: `EXIT` finishes immediately; host preview `WebViewActivity` wired too for preview/export parity |
| UI | Two `FilterChip`s in the advanced card, next to the floating-back-button toggle |
| i18n | 4 new strings × 10 languages |
| Tests | New `BackButtonBehaviorExportWiringTest` |

## Behavior notes

`EXIT` only replaces the *history-navigation* path. Two system-level states still take precedence, which is the intuitive semantics:
- **Forced-run (kiosk)** back-blocking still wins — Back stays locked during forced run.
- **Fullscreen video** still closes first — Back exits fullscreen before exiting the app.

The existing polished automatic logic (smart finish on blank/error pages, Escape-to-close page modals, JS `history.back` for bfcache) is untouched and remains the `GO_BACK` path.

## Test plan

Verified locally:
- [x] `python3 scripts/check_config_field_drift.py` → OK
- [x] `:app:testDebugUnitTest` for `BackButtonBehaviorExportWiringTest` (2) + `WebViewConfigBooleanCoverageTest` + `StaticAssetPackExportWiringTest` regression — all green
- [x] `:app:compileDebugKotlin` → BUILD SUCCESSFUL
- [x] `:shell:assembleRelease` + `:app:syncShellTemplateApk` (R8) → BUILD SUCCESSFUL

CI `check` runs the same gates (`:app:compileDebugKotlin`, `:shell:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:checkConfigFieldDrift`).

## Notes

- Default is **Go back in history**, so existing apps are unaffected.
- The regenerated local `webview_shell.apk` template is a gitignored build artifact and is intentionally not committed.
