### PR TITLE
fix(engine): actually request Android permissions for GeckoView (geolocation/camera/mic)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
@@ -47,4 +47,15 @@ interface BrowserEngineCallback {
     fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {}
 
     fun onNewWindow(resultMsg: android.os.Message?) {}
+
+    /**
+     * Request Android runtime permissions on behalf of the engine. GeckoView surfaces these via
+     * `PermissionDelegate.onAndroidPermissionsRequest` (e.g. ACCESS_*_LOCATION for geolocation,
+     * CAMERA/RECORD_AUDIO for media). The engine must NOT auto-grant: the host shows the system
+     * permission dialog and reports whether every permission was granted through [onResult].
+     * Default grants so non-shell hosts do not deadlock the engine.
+     */
+    fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+        onResult(true)
+    }
 }

--- a/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
@@ -201,5 +201,9 @@ fun WebViewCallbacks.toBrowserEngineCallback(): BrowserEngineCallback {
         override fun onNewWindow(resultMsg: android.os.Message?) {
             source.onNewWindow(resultMsg)
         }
+
+        override fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+            source.onAndroidPermissionsRequest(permissions, onResult)
+        }
     }
 }

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -675,7 +675,19 @@ class GeckoViewEngine(
                 permissions: Array<out String>?,
                 callback: GeckoSession.PermissionDelegate.Callback
             ) {
-                callback.grant()
+                // Actually request the Android runtime permissions through the host Activity
+                // instead of auto-granting (#344). Auto-granting told GeckoView the permission was
+                // available while the OS-level permission was never obtained, so geolocation and
+                // camera/mic silently failed.
+                val perms = permissions?.filter { it.isNotBlank() }?.toTypedArray() ?: emptyArray()
+                val host = this@GeckoViewEngine.callback
+                if (perms.isEmpty() || host == null) {
+                    callback.grant()
+                    return
+                }
+                host.onAndroidPermissionsRequest(perms) { granted ->
+                    if (granted) callback.grant() else callback.reject()
+                }
             }
         }
     }

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
@@ -40,4 +40,13 @@ interface WebViewCallbacks {
     fun onNewWindow(resultMsg: android.os.Message?) {}
 
     fun onRenderProcessGone(didCrash: Boolean) {}
+
+    /**
+     * Request Android runtime permissions on behalf of an engine that cannot request them itself
+     * (GeckoView). The host shows the system dialog and reports the result via [onResult]. Default
+     * grants so hosts without an Activity (e.g. headless preview) do not deadlock the engine.
+     */
+    fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+        onResult(true)
+    }
 }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -285,6 +285,8 @@ class ShellActivity : AppCompatActivity() {
     }
 
     fun handlePermissionRequest(request: PermissionRequest) = permissionDelegate.handlePermissionRequest(request)
+    fun handleAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) =
+        permissionDelegate.requestAndroidPermissions(permissions, onResult)
     fun handleGeolocationPermission(origin: String?, callback: GeolocationPermissions.Callback?) {
         val cfg = shellConfig
         permissionDelegate.handleGeolocationPermission(

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellPermissionDelegate.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellPermissionDelegate.kt
@@ -419,6 +419,34 @@ class ShellPermissionDelegate(private val activity: AppCompatActivity) {
         }
     }
 
+    private var pendingAndroidPermissionsCallback: ((Boolean) -> Unit)? = null
+
+    private val androidPermissionLauncher = activity.registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val allGranted = permissions.values.all { it }
+        AppLogger.d("ShellActivity", "Android permissions (engine) result: $permissions allGranted=$allGranted")
+        pendingAndroidPermissionsCallback?.invoke(allGranted)
+        pendingAndroidPermissionsCallback = null
+    }
+
+    /**
+     * Request Android runtime permissions on behalf of an engine that cannot request them itself
+     * (GeckoView's onAndroidPermissionsRequest, #344). Reports whether every permission ended up
+     * granted; permissions already granted skip the system dialog.
+     */
+    fun requestAndroidPermissions(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+        val notGranted = permissions.filter {
+            ContextCompat.checkSelfPermission(activity, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (notGranted.isEmpty()) {
+            onResult(true)
+            return
+        }
+        pendingAndroidPermissionsCallback = onResult
+        androidPermissionLauncher.launch(notGranted.toTypedArray())
+    }
+
     private val locationPermissionLauncher = activity.registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
@@ -156,6 +156,11 @@ fun createShellWebViewCallbacks(
                 ?: callback?.invoke(origin, true, false)
         }
 
+        override fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
+            (context as? ShellActivity)?.handleAndroidPermissionsRequest(permissions, onResult)
+                ?: onResult(true)
+        }
+
         override fun onPermissionRequest(request: PermissionRequest?) {
 
             AppLogger.d("ShellActivity", "WebViewCallbacks.onPermissionRequest called, request: ${request?.resources?.joinToString()}")


### PR DESCRIPTION
## Summary

Fixes GeckoView apps being unable to access location (and camera/mic), reported in #344.

`GeckoViewEngine`'s `PermissionDelegate.onAndroidPermissionsRequest` just called `callback.grant()` **without ever requesting the Android runtime permission** from the user. GeckoView then believed the permission was available while the OS-level permission was never obtained, so `navigator.geolocation` failed with `PERMISSION_DENIED` — "can't detect location". Camera/mic verification failed the same way (the camera/mic complaint in #292).

The System WebView path was never affected: `ShellPermissionDelegate.handleGeolocationPermission` requests the Android permission through a launcher *before* invoking the geolocation callback. GeckoView had no equivalent — until now. This hits every ECH app too, since ECH forces the GeckoView engine.

Fixes #344

## The fix

Route GeckoView's Android permission requests through the host Activity so the real system dialog is shown:

- `BrowserEngineCallback` / `WebViewCallbacks` gain `onAndroidPermissionsRequest(permissions, onResult)` (default grants, so non-Activity hosts don't deadlock the engine).
- `GeckoViewEngine.onAndroidPermissionsRequest` now forwards to the host and calls the GeckoView callback's `grant()` / `reject()` based on the real result.
- `ShellPermissionDelegate` adds a `RequestMultiplePermissions` launcher + `requestAndroidPermissions(...)` (skips the dialog for already-granted permissions); `ShellActivity` exposes it and `ShellWebViewCallbacks` wires it through.

| File | Change |
|---|---|
| `core/engine/BrowserEngineCallback.kt` | new `onAndroidPermissionsRequest` |
| `core/webview/WebViewCallbacks.kt` | new `onAndroidPermissionsRequest` |
| `core/engine/EngineViewFactory.kt` | adapter wiring |
| `core/engine/GeckoViewEngine.kt` | request via host, grant/reject on result |
| `ui/shell/ShellPermissionDelegate.kt` | launcher + `requestAndroidPermissions` |
| `ui/shell/ShellActivity.kt` | `handleAndroidPermissionsRequest` |
| `ui/shell/ShellWebViewCallbacks.kt` | implement override |

## Test plan

- [x] `:app:compileDebugKotlin` → BUILD SUCCESSFUL
- [x] `:shell:assembleRelease` + `:app:syncShellTemplateApk` (R8) → BUILD SUCCESSFUL (engine + shell are shell-synced)

No config-field changes, so the drift gate is unaffected.

Diagnosed via code analysis of the two engine permission paths; not reproduced on-device. The System WebView path is unchanged.

## Notes

- The regenerated local `webview_shell.apk` template is a gitignored build artifact and is intentionally not committed.
