### PR TITLE
fix(engine): stop the white flash when launching GeckoView apps

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -423,6 +423,11 @@ class GeckoViewEngine(
         session = newSession
 
         val view = GeckoView(context)
+        // GeckoView renders on an opaque surface that defaults to white until the first
+        // frame is composited, which shows as a white flash on startup (#322). Make it
+        // transparent so the window/splash background shows through until content paints,
+        // matching the System WebView path (which has no opaque backing surface).
+        view.setBackgroundColor(android.graphics.Color.TRANSPARENT)
         view.setSession(newSession)
         geckoView = view
 


### PR DESCRIPTION
## Summary

Fixes the white flash seen when launching GeckoView-based apps, reported in #322.

GeckoView renders on an opaque surface that defaults to **white until the first frame is composited**. The dual-engine shell (introduced after v2.1.7 via `EngineViewFactory` / `BrowserSurface` / `ShellBrowserView`) creates the `GeckoView` and adds it to the layout immediately **without setting a background**, so GeckoView apps flash white before the site paints.

The System WebView path has no opaque backing surface (it draws into the normal view hierarchy), which is exactly why the reporter only sees the flash with GeckoView and not with WebView. v2.1.7 didn't flash because its shell WEB path always rendered through a System `WebView`; v2.3.5 is the first version that actually renders WEB apps through a real GeckoView widget.

Fixes #322

## The fix

One line in `GeckoViewEngine.createView`: set the GeckoView background to transparent so the window/splash background shows through until content is rendered — matching the System WebView behavior.

```kotlin
val view = GeckoView(context)
view.setBackgroundColor(android.graphics.Color.TRANSPARENT)
view.setSession(newSession)
```

- Transparent is correct for both light and dark themes (it reveals the themed window background, not a hardcoded color).
- The crash-recovery path reuses the same `GeckoView`, so the background persists.

## Test plan

- [x] `:app:compileDebugKotlin` → BUILD SUCCESSFUL
- [x] `:shell:assembleRelease` + `:app:syncShellTemplateApk` (R8) → BUILD SUCCESSFUL (`core/engine` is shell-synced)

No config-field changes, so the drift gate is unaffected.

Diagnosed via code archaeology (v2.1.7 ↔ v2.3.5 diff of the shell hosting path), not an on-device reproduction. The change is minimal and low-risk; happy to add an emulator verification pass if wanted.

## Notes

- The regenerated local `webview_shell.apk` template is a gitignored build artifact and is intentionally not committed.
