### PR TITLE
fix(permissions): accumulate multiple runtime-permission toggles

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -512,14 +512,7 @@ fun CreateAppScreen(
                     onConfigChange = { viewModel.updateEditState { copy(webViewConfig = it) } },
                     runtimePermissions = editState.apkExportConfig?.runtimePermissions
                         ?: com.webtoapp.data.model.ApkRuntimePermissions(),
-                    onRuntimePermissionsChange = { rp ->
-                        viewModel.updateEditState {
-                            copy(
-                                apkExportConfig = (apkExportConfig ?: com.webtoapp.data.model.ApkExportConfig())
-                                    .copy(runtimePermissions = rp)
-                            )
-                        }
-                    }
+                    onRuntimePermissionsTransform = viewModel::updateRuntimePermissions
                 )
             }
 
@@ -527,6 +520,7 @@ fun CreateAppScreen(
                 ExportAndPermissionDrawer(
                     exportConfig = editState.apkExportConfig,
                     onExportConfigChange = { viewModel.updateEditState { copy(apkExportConfig = it) } },
+                    onRuntimePermissionsTransform = viewModel::updateRuntimePermissions,
                     webViewConfig = editState.webViewConfig,
                     autoStartConfig = editState.autoStartConfig,
                     bgmEnabled = editState.bgmEnabled
@@ -572,6 +566,7 @@ fun CreateAppScreen(
 private fun ExportAndPermissionDrawer(
     exportConfig: ApkExportConfig,
     onExportConfigChange: (ApkExportConfig) -> Unit,
+    onRuntimePermissionsTransform: ((ApkRuntimePermissions) -> ApkRuntimePermissions) -> Unit,
     webViewConfig: WebViewConfig,
     autoStartConfig: AutoStartConfig?,
     bgmEnabled: Boolean
@@ -622,9 +617,7 @@ private fun ExportAndPermissionDrawer(
 
                     PermissionConfigPanel(
                         permissions = exportConfig.runtimePermissions,
-                        onPermissionsChange = { permissions ->
-                            onExportConfigChange(exportConfig.copy(runtimePermissions = permissions))
-                        },
+                        onPermissionsTransform = onRuntimePermissionsTransform,
                         showDescription = false,
                         featureReasons = featureReasons
                     )

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -3148,7 +3148,7 @@ fun SpecialSettingsCard(
     config: com.webtoapp.data.model.WebViewConfig,
     onConfigChange: (com.webtoapp.data.model.WebViewConfig) -> Unit,
     runtimePermissions: com.webtoapp.data.model.ApkRuntimePermissions,
-    onRuntimePermissionsChange: (com.webtoapp.data.model.ApkRuntimePermissions) -> Unit,
+    onRuntimePermissionsTransform: ((com.webtoapp.data.model.ApkRuntimePermissions) -> com.webtoapp.data.model.ApkRuntimePermissions) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -3609,7 +3609,9 @@ fun SpecialSettingsCard(
                                 subtitle = Strings.cameraAccessDesc,
                                 icon = Icons.Outlined.PhotoCamera,
                                 checked = runtimePermissions.camera,
-                                onCheckedChange = { onRuntimePermissionsChange(runtimePermissions.copy(camera = it)) }
+                                onCheckedChange = { checked ->
+                                    onRuntimePermissionsTransform { p -> p.copy(camera = checked) }
+                                }
                             )
                         }
 
@@ -3619,7 +3621,9 @@ fun SpecialSettingsCard(
                                 subtitle = Strings.microphoneAccessDesc,
                                 icon = Icons.Outlined.Mic,
                                 checked = runtimePermissions.microphone,
-                                onCheckedChange = { onRuntimePermissionsChange(runtimePermissions.copy(microphone = it)) }
+                                onCheckedChange = { checked ->
+                                    onRuntimePermissionsTransform { p -> p.copy(microphone = checked) }
+                                }
                             )
                         }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/PermissionConfigScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/PermissionConfigScreen.kt
@@ -237,7 +237,7 @@ fun PermissionConfigScreen(
             ) {
                 PermissionConfigPanel(
                     permissions = permissions,
-                    onPermissionsChange = onPermissionsChange
+                    onPermissionsTransform = { transform -> onPermissionsChange(transform(permissions)) }
                 )
             }
         }
@@ -247,7 +247,7 @@ fun PermissionConfigScreen(
 @Composable
 fun PermissionConfigPanel(
     permissions: ApkRuntimePermissions,
-    onPermissionsChange: (ApkRuntimePermissions) -> Unit,
+    onPermissionsTransform: ((ApkRuntimePermissions) -> ApkRuntimePermissions) -> Unit,
     modifier: Modifier = Modifier,
     showDescription: Boolean = true,
     featureReasons: Map<String, List<PermissionFeatureReason>> = emptyMap()
@@ -323,7 +323,7 @@ fun PermissionConfigPanel(
                 val selected = preset.match(permissions)
                 FilterChip(
                     selected = selected,
-                    onClick = { onPermissionsChange(preset.apply(permissions)) },
+                    onClick = { onPermissionsTransform { preset.apply(it) } },
                     label = { Text(preset.label()) },
                     leadingIcon = {
                         Icon(
@@ -344,7 +344,7 @@ fun PermissionConfigPanel(
                 savedPresets = PermissionPresetStorage.save(context, schemeName, permissions)
                 schemeName = ""
             },
-            onApplyScheme = { onPermissionsChange(it.permissions) },
+            onApplyScheme = { scheme -> onPermissionsTransform { scheme.permissions } },
             onDeleteScheme = {
                 savedPresets = PermissionPresetStorage.delete(context, it.id)
             }
@@ -415,7 +415,7 @@ fun PermissionConfigPanel(
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 if (enabledCount > 0) {
-                    TextButton(onClick = { onPermissionsChange(ApkRuntimePermissions()) }) {
+                    TextButton(onClick = { onPermissionsTransform { ApkRuntimePermissions() } }) {
                         Text(Strings.permissionClearAll, style = MaterialTheme.typography.labelSmall)
                     }
                 }
@@ -427,7 +427,7 @@ fun PermissionConfigPanel(
                 PermissionGroupCard(
                     group = group,
                     permissions = permissions,
-                    onPermissionsChange = onPermissionsChange,
+                    onPermissionsTransform = onPermissionsTransform,
                     featureReasons = featureReasons
                 )
             }
@@ -601,7 +601,7 @@ private fun PermissionSchemeCard(
 private fun PermissionGroupCard(
     group: PermissionGroup,
     permissions: ApkRuntimePermissions,
-    onPermissionsChange: (ApkRuntimePermissions) -> Unit,
+    onPermissionsTransform: ((ApkRuntimePermissions) -> ApkRuntimePermissions) -> Unit,
     featureReasons: Map<String, List<PermissionFeatureReason>> = emptyMap()
 ) {
     val enabledInGroup = group.items.count { it.checked(permissions) }
@@ -692,7 +692,10 @@ private fun PermissionGroupCard(
                             checked = item.checked(permissions),
                             featureReasonLabels = reasons.map { it.displayLabel() },
                             onCheckedChange = { checked ->
-                                onPermissionsChange(item.update(permissions, checked))
+                                // Transform semantics: applied against the *latest* permissions
+                                // in the ViewModel, so rapid consecutive toggles accumulate
+                                // instead of overwriting each other from a stale snapshot.
+                                onPermissionsTransform { current -> item.update(current, checked) }
                             }
                         )
                     }

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
@@ -192,6 +192,22 @@ class MainViewModel(
         _hasUnsavedChanges.value = true
     }
 
+    /**
+     * Applies a transform to the runtime permissions based on the *current* edit state,
+     * so rapid consecutive permission toggles accumulate instead of overwriting each
+     * other (a Compose callback may still hold a pre-recomposition snapshot otherwise).
+     */
+    fun updateRuntimePermissions(transform: (ApkRuntimePermissions) -> ApkRuntimePermissions) {
+        updateEditState {
+            val currentExport = apkExportConfig
+            copy(
+                apkExportConfig = currentExport.copy(
+                    runtimePermissions = transform(currentExport.runtimePermissions)
+                )
+            )
+        }
+    }
+
     fun analyzePwa(url: String) {
         if (url.isBlank()) return
         viewModelScope.launch {


### PR DESCRIPTION
Fixes #362

## Summary

Opening several runtime permissions in the editor (APK export config → permissions → Basic group: Camera / Microphone / Location) kept only the **last** toggled one; the generated APK then requested only that single permission.

The permission switches captured the pre-recomposition permission snapshot and replaced the whole permission set on each toggle:

```kotlin
// stale snapshot `permissions`, then whole-set replace
onCheckedChange = { checked -> onPermissionsChange(item.update(permissions, checked)) }
// in ExportAndPermissionDrawer
onPermissionsChange = { permissions -> onExportConfigChange(exportConfig.copy(runtimePermissions = permissions)) }
```

Compose recomposition is async, so when multiple switches are toggled faster than a recomposition completes, each toggle does `permissions.copy(field = v)` against the **same stale snapshot** and replaces the whole set — every toggle after the first overwrites the previous one.

The export pipeline (`ApkBuilder.buildRequiredPermissions`) was already correct (accumulates every enabled permission into the manifest); the loss was purely in the editor UI before the value reached the model.

## Change

Switch permission updates to **transform semantics** applied against the latest edit state, so rapid consecutive toggles accumulate:

- Add `MainViewModel.updateRuntimePermissions(transform)` — applies the transform against the current `EditState.apkExportConfig.runtimePermissions` (always the latest `_editState.value`), then runs the existing feature-driven permission sync.
- `PermissionConfigPanel` / `PermissionGroupCard` (`PermissionConfigScreen.kt`): `onPermissionsChange: (ApkRuntimePermissions) -> Unit` → `onPermissionsTransform: ((ApkRuntimePermissions) -> ApkRuntimePermissions) -> Unit`. Switches become `onPermissionsTransform { current -> item.update(current, checked) }`. Presets, clear-all, and saved-scheme apply follow the same transform shape.
- `ExportAndPermissionDrawer` (`CreateAppScreen.kt`): receives `onRuntimePermissionsTransform`, wired to `viewModel::updateRuntimePermissions`.
- `SpecialSettingsCard` (`CreateAppWebViewCards.kt`): Camera/Microphone switches get the same transform treatment (they had the identical stale-snapshot bug).

## Test plan

- [x] `:app:compileDebugKotlin` passes.
- [x] `RuntimePermissionSyncTest` passes.
- [ ] Manual: rapidly toggle Camera + Microphone + Location in the Basic group → all three stay enabled.
- [ ] Manual: build an APK and confirm the manifest requests all three permissions.
- [ ] Manual: permission presets (None/Minimal/Standard/Full), clear-all, and saved-scheme apply still work.