### PR TITLE
feat(agent): composer attachments — upload images, files, and folders

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
@@ -40,12 +40,27 @@ data class AgentMessage(
 
     val attachments: List<String> = emptyList(),
 
+    val userAttachments: List<UserAttachment> = emptyList(),
+
     val mentionedFiles: List<String> = emptyList(),
     val isError: Boolean = false,
     val timestamp: Long = System.currentTimeMillis()
 ) {
     enum class Role { USER, ASSISTANT, SYSTEM }
 }
+
+/**
+ * A file the user attached to a message from the composer. The bytes live in the
+ * session sandbox at [path] (session-relative); only metadata is persisted here so
+ * the sessions blob stays small. [isImage] attachments are also sent to the model
+ * as vision input when it is multimodal.
+ */
+data class UserAttachment(
+    val path: String,
+    val displayName: String,
+    val mimeType: String,
+    val isImage: Boolean
+)
 
 data class RecordedToolCall(
     val toolCallId: String,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1434,6 +1434,10 @@ object Strings {
     val agentDrawerSearchHint: String get() = StringsB.agentDrawerSearchHint
     val agentComposerHintIdle: String get() = StringsB.agentComposerHintIdle
     val agentComposerHintWorking: String get() = StringsB.agentComposerHintWorking
+    val agentAttachTooltip: String get() = StringsB.agentAttachTooltip
+    val agentAttachImage: String get() = StringsB.agentAttachImage
+    val agentAttachFile: String get() = StringsB.agentAttachFile
+    val agentAttachFolder: String get() = StringsB.agentAttachFolder
     val agentSaveAsApp: String get() = StringsB.agentSaveAsApp
     val agentSaveAsAppTitle: String get() = StringsB.agentSaveAsAppTitle
     val agentSaveAsAppDescription: String get() = StringsB.agentSaveAsAppDescription
@@ -22838,6 +22842,54 @@ object StringsB {
         AppLanguage.RUSSIAN -> "ИИ работает…"
         AppLanguage.JAPANESE -> "AI処理中…"
         AppLanguage.KOREAN -> "AI 작동 중…"
+    }
+    val agentAttachTooltip: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "添加附件"
+        AppLanguage.ENGLISH -> "Attach"
+        AppLanguage.ARABIC -> "إرفاق"
+        AppLanguage.PORTUGUESE -> "Anexar"
+        AppLanguage.SPANISH -> "Adjuntar"
+        AppLanguage.FRENCH -> "Joindre"
+        AppLanguage.GERMAN -> "Anhängen"
+        AppLanguage.RUSSIAN -> "Прикрепить"
+        AppLanguage.JAPANESE -> "添付"
+        AppLanguage.KOREAN -> "첨부"
+    }
+    val agentAttachImage: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "图片"
+        AppLanguage.ENGLISH -> "Image"
+        AppLanguage.ARABIC -> "صورة"
+        AppLanguage.PORTUGUESE -> "Imagem"
+        AppLanguage.SPANISH -> "Imagen"
+        AppLanguage.FRENCH -> "Image"
+        AppLanguage.GERMAN -> "Bild"
+        AppLanguage.RUSSIAN -> "Изображение"
+        AppLanguage.JAPANESE -> "画像"
+        AppLanguage.KOREAN -> "이미지"
+    }
+    val agentAttachFile: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "文件"
+        AppLanguage.ENGLISH -> "File"
+        AppLanguage.ARABIC -> "ملف"
+        AppLanguage.PORTUGUESE -> "Arquivo"
+        AppLanguage.SPANISH -> "Archivo"
+        AppLanguage.FRENCH -> "Fichier"
+        AppLanguage.GERMAN -> "Datei"
+        AppLanguage.RUSSIAN -> "Файл"
+        AppLanguage.JAPANESE -> "ファイル"
+        AppLanguage.KOREAN -> "파일"
+    }
+    val agentAttachFolder: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "文件夹"
+        AppLanguage.ENGLISH -> "Folder"
+        AppLanguage.ARABIC -> "مجلد"
+        AppLanguage.PORTUGUESE -> "Pasta"
+        AppLanguage.SPANISH -> "Carpeta"
+        AppLanguage.FRENCH -> "Dossier"
+        AppLanguage.GERMAN -> "Ordner"
+        AppLanguage.RUSSIAN -> "Папка"
+        AppLanguage.JAPANESE -> "フォルダー"
+        AppLanguage.KOREAN -> "폴더"
     }
     val agentSaveAsApp: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "保存为应用"

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -2,6 +2,8 @@ package com.webtoapp.ui.agent
 
 import android.app.Application
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -117,6 +119,16 @@ fun AgentScreen(
     val snackbar = remember { SnackbarHostState() }
 
     var drawerMounted by remember { mutableStateOf(false) }
+
+    val imagePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetMultipleContents()
+    ) { uris -> vm.attachUris(uris) }
+    val filePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetMultipleContents()
+    ) { uris -> vm.attachUris(uris) }
+    val folderPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri -> uri?.let { vm.attachFolder(it) } }
 
     val leaveScreen: () -> Unit = {
         scope.launch {
@@ -315,6 +327,11 @@ fun AgentScreen(
                     onToggleAutoApprove = { vm.setAutoApprove(!state.autoApprove) },
 
                     onTriggerSlash = { vm.setComposerText("/") },
+
+                    onAttachImage = { imagePicker.launch("image/*") },
+                    onAttachFile = { filePicker.launch("*/*") },
+                    onAttachFolder = { folderPicker.launch(null) },
+                    onRemoveAttachment = vm::removePendingAttachment,
 
                     onOpenModelPicker = vm::openModelPicker,
                     onCompactContext = vm::compactNow

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -5,6 +5,7 @@ import com.webtoapp.core.agent.permission.ChoiceRequest
 import com.webtoapp.core.agent.permission.PermissionRequest
 import com.webtoapp.core.agent.session.AgentSession
 import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.agent.todo.TodoManager
 
 data class AgentUiState(
@@ -37,6 +38,8 @@ data class AgentUiState(
     val composerText: String = "",
     val slashOpen: Boolean = false,
     val slashCommands: List<SlashCommand> = emptyList(),
+
+    val pendingAttachments: List<UserAttachment> = emptyList(),
 
     val modelPickerOpen: Boolean = false,
     val modelProviderGroups: List<ProviderGroup> = emptyList(),

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -5,6 +5,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
 import android.os.IBinder
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
@@ -25,12 +27,14 @@ import com.webtoapp.core.agent.session.AgentMessage
 import com.webtoapp.core.agent.session.AgentSession
 import com.webtoapp.core.agent.session.RecordedToolCall
 import com.webtoapp.core.agent.session.SessionStore
+import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.agent.todo.TodoManager
 import com.webtoapp.core.agent.tool.ToolContext
 import com.webtoapp.core.agent.tool.ToolRegistryFactory
 import com.webtoapp.core.agent.prompt.SystemPromptBuilder
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.AiFeature
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,6 +45,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 class AgentViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -716,7 +721,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     fun send() {
         val current = _ui.value
         if (current.phase != AgentUiState.Phase.Idle) return
-        val rawMessage = current.composerText.trim().ifEmpty { return }
+        val rawMessage = current.composerText.trim()
+        if (rawMessage.isEmpty() && current.pendingAttachments.isEmpty()) return
 
         if (rawMessage == "/model" || rawMessage.startsWith("/model ")) {
             val arg = rawMessage.removePrefix("/model").trim()
@@ -727,6 +733,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
 
         viewModelScope.launch {
             val session = ensureActiveSession() ?: return@launch
+            val pending = current.pendingAttachments
             val mentionedPaths = extractMentionPaths(rawMessage, session.id)
 
             val editingId = _ui.value.editingMessageId
@@ -737,7 +744,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
             val userMsg = AgentMessage(
                 role = AgentMessage.Role.USER,
                 content = rawMessage,
-                mentionedFiles = mentionedPaths
+                mentionedFiles = mentionedPaths,
+                userAttachments = pending
             )
             val updated = sessionStore.appendMessage(baseSession.id, userMsg) ?: return@launch
 
@@ -747,7 +755,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                     editingMessageId = null,
                     mentionPickerOpen = false,
                     mentionQuery = "",
-                    mentionMatches = emptyList()
+                    mentionMatches = emptyList(),
+                    pendingAttachments = emptyList()
                 )
             }
 
@@ -767,6 +776,122 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         }
         return seen.toList()
     }
+
+    fun attachUris(uris: List<Uri>) {
+        if (uris.isEmpty()) return
+        viewModelScope.launch {
+            val session = ensureActiveSession() ?: return@launch
+            val added = withContext(Dispatchers.IO) {
+                uris.mapNotNull { uri -> importUriToUploads(session.id, uri) }
+            }
+            if (added.isNotEmpty()) {
+                _ui.update { it.copy(pendingAttachments = it.pendingAttachments + added) }
+                refreshFiles(session.id)
+            }
+        }
+    }
+
+    fun attachFolder(treeUri: Uri) {
+        viewModelScope.launch {
+            val session = ensureActiveSession() ?: return@launch
+            val added = withContext(Dispatchers.IO) { importFolderToUploads(session.id, treeUri) }
+            if (added.isNotEmpty()) {
+                _ui.update { it.copy(pendingAttachments = it.pendingAttachments + added) }
+                refreshFiles(session.id)
+            }
+        }
+    }
+
+    fun removePendingAttachment(path: String) {
+        val sid = _ui.value.currentSession?.id
+        if (sid != null) runCatching { files.delete(sid, path) }
+        _ui.update { it.copy(pendingAttachments = it.pendingAttachments.filter { it.path != path }) }
+        if (sid != null) refreshFiles(sid)
+    }
+
+    private fun importUriToUploads(sessionId: String, uri: Uri): UserAttachment? {
+        val name = queryDisplayName(uri) ?: "upload_${System.currentTimeMillis()}"
+        val mime = ctx.contentResolver.getType(uri) ?: mimeFromName(name)
+        val bytes = ctx.contentResolver.openInputStream(uri)?.use { it.readBytes() } ?: return null
+        return writeUpload(sessionId, "uploads", name, bytes, mime)
+    }
+
+    private fun importFolderToUploads(sessionId: String, treeUri: Uri): List<UserAttachment> {
+        val tree = DocumentFile.fromTreeUri(ctx, treeUri) ?: return emptyList()
+        val folderName = tree.name ?: "folder"
+        val result = mutableListOf<UserAttachment>()
+        fun walk(dir: DocumentFile, relBase: String) {
+            dir.listFiles().forEach { child ->
+                val childName = child.name ?: return@forEach
+                if (child.isDirectory) {
+                    walk(child, "$relBase$childName/")
+                } else {
+                    val mime = child.type ?: mimeFromName(childName)
+                    val bytes = ctx.contentResolver.openInputStream(child.uri)
+                        ?.use { it.readBytes() } ?: return@forEach
+                    writeUpload(sessionId, "uploads/$relBase", childName, bytes, mime)?.let {
+                        result += it
+                    }
+                }
+            }
+        }
+        walk(tree, "$folderName/")
+        return result
+    }
+
+    private fun writeUpload(
+        sessionId: String,
+        dir: String,
+        name: String,
+        bytes: ByteArray,
+        mime: String
+    ): UserAttachment? {
+        val safeName = name.replace('/', '_')
+        val base = safeName.substringBeforeLast('.', safeName)
+        val ext = safeName.substringAfterLast('.', "").let { if (it.isEmpty() || it == safeName) "" else ".$it" }
+        var candidate = "$dir/$safeName"
+        var i = 1
+        while (files.exists(sessionId, candidate)) {
+            candidate = "$dir/$base-$i$ext"
+            i++
+        }
+        files.writeBytes(sessionId, candidate, bytes) ?: return null
+        return UserAttachment(
+            path = candidate,
+            displayName = candidate.removePrefix("uploads/"),
+            mimeType = mime,
+            isImage = mime.startsWith("image/")
+        )
+    }
+
+    private fun queryDisplayName(uri: Uri): String? {
+        var name: String? = null
+        runCatching {
+            ctx.contentResolver.query(uri, null, null, null, null)?.use { c ->
+                val idx = c.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                if (idx >= 0 && c.moveToFirst()) name = c.getString(idx)
+            }
+        }
+        return name ?: uri.lastPathSegment?.substringAfterLast('/')
+    }
+
+    private fun mimeFromName(name: String): String =
+        when (name.substringAfterLast('.', "").lowercase()) {
+            "png" -> "image/png"
+            "jpg", "jpeg" -> "image/jpeg"
+            "webp" -> "image/webp"
+            "gif" -> "image/gif"
+            "json" -> "application/json"
+            "js" -> "text/javascript"
+            "css" -> "text/css"
+            "html", "htm" -> "text/html"
+            "txt", "md", "log" -> "text/plain"
+            "xml" -> "text/xml"
+            else -> "application/octet-stream"
+        }
+
+    private fun isTextUpload(mime: String): Boolean =
+        mime.startsWith("text/") || mime == "application/json" || mime == "application/xml"
 
     fun deleteFromMessage(messageId: String) {
         val sid = _ui.value.currentSession?.id ?: return
@@ -913,7 +1038,11 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
             when (m.role) {
                 AgentMessage.Role.USER -> {
                     val out = mutableListOf<LlmMessage>()
-                    out += LlmMessage(LlmMessage.Role.USER, m.content)
+                    val images = m.userAttachments.filter { it.isImage }.mapNotNull { att ->
+                        val bytes = files.readBytes(workingSession.id, att.path) ?: return@mapNotNull null
+                        com.webtoapp.core.agent.tool.ImageAttachment(bytes, att.mimeType, att.path)
+                    }
+                    out += LlmMessage(LlmMessage.Role.USER, m.content, images = images)
                     out += synthesiseReadCallsFor(m, workingSession.id)
                     out
                 }
@@ -1465,14 +1594,18 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private fun synthesiseReadCallsFor(m: AgentMessage, sessionId: String): List<LlmMessage> {
-        if (m.mentionedFiles.isEmpty()) return emptyList()
+        val textUploads = m.userAttachments
+            .filter { !it.isImage && isTextUpload(it.mimeType) }
+            .map { it.path }
+        val pathsToRead = (m.mentionedFiles + textUploads).distinct()
+        if (pathsToRead.isEmpty()) return emptyList()
 
         val out = mutableListOf<LlmMessage>()
         val toolCalls = mutableListOf<com.webtoapp.core.agent.llm.LlmToolCall>()
         val toolResults = mutableListOf<LlmMessage>()
         var budget = MENTION_TOTAL_CHAR_BUDGET
 
-        m.mentionedFiles.forEachIndexed { idx, path ->
+        pathsToRead.forEachIndexed { idx, path ->
             val callId = "mention-${m.id}-$idx"
             val argsJson = """{"path":"${path.replace("\"", "\\\"")}"}"""
             toolCalls += com.webtoapp.core.agent.llm.LlmToolCall(callId, "Read", argsJson)

--- a/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
@@ -1,5 +1,7 @@
 package com.webtoapp.ui.agent.components
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,18 +15,26 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Send
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.DataUsage
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.InsertDriveFile
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material.icons.outlined.SmartToy
 import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -32,11 +42,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.agent.AgentUiState
 import com.webtoapp.ui.agent.SlashCommand
@@ -66,6 +79,11 @@ fun Composer(
 
     onTriggerSlash: () -> Unit,
 
+    onAttachImage: () -> Unit,
+    onAttachFile: () -> Unit,
+    onAttachFolder: () -> Unit,
+    onRemoveAttachment: (String) -> Unit,
+
     onOpenModelPicker: () -> Unit = {},
     onCompactContext: () -> Unit = {}
 ) {
@@ -88,6 +106,12 @@ fun Composer(
                 onDismiss = onDismissMention
             )
         }
+        if (state.pendingAttachments.isNotEmpty()) {
+            PendingAttachmentsRow(
+                attachments = state.pendingAttachments,
+                onRemove = onRemoveAttachment
+            )
+        }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -97,6 +121,12 @@ fun Composer(
                 ),
             verticalAlignment = Alignment.Bottom
         ) {
+            AttachButton(
+                onAttachImage = onAttachImage,
+                onAttachFile = onAttachFile,
+                onAttachFolder = onAttachFolder
+            )
+            Spacer(Modifier.width(WtaSpacing.Small))
             WtaTextField(
                 value = state.composerText,
                 onValueChange = onTextChange,
@@ -110,7 +140,8 @@ fun Composer(
             Spacer(Modifier.width(WtaSpacing.Small))
             SendButton(
                 working = state.isWorking,
-                enabled = state.canSend && state.composerText.isNotBlank(),
+                enabled = state.canSend &&
+                    (state.composerText.isNotBlank() || state.pendingAttachments.isNotEmpty()),
                 onSend = onSend,
                 onCancel = onCancel
             )
@@ -127,6 +158,91 @@ fun Composer(
             compacting = state.compacting,
             onCompactContext = onCompactContext
         )
+    }
+}
+
+@Composable
+private fun AttachButton(
+    onAttachImage: () -> Unit,
+    onAttachFile: () -> Unit,
+    onAttachFolder: () -> Unit
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Box {
+        WtaIconButton(
+            onClick = { menuOpen = true },
+            icon = Icons.Outlined.Add,
+            contentDescription = Strings.agentAttachTooltip
+        )
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text(Strings.agentAttachImage) },
+                leadingIcon = { Icon(Icons.Outlined.Image, contentDescription = null) },
+                onClick = { menuOpen = false; onAttachImage() }
+            )
+            DropdownMenuItem(
+                text = { Text(Strings.agentAttachFile) },
+                leadingIcon = { Icon(Icons.Outlined.InsertDriveFile, contentDescription = null) },
+                onClick = { menuOpen = false; onAttachFile() }
+            )
+            DropdownMenuItem(
+                text = { Text(Strings.agentAttachFolder) },
+                leadingIcon = { Icon(Icons.Outlined.Folder, contentDescription = null) },
+                onClick = { menuOpen = false; onAttachFolder() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun PendingAttachmentsRow(
+    attachments: List<UserAttachment>,
+    onRemove: (String) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = WtaSpacing.ScreenHorizontal, vertical = WtaSpacing.Tiny),
+        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+    ) {
+        attachments.forEach { att ->
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.secondaryContainer
+            ) {
+                Row(
+                    modifier = Modifier.padding(
+                        horizontal = WtaSpacing.Small,
+                        vertical = WtaSpacing.Tiny
+                    ),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = if (att.isImage) Icons.Outlined.Image else Icons.Outlined.AttachFile,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(WtaSize.IconSmall)
+                    )
+                    Spacer(Modifier.width(WtaSpacing.Tiny))
+                    Text(
+                        text = att.displayName,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        maxLines = 1
+                    )
+                    Spacer(Modifier.width(WtaSpacing.Tiny))
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = Strings.btnDelete,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier
+                            .size(WtaSize.IconSmall)
+                            .clickable { onRemove(att.path) }
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -26,11 +26,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.HourglassTop
@@ -64,6 +66,7 @@ import androidx.compose.ui.unit.sp
 import com.google.gson.JsonParser
 import com.webtoapp.core.agent.session.AgentMessage
 import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.design.WtaAlpha
 import com.webtoapp.ui.design.WtaCard
@@ -124,12 +127,18 @@ fun MessageBubble(
             modifier = Modifier.widthIn(max = 560.dp)
         ) {
             if (isUser) {
-                SelectionContainer {
-                    Text(
-                        text = message.content.ifBlank { Strings.agentNoOutput },
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = onContainer
-                    )
+                if (message.userAttachments.isNotEmpty()) {
+                    UserAttachmentList(message.userAttachments)
+                    if (message.content.isNotBlank()) Spacer(Modifier.height(WtaSpacing.Small))
+                }
+                if (message.content.isNotBlank() || message.userAttachments.isEmpty()) {
+                    SelectionContainer {
+                        Text(
+                            text = message.content.ifBlank { Strings.agentNoOutput },
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = onContainer
+                        )
+                    }
                 }
                 if (message.mentionedFiles.isNotEmpty()) {
                     Spacer(Modifier.height(WtaSpacing.Small))
@@ -980,6 +989,40 @@ private fun AttachmentList(paths: List<String>) {
                 containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                 contentColor = MaterialTheme.colorScheme.onTertiaryContainer
             )
+        }
+    }
+}
+
+@Composable
+private fun UserAttachmentList(attachments: List<UserAttachment>) {
+    Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+        attachments.take(8).forEach { att ->
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.secondaryContainer
+            ) {
+                Row(
+                    modifier = Modifier.padding(
+                        horizontal = WtaSpacing.Small,
+                        vertical = WtaSpacing.Tiny
+                    ),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = if (att.isImage) Icons.Outlined.Image else Icons.Outlined.AttachFile,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(WtaSize.IconSmall)
+                    )
+                    Spacer(Modifier.width(WtaSpacing.Tiny))
+                    Text(
+                        text = att.displayName,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        maxLines = 1
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #373

## Summary

Step 3 of the Agent upgrade. The composer can now attach **images, files, and whole folders**. Images go to the model as vision input (building on #372); files/folders land in the session sandbox for the agent's file tools, and attached text files are auto-injected into context.

## What changed

- **`SessionModels`**: new `UserAttachment` (path / displayName / mimeType / isImage) + `AgentMessage.userAttachments`. Only path-based metadata is persisted — bytes stay in the sandbox so the sessions blob stays small; Gson-safe for existing data.
- **`AgentViewModel`**:
  - `attachUris` / `attachFolder` copy picked content into `uploads/` (folders recursively via `DocumentFile`, with filename de-duplication) and stage `pendingAttachments`.
  - `send()` records pending attachments on the user message, clears them, and now allows attachment-only sends (empty text).
  - `dispatchTurn` reads attached image bytes into `LlmMessage.images` (vision); `synthesiseReadCallsFor` auto-reads attached **text** files into context.
- **`AgentUiState`**: `pendingAttachments`.
- **`Composer`**: an attach (+) menu (Image / File / Folder) and a pending-attachments row with per-item remove; send enabled when there are attachments even with empty text.
- **`AgentScreen`**: `GetMultipleContents` pickers (images `image/*`, files `*/*`) + `OpenDocumentTree` for folders, wired to the ViewModel.
- **`MessageBubbles`**: user messages render attachments as image/file chips.
- **`Strings`**: attach-menu labels in all 10 languages.

## Notes

- Image bytes are re-read from the sandbox per turn when building history; non-multimodal models have images stripped at the engine (from #372).
- Pending attachments live in UI state; the sandbox files persist for the session.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: attach an image (vision model sees it), a text file (auto-read), and a folder (files readable from sandbox); attachment-only send works