### PR TITLE
fix(adblock): stop the OutOfMemoryError crash loop on startup and the App Creation screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -218,6 +218,7 @@
     <application
         android:name=".WebToAppApplication"
         android:allowBackup="false"
+        android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlockFilterCache.kt
@@ -240,6 +240,15 @@ object AdBlockFilterCache {
                     scriptletRules = scriptletRules
                 )
             }
+        } catch (oom: OutOfMemoryError) {
+            // The compiled rule set can exceed the heap on devices with many large filter
+            // lists. OutOfMemoryError is an Error (not Exception), so without this branch it
+            // would escape and the on-disk cache would survive — re-triggering the same OOM on
+            // every cold start until app data is wiped. Invalidate the cache to break the loop.
+            runCatching { System.gc() }
+            AppLogger.e(TAG, "OutOfMemoryError loading compiled state; invalidating cache to break crash loop", oom)
+            File(context.filesDir, "$CACHE_DIR/$COMPILED_STATE_FILE").delete()
+            null
         } catch (e: Exception) {
             AppLogger.e(TAG, "Failed to load compiled state (will re-parse)", e)
 

--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -1891,9 +1891,20 @@ class AdBlocker {
             }
             hydrateSourceRuleCountsFromDisk(context)
             Result.success(hostsFileHosts.size)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             Result.failure(e)
         }
+    }
+
+    /**
+     * Lightweight metadata-only hydration: populates [enabledHostsSources]/[disabledHostsSources]/
+     * [sourceRuleCounts] from the small on-disk sources registry WITHOUT loading the full compiled
+     * filter database into memory. Intended for config UI (e.g. AdBlockCard) that only needs to
+     * know which hosts sources are downloaded, avoiding the heavy [loadHostsRules] path that can
+     * exhaust the heap on devices with many large filter lists.
+     */
+    suspend fun hydrateSourcesMetadata(context: Context) = withContext(Dispatchers.IO) {
+        hydrateSourceRuleCountsFromDisk(context)
     }
 
     private fun hydrateSourceRuleCountsFromDisk(context: Context) {

--- a/app/src/main/java/com/webtoapp/core/startup/RuntimeWarmupStartup.kt
+++ b/app/src/main/java/com/webtoapp/core/startup/RuntimeWarmupStartup.kt
@@ -11,9 +11,10 @@ class RuntimeWarmupStartup(
         appScope.launch {
             com.webtoapp.core.perf.SystemPerfOptimizer.initSystem(appContext)
             com.webtoapp.core.perf.SystemPerfOptimizer.readaheadCriticalFiles(appContext)
-            runCatching {
-                com.webtoapp.WebToAppApplication.adBlock.loadHostsRules(appContext)
-            }
+            // NOTE: do NOT preload adblock filters here. The full compiled rule set can be huge
+            // (many large filter lists) and loading it on every cold start exhausted the heap and
+            // crashed the app (issue #356). Filters are loaded lazily on first actual use
+            // (preview/runtime via AdBlocker.loadHostsRules / prepareRuntimeFilters).
         }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -445,7 +445,9 @@ fun AdBlockCard(
     val allSources = remember { com.webtoapp.core.adblock.AdBlocker.getPopularHostsSources() }
     var hostsEpoch by remember { mutableStateOf(0) }
     LaunchedEffect(Unit) {
-        adBlocker.loadHostsRules(context)
+        // Lightweight metadata-only hydration — just enough to know which sources are downloaded.
+        // A full loadHostsRules() here loaded the entire filter DB on scroll and could OOM (#356).
+        adBlocker.hydrateSourcesMetadata(context)
         hostsEpoch += 1
     }
     val downloadedSources = remember(allSources, hostsEpoch) {


### PR DESCRIPTION
## Summary

Fixes the repeated `OutOfMemoryError` crashes reported in #356 (app dies on the App Creation screen when scrolling to the bottom cards, and a "set custom DoH then crash forever until app data is cleared" variant). 5 files changed.

Fixes #356

## Root cause

The adblock engine materializes the **entire** compiled filter database (hundreds of thousands of hosts + tens of thousands of network/cosmetic rules, each carrying several `LinkedHashSet`s) into plain in-memory collections, persisted as one monolithic `compiled_state.bin`. With several of the 20 bundled lists enabled, the load peak (2–3 concurrent copies) exceeds the host's **256MB heap** (no `largeHeap`).

Two regression triggers shipped in v2.3.0 (`27c15082`):
- `loadHostsRules()` ran on **every cold start** (`RuntimeWarmupStartup`), holding the huge resident set before any UI.
- `AdBlockCard`'s `LaunchedEffect` ran a **full `loadHostsRules()` just to show which sources are downloaded**, re-triggering the load on scroll.

The crash-loop: `AdBlockFilterCache.loadCompiledState` only caught `Exception`, so the `OutOfMemoryError` (an `Error`) escaped and the on-disk cache was **never invalidated** — the same OOM repeated on every launch until app data was wiped. (The DoH variant: the DoH/ECH card sits right next to `AdBlockCard`, so scrolling there triggered the full load.) `CreateAppScreen` itself is a lazy list of collapsed cards — it is where the already-full heap tips over, not the allocator.

## What changed

- **OOM-safe load (breaks the crash loop):** `AdBlockFilterCache.loadCompiledState` now catches `OutOfMemoryError`, runs `gc`, **deletes the compiled cache**, and returns null. `AdBlocker.loadHostsRules` catches `Throwable` so an OOM during `restoreFromCompiledState` is also handled (`Result.failure`).
- **No eager startup load:** removed `loadHostsRules` from `RuntimeWarmupStartup`; filters now load lazily on first actual use (preview/runtime via `prepareRuntimeFilters`).
- **Lightweight card metadata:** added `AdBlocker.hydrateSourcesMetadata()` that only reads the small sources registry; `AdBlockCard` uses it instead of the full load (`isHostsSourceDownloaded` only needs the source sets, not the filter DB).
- **Headroom:** added `android:largeHeap="true"` (~512MB) to the host manifest. Generated shell APKs are protected by the synced OOM-safe load (graceful degradation: drop cache + disable adblock for the session instead of crashing).

`AdBlocker.kt` / `AdBlockFilterCache.kt` are shell-synced; mirrors updated.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin :shell:assembleRelease :app:syncShellTemplateApk` → BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests *AdBlockerTest --tests *AdBlockerHostRuntimeTest` → pass (normal load/match unaffected)
- [x] `loadHostsRules` now only remains at on-demand call sites (HostsAdBlockScreen / prepareRuntimeFilters / export compiler); startup and AdBlockCard no longer preload