### PR TITLE
fix(permissions): clear auto-enabled permissions when the enabling feature is turned off

### DIFF
--- a/app/src/main/java/com/webtoapp/data/model/RuntimePermissionSync.kt
+++ b/app/src/main/java/com/webtoapp/data/model/RuntimePermissionSync.kt
@@ -108,18 +108,24 @@ fun WebApp.featureRequiredRuntimePermissions(): ApkRuntimePermissions =
 fun WebApp.withRuntimePermissionsSyncedFromFeatures(): WebApp {
     val required = featureRequiredRuntimePermissions()
     val currentExport = apkExportConfig ?: ApkExportConfig()
-    val merged = currentExport.runtimePermissions.enableFrom(required)
+    // Preserve permissions the user added manually (beyond what features auto-enabled last
+    // time) while recomputing feature-required permissions. This lets turning a feature OFF
+    // clear the permission it had auto-enabled, instead of the old one-way OR latch that kept
+    // it forever (issue #356).
+    val manual = currentExport.runtimePermissions.manualBeyond(currentExport.autoEnabledPermissions)
+    val merged = manual.enableFrom(required)
     // Location coherence (issue #292): granting the location permission implies the
     // WebView geolocation API should be enabled. The reverse direction (geolocationEnabled
     // -> location permission) is already handled by featureRequiredRuntimePermissions above.
     val effectiveGeolocation = webViewConfig.geolocationEnabled || merged.location
-    val permissionsChanged = merged != currentExport.runtimePermissions || apkExportConfig == null
+    val permissionsChanged = merged != currentExport.runtimePermissions ||
+        required != currentExport.autoEnabledPermissions || apkExportConfig == null
     val geolocationChanged = effectiveGeolocation != webViewConfig.geolocationEnabled
     if (!permissionsChanged && !geolocationChanged) {
         return this
     }
     return copy(
-        apkExportConfig = currentExport.copy(runtimePermissions = merged),
+        apkExportConfig = currentExport.copy(runtimePermissions = merged, autoEnabledPermissions = required),
         webViewConfig = webViewConfig.copy(geolocationEnabled = effectiveGeolocation)
     )
 }
@@ -135,8 +141,10 @@ fun ApkExportConfig.withRuntimePermissionsSyncedFromFeatures(
         autoStartConfig = autoStartConfig,
         bgmEnabled = bgmEnabled
     )
-    val merged = runtimePermissions.enableFrom(required)
-    return if (merged == runtimePermissions) this else copy(runtimePermissions = merged)
+    val manual = runtimePermissions.manualBeyond(autoEnabledPermissions)
+    val merged = manual.enableFrom(required)
+    return if (merged == runtimePermissions && required == autoEnabledPermissions) this
+    else copy(runtimePermissions = merged, autoEnabledPermissions = required)
 }
 
 enum class PermissionFeatureReason {

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -1056,6 +1056,7 @@ data class ApkExportConfig(
     val customVersionCode: Int? = null,
     val architecture: ApkArchitecture = ApkArchitecture.UNIVERSAL,
     val runtimePermissions: ApkRuntimePermissions = ApkRuntimePermissions(),
+    val autoEnabledPermissions: ApkRuntimePermissions = ApkRuntimePermissions(),
     val networkTrustConfig: NetworkTrustConfig = NetworkTrustConfig(),
     val encryptionConfig: ApkEncryptionConfig = ApkEncryptionConfig(),
     val isolationConfig: com.webtoapp.core.privacy.IsolationConfig = com.webtoapp.core.privacy.IsolationConfig(),
@@ -1127,7 +1128,50 @@ data class ApkRuntimePermissions(
     val installPackages: Boolean = false,
     val requestDeletePackages: Boolean = false,
     val systemAlertWindow: Boolean = false
-)
+) {
+    /**
+     * Permissions enabled in this set but NOT in [auto] — i.e. permissions the user added
+     * manually beyond what features auto-enabled. The permission sync uses this to preserve
+     * manual choices while clearing permissions whose enabling feature was turned off
+     * (fixes the "can't turn off an auto-enabled permission" latch, issue #356).
+     */
+    fun manualBeyond(auto: ApkRuntimePermissions): ApkRuntimePermissions = copy(
+        camera = camera && !auto.camera,
+        microphone = microphone && !auto.microphone,
+        location = location && !auto.location,
+        notifications = notifications && !auto.notifications,
+        readExternalStorage = readExternalStorage && !auto.readExternalStorage,
+        writeExternalStorage = writeExternalStorage && !auto.writeExternalStorage,
+        readMediaImages = readMediaImages && !auto.readMediaImages,
+        readMediaVideo = readMediaVideo && !auto.readMediaVideo,
+        readMediaAudio = readMediaAudio && !auto.readMediaAudio,
+        bluetooth = bluetooth && !auto.bluetooth,
+        nfc = nfc && !auto.nfc,
+        wifiState = wifiState && !auto.wifiState,
+        bodySensors = bodySensors && !auto.bodySensors,
+        activityRecognition = activityRecognition && !auto.activityRecognition,
+        readPhoneState = readPhoneState && !auto.readPhoneState,
+        callPhone = callPhone && !auto.callPhone,
+        readContacts = readContacts && !auto.readContacts,
+        writeContacts = writeContacts && !auto.writeContacts,
+        readCalendar = readCalendar && !auto.readCalendar,
+        writeCalendar = writeCalendar && !auto.writeCalendar,
+        readSms = readSms && !auto.readSms,
+        sendSms = sendSms && !auto.sendSms,
+        receiveSms = receiveSms && !auto.receiveSms,
+        readCallLog = readCallLog && !auto.readCallLog,
+        writeCallLog = writeCallLog && !auto.writeCallLog,
+        processOutgoingCalls = processOutgoingCalls && !auto.processOutgoingCalls,
+        foregroundService = foregroundService && !auto.foregroundService,
+        wakeLock = wakeLock && !auto.wakeLock,
+        requestIgnoreBatteryOptimizations = requestIgnoreBatteryOptimizations && !auto.requestIgnoreBatteryOptimizations,
+        bootCompleted = bootCompleted && !auto.bootCompleted,
+        vibration = vibration && !auto.vibration,
+        installPackages = installPackages && !auto.installPackages,
+        requestDeletePackages = requestDeletePackages && !auto.requestDeletePackages,
+        systemAlertWindow = systemAlertWindow && !auto.systemAlertWindow
+    )
+}
 
 fun ApkExportConfig?.isMeaningful(): Boolean {
     if (this == null) return false
@@ -1430,7 +1474,7 @@ data class NativeBridgeCapabilities(
     val vibration: Boolean = true,
     val geolocation: Boolean = true,
     val brightness: Boolean = true,
-    val notification: Boolean = true,
+    val notification: Boolean = false,
     val notificationScheduled: Boolean = true,
     val notificationPersistent: Boolean = true,
     val download: Boolean = true,

--- a/app/src/test/java/com/webtoapp/data/model/RuntimePermissionSyncTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/RuntimePermissionSyncTest.kt
@@ -134,4 +134,44 @@ class RuntimePermissionSyncTest {
         assertThat(synced.apkExportConfig?.runtimePermissions?.location).isTrue()
         assertThat(synced.webViewConfig.geolocationEnabled).isTrue()
     }
+
+    @Test
+    fun `disabling a feature clears the permission it had auto-enabled`() {
+        // Sync with the feature ON first, establishing autoEnabledPermissions.
+        val withFeature = WebApp(
+            name = "Notify",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(notificationEnabled = true)
+        ).withRuntimePermissionsSyncedFromFeatures()
+        assertThat(withFeature.apkExportConfig?.runtimePermissions?.notifications).isTrue()
+
+        // Turn the feature OFF and sync again: the auto-enabled permission is cleared
+        // (the old one-way OR latch kept it forever — issue #356).
+        val featureOff = withFeature.copy(
+            apkExportConfig = withFeature.apkExportConfig!!.copy(notificationEnabled = false)
+        ).withRuntimePermissionsSyncedFromFeatures()
+        assertThat(featureOff.apkExportConfig?.runtimePermissions?.notifications).isFalse()
+    }
+
+    @Test
+    fun `manually added permission survives the enabling feature being turned off`() {
+        // User manually enabled camera while a notification feature was on.
+        val withFeature = WebApp(
+            name = "Mix",
+            url = "https://example.com",
+            apkExportConfig = ApkExportConfig(
+                notificationEnabled = true,
+                runtimePermissions = ApkRuntimePermissions(camera = true)
+            )
+        ).withRuntimePermissionsSyncedFromFeatures()
+        assertThat(withFeature.apkExportConfig?.runtimePermissions?.camera).isTrue()
+        assertThat(withFeature.apkExportConfig?.runtimePermissions?.notifications).isTrue()
+
+        // Turn the feature off: auto-enabled notifications cleared, manual camera preserved.
+        val featureOff = withFeature.copy(
+            apkExportConfig = withFeature.apkExportConfig!!.copy(notificationEnabled = false)
+        ).withRuntimePermissionsSyncedFromFeatures()
+        assertThat(featureOff.apkExportConfig?.runtimePermissions?.notifications).isFalse()
+        assertThat(featureOff.apkExportConfig?.runtimePermissions?.camera).isTrue()
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the notification permission being forced on and un-clearable. Two root causes addressed: (1) the NativeBridge notification capability defaulted to `true`, silently auto-enabling the notification permission; (2) the permission sync was a one-way OR latch, so an auto-enabled permission stayed `true` forever even after the feature was turned off.

Fixes #360

## What changed

**1. NativeBridge notification capability defaults to `false`** (`WebApp.kt`)
Enabling NativeBridge no longer silently auto-enables the notification permission; the notification bridge is now opt-in.

**2. Permission sync no longer latches** (`RuntimePermissionSync.kt`, `WebApp.kt`)
- `ApkExportConfig` gains `autoEnabledPermissions` — tracks which permissions features auto-enabled at the last sync (Gson-serialized field, **no Room migration**).
- `ApkRuntimePermissions` gains `manualBeyond(auto)` — returns permissions the user added manually (on, but not auto-enabled).
- Both `withRuntimePermissionsSyncedFromFeatures` functions now compute `merged = manual.enableFrom(required)` and store `autoEnabledPermissions = required`. Turning a feature OFF clears the permission it had auto-enabled; user-added permissions are preserved.

`WebApp.kt` / `RuntimePermissionSync.kt` are shell-synced; mirrors updated.

## Behavior

- **New apps** with NativeBridge enabled: notification permission not auto-enabled.
- **Existing apps**: disable the NativeBridge notification capability → the sync clears the latched `notifications = true` → rebuild no longer declares/requests `POST_NOTIFICATIONS`.
- **Manual permissions**: a permission the user enabled themselves (not required by any feature) survives features being turned off.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests *RuntimePermissionSyncTest --tests *ExportSecurityRegressionTest` → pass
- [x] New tests: `disabling a feature clears the permission it had auto-enabled`, `manually added permission survives the enabling feature being turned off`
- [x] Existing auto-enable tests still pass (features still auto-enable their permissions)