### PR TITLE
feat(agent): multimodal image input across all LLM providers

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -51,6 +51,11 @@ class AgentEngine(
             messages += LlmMessage(LlmMessage.Role.USER, input.userMessage)
         }
 
+        // Only multimodal (vision) models can accept image parts; strip them for
+        // text-only models so attachments never break a non-vision chat request.
+        val supportsVision = input.toolContext.textModel.model.capabilities
+            .contains(com.webtoapp.data.model.ModelCapability.MULTIMODAL)
+
         var totalToolCalls = 0
         val accText = StringBuilder()
         val maxContinuations = 3
@@ -79,7 +84,7 @@ class AgentEngine(
                     if (abortController.aborted) { send(AgentEvent.Aborted); return@channelFlow }
 
                     val isContinuation = continuationCount > 0
-                    val requestMessages = if (isContinuation && turnText.isNotEmpty()) {
+                    val baseMessages = if (isContinuation && turnText.isNotEmpty()) {
                         messages + LlmMessage(
                             role = LlmMessage.Role.ASSISTANT,
                             content = turnText.toString(),
@@ -88,6 +93,8 @@ class AgentEngine(
                     } else {
                         messages.toList()
                     }
+                    val requestMessages = if (supportsVision) baseMessages
+                        else baseMessages.map { if (it.images.isEmpty()) it else it.copy(images = emptyList()) }
 
                     gateway.chatStream(
                         ChatRequest(
@@ -196,7 +203,8 @@ class AgentEngine(
                                 role = LlmMessage.Role.TOOL,
                                 content = trimToolText(result.text),
                                 toolCallId = call.id,
-                                name = call.name
+                                name = call.name,
+                                images = result.images
                             )
                             if (result.planReviewPath != null) {
                                 send(AgentEvent.PlanReviewRequired(result.planReviewPath))
@@ -217,7 +225,8 @@ class AgentEngine(
                                 role = LlmMessage.Role.TOOL,
                                 content = trimToolText(result.text),
                                 toolCallId = call.id,
-                                name = call.name
+                                name = call.name,
+                                images = result.images
                             )
                             if (result.planReviewPath != null) {
                                 send(AgentEvent.PlanReviewRequired(result.planReviewPath))

--- a/app/src/main/java/com/webtoapp/core/agent/llm/AnthropicProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/AnthropicProvider.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.webtoapp.core.agent.tool.ImageAttachment
 import com.webtoapp.core.network.NetworkModule
 import com.webtoapp.data.model.AiProvider
 import com.webtoapp.util.GsonProvider
@@ -61,9 +62,17 @@ internal class AnthropicProvider(@Suppress("UNUSED_PARAMETER") context: Context)
         }
     }
     private fun buildMsg(m: LlmMessage): JsonObject = when(m.role) {
-        LlmMessage.Role.USER -> JsonObject().apply{addProperty("role","user");addProperty("content",m.content)}
+        LlmMessage.Role.USER -> JsonObject().apply{addProperty("role","user"); if (m.images.isNotEmpty()) add("content", JsonArray().apply { if (m.content.isNotEmpty()) add(JsonObject().apply{addProperty("type","text");addProperty("text",m.content)}); m.images.forEach { add(imageBlock(it)) } }) else addProperty("content",m.content)}
         LlmMessage.Role.ASSISTANT -> JsonObject().apply{addProperty("role","assistant");val c=JsonArray();if(m.content.isNotEmpty())c.add(JsonObject().apply{addProperty("type","text");addProperty("text",m.content)});m.toolCalls.forEach{tc->c.add(JsonObject().apply{addProperty("type","tool_use");addProperty("id",tc.id);addProperty("name",tc.name);add("input",runCatching{JsonParser.parseString(tc.argumentsJson)}.getOrElse{JsonObject()})})};add("content",c)}
-        LlmMessage.Role.TOOL -> JsonObject().apply{addProperty("role","user");add("content",JsonArray().apply{add(JsonObject().apply{addProperty("type","tool_result");addProperty("tool_use_id",m.toolCallId.orEmpty());addProperty("content",m.content)})})}
+        LlmMessage.Role.TOOL -> JsonObject().apply{addProperty("role","user");add("content",JsonArray().apply{add(JsonObject().apply{addProperty("type","tool_result");addProperty("tool_use_id",m.toolCallId.orEmpty()); if (m.images.isNotEmpty()) add("content", JsonArray().apply { if (m.content.isNotEmpty()) add(JsonObject().apply{addProperty("type","text");addProperty("text",m.content)}); m.images.forEach { add(imageBlock(it)) } }) else addProperty("content",m.content)})})}
         else -> JsonObject()
+    }
+    private fun imageBlock(img: ImageAttachment) = JsonObject().apply {
+        addProperty("type", "image")
+        add("source", JsonObject().apply {
+            addProperty("type", "base64")
+            addProperty("media_type", img.mimeType)
+            addProperty("data", android.util.Base64.encodeToString(img.bytes, android.util.Base64.NO_WRAP))
+        })
     }
 }

--- a/app/src/main/java/com/webtoapp/core/agent/llm/GeminiProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/GeminiProvider.kt
@@ -68,6 +68,9 @@ internal class GeminiProvider(@Suppress("UNUSED_PARAMETER") context: Context) : 
         when(m.role){LlmMessage.Role.USER->{if(m.content.isNotEmpty())parts.add(JsonObject().apply{addProperty("text",m.content)})}
         LlmMessage.Role.ASSISTANT->{if(m.content.isNotEmpty())parts.add(JsonObject().apply{addProperty("text",m.content)});m.toolCalls.forEach{tc->parts.add(JsonObject().apply{add("functionCall",JsonObject().apply{addProperty("name",tc.name);add("args",runCatching{JsonParser.parseString(tc.argumentsJson)}.getOrElse{JsonObject()})})})}}
         LlmMessage.Role.TOOL->{parts.add(JsonObject().apply{add("functionResponse",JsonObject().apply{addProperty("name",m.name?:"tool");add("response",JsonObject().apply{addProperty("result",m.content)})})})}
-        else->{}}; return parts
+        else->{}}
+        m.images.forEach { img -> parts.add(JsonObject().apply { add("inlineData", JsonObject().apply { addProperty("mimeType", img.mimeType); addProperty("data", base64(img.bytes)) }) }) }
+        return parts
     }
+    private fun base64(bytes: ByteArray) = android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP)
 }

--- a/app/src/main/java/com/webtoapp/core/agent/llm/LlmModels.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/LlmModels.kt
@@ -1,6 +1,7 @@
 package com.webtoapp.core.agent.llm
 
 import com.google.gson.JsonElement
+import com.webtoapp.core.agent.tool.ImageAttachment
 import com.webtoapp.data.model.AiModel
 import com.webtoapp.data.model.ApiKeyConfig
 
@@ -21,7 +22,9 @@ data class LlmMessage(
     val toolCallId: String? = null,
     val name: String? = null,
 
-    val reasoningContent: String? = null
+    val reasoningContent: String? = null,
+
+    val images: List<ImageAttachment> = emptyList()
 ) {
     enum class Role { SYSTEM, USER, ASSISTANT, TOOL }
 }

--- a/app/src/main/java/com/webtoapp/core/agent/llm/OllamaProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OllamaProvider.kt
@@ -23,7 +23,7 @@ internal class OllamaProvider(@Suppress("UNUSED_PARAMETER") context: Context) : 
         val url = HttpHelpers.joinUrl(HttpHelpers.baseUrl(req.apiKey), "/api/chat")
         val body = JsonObject().apply {
             addProperty("model",req.model.id); addProperty("stream",true)
-            add("messages",JsonArray().apply{req.messages.forEach{m->add(JsonObject().apply{addProperty("role",when(m.role){LlmMessage.Role.SYSTEM->"system";LlmMessage.Role.USER->"user";LlmMessage.Role.ASSISTANT->"assistant";LlmMessage.Role.TOOL->"tool"});addProperty("content",m.content)})}})
+            add("messages",JsonArray().apply{req.messages.forEach{m->add(JsonObject().apply{addProperty("role",when(m.role){LlmMessage.Role.SYSTEM->"system";LlmMessage.Role.USER->"user";LlmMessage.Role.ASSISTANT->"assistant";LlmMessage.Role.TOOL->"tool"});addProperty("content",m.content); if (m.images.isNotEmpty()) add("images", JsonArray().apply { m.images.forEach { add(com.google.gson.JsonPrimitive(android.util.Base64.encodeToString(it.bytes, android.util.Base64.NO_WRAP))) } })})}})
             add("options",JsonObject().apply{addProperty("temperature",req.temperature)})
             if(req.useTools&&req.tools.isNotEmpty()) add("tools",JsonArray().apply{req.tools.forEach{t->add(JsonObject().apply{addProperty("type","function");add("function",JsonObject().apply{addProperty("name",t.name);addProperty("description",t.description);add("parameters",t.parametersSchema)})})}})
         }

--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -123,6 +123,19 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
     private fun buildMsg(msg: LlmMessage) = JsonObject().apply {
         addProperty("role", when(msg.role){LlmMessage.Role.SYSTEM->"system";LlmMessage.Role.USER->"user";LlmMessage.Role.ASSISTANT->"assistant";LlmMessage.Role.TOOL->"tool"})
         if (msg.toolCalls.isNotEmpty()) { add("tool_calls", JsonArray().apply { msg.toolCalls.forEach { tc -> add(JsonObject().apply { addProperty("id",tc.id);addProperty("type","function");add("function",JsonObject().apply{addProperty("name",tc.name);addProperty("arguments",tc.argumentsJson)}) }) } }); if(msg.content.isNotEmpty()) addProperty("content",msg.content) }
+        else if (msg.images.isNotEmpty()) {
+            add("content", JsonArray().apply {
+                if (msg.content.isNotEmpty()) add(JsonObject().apply { addProperty("type", "text"); addProperty("text", msg.content) })
+                msg.images.forEach { img ->
+                    add(JsonObject().apply {
+                        addProperty("type", "image_url")
+                        add("image_url", JsonObject().apply {
+                            addProperty("url", "data:${img.mimeType};base64,${base64(img.bytes)}")
+                        })
+                    })
+                }
+            })
+        }
         else addProperty("content", msg.content)
 
         if (msg.role == LlmMessage.Role.ASSISTANT && !msg.reasoningContent.isNullOrEmpty()) {
@@ -130,5 +143,6 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
         }
         msg.toolCallId?.let { addProperty("tool_call_id", it) }; msg.name?.let { addProperty("name", it) }
     }
+    private fun base64(bytes: ByteArray) = android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP)
     private fun buildTool(t: ToolDeclaration) = JsonObject().apply { addProperty("type","function"); add("function", JsonObject().apply { addProperty("name",t.name);addProperty("description",t.description);add("parameters",t.parametersSchema) }) }
 }


### PR DESCRIPTION
Fixes #371

## Summary

Step 2 of the Agent upgrade. Adds real **image input** to the Agent's LLM layer so a vision-capable model can see images — the foundation for composer image uploads (follow-up), and it fixes tool-generated images never reaching the model.

## What changed

- `LlmMessage` gains `images: List<ImageAttachment>` (reuses the existing `tool.ImageAttachment`; `llm -> tool` is a new one-directional dependency, verified acyclic).
- Per-provider image serialization:
  - **OpenAI-compatible** (`buildMsg`): `content` → parts array with `{type:image_url, image_url:{url:data:<mime>;base64,..}}`
  - **Gemini** (`buildParts`): adds `{inlineData:{mimeType,data}}`
  - **Anthropic** (`buildMsg`): USER / `tool_result` content → block array with `{type:image, source:{type:base64,media_type,data}}`
  - **Ollama**: adds a sibling `images` array of raw base64 strings
- `AgentEngine`: `ToolResult.images` now fed back into TOOL messages (previously discarded, so `GenerateImage` output never reached the model).
- **Capability gate**: images are stripped from the request when the text model lacks `ModelCapability.MULTIMODAL`, so attachments never break a text-only chat request.

## Notes

- base64 via `android.util.Base64.NO_WRAP`.
- User-uploaded image injection into the USER message lands with the composer attachment work (next step); this PR delivers the engine/provider foundation + tool-image feedback.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual (with a multimodal model): generated image is seen by the model; text-only model gets images stripped