### PR TITLE
feat(agent): app tools — let the agent create and edit any app type

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -103,6 +103,7 @@ class AgentService : Service() {
                     imageApiKey = request.toolContext.imageApiKey,
                     prompter = permissionPrompter,
                     todos = request.toolContext.todos,
+                    appRepository = request.toolContext.appRepository,
                     readFiles = request.toolContext.readFiles,
                     activePlanFile = request.toolContext.activePlanFile
                 )

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolContext.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolContext.kt
@@ -6,6 +6,7 @@ import com.webtoapp.core.agent.permission.PermissionPrompter
 import com.webtoapp.core.agent.todo.TodoManager
 import com.webtoapp.data.model.ApiKeyConfig
 import com.webtoapp.data.model.SavedModel
+import com.webtoapp.data.repository.WebAppRepository
 
 data class ToolContext(
     val androidContext: Context,
@@ -21,6 +22,8 @@ data class ToolContext(
     val prompter: PermissionPrompter,
 
     val todos: TodoManager,
+
+    val appRepository: WebAppRepository,
 
     val readFiles: MutableSet<String> = mutableSetOf(),
 

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
@@ -3,16 +3,20 @@ package com.webtoapp.core.agent.tool
 import com.webtoapp.core.agent.imagery.ImageGeneratorRegistry
 import com.webtoapp.core.agent.plan.PlanManager
 import com.webtoapp.core.agent.tool.builtin.AskUserTool
+import com.webtoapp.core.agent.tool.builtin.CreateAppTool
 import com.webtoapp.core.agent.tool.builtin.DeleteFileTool
 import com.webtoapp.core.agent.tool.builtin.EditFileTool
 import com.webtoapp.core.agent.tool.builtin.EnterPlanModeTool
 import com.webtoapp.core.agent.tool.builtin.ExitPlanModeTool
+import com.webtoapp.core.agent.tool.builtin.GetAppTool
 import com.webtoapp.core.agent.tool.builtin.GlobTool
 import com.webtoapp.core.agent.tool.builtin.GrepTool
+import com.webtoapp.core.agent.tool.builtin.ListAppsTool
 import com.webtoapp.core.agent.tool.builtin.ListFilesTool
 import com.webtoapp.core.agent.tool.builtin.ReadFileTool
 import com.webtoapp.core.agent.tool.builtin.TodoUpdateTool
 import com.webtoapp.core.agent.tool.builtin.TodoWriteTool
+import com.webtoapp.core.agent.tool.builtin.UpdateAppTool
 import com.webtoapp.core.agent.tool.builtin.WriteFileTool
 import com.webtoapp.core.agent.tool.builtin.imagery.GenerateImageTool
 import com.webtoapp.core.agent.tool.builtin.imagery.ListImagesTool
@@ -42,6 +46,10 @@ class ToolRegistryFactory(
         AskUserTool(),
         TodoWriteTool(),
         TodoUpdateTool(),
+        ListAppsTool(),
+        GetAppTool(),
+        CreateAppTool(),
+        UpdateAppTool(),
     )
 
     private fun planTools(): List<Tool> = listOf(

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/CreateAppTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/CreateAppTool.kt
@@ -1,0 +1,206 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.webtoapp.core.agent.export.DetectedArtifact
+import com.webtoapp.core.agent.export.SaveSessionAsAppUseCase
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.core.port.PortManager
+import com.webtoapp.core.wordpress.WordPressManager
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.ManifestUtils
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.WordPressConfig
+import com.webtoapp.util.IconStorage
+import java.util.UUID
+
+class CreateAppTool : Tool {
+    override val name = "CreateApp"
+    override val description = """
+        Create a new app in WebToApp and add it to the app list.
+        - Config-only types (WEB, IMAGE, VIDEO, GALLERY, MULTI_WEB): pass `manifest` JSON with the
+          config, e.g. {"url":"https://example.com"} for WEB, or galleryConfig / multiWebConfig /
+          mediaConfig for the others. GALLERY/MULTI_WEB may instead pass `sourceDir` pointing to a
+          sandbox folder containing gallery.json / multi-web.json.
+        - Project types (HTML, FRONTEND, NODEJS_APP, PHP_APP, PYTHON_APP, GO_APP): first write the
+          project files into the session sandbox, then pass `sourceDir` (the sandbox-relative folder).
+        - WORDPRESS: created from bundled WordPress (dependencies must be installed); `manifest` may
+          carry siteTitle / adminUser / adminEmail.
+        Optionally pass `iconRef` (sandbox-relative path to an image) to set the app icon.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        enum("appType", AppType.entries.map { it.name }, "The type of app to create.", required = true)
+        string("name", "The app name.", required = true)
+        string("iconRef", "Sandbox-relative path to an image to use as the app icon.")
+        string("manifest", "Partial WebApp manifest JSON (config-only types and WORDPRESS).")
+        string("sourceDir", "Sandbox-relative folder containing the project files (project types).")
+    }
+
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("name")?.asString?.let { "Creating app \"$it\"" }
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val appType = args.get("appType")?.asString
+            ?.let { runCatching { AppType.valueOf(it.trim()) }.getOrNull() }
+            ?: return ToolResult.error("CreateApp: missing or invalid `appType`.")
+        val name = args.get("name")?.asString?.trim().orEmpty()
+        if (name.isEmpty()) return ToolResult.error("CreateApp: missing `name`.")
+        val iconRef = ctx.resolveSafePath(args.get("iconRef")?.asString)
+        val manifest = args.get("manifest")?.asString
+        val sourceDir = ctx.resolveSafePath(args.get("sourceDir")?.asString)
+
+        val iconPath = iconRef?.let { ref ->
+            ctx.fileManager.readBytes(ctx.sessionId, ref)?.let { bytes ->
+                IconStorage.saveIconFromBytes(ctx.androidContext, bytes)
+            }
+        }
+
+        return when {
+            appType == AppType.WORDPRESS -> createWordPress(ctx, name, iconPath, manifest)
+            appType in PROJECT_TYPES -> createFromSource(ctx, appType, name, iconPath, sourceDir)
+            appType == AppType.GALLERY || appType == AppType.MULTI_WEB ->
+                if (sourceDir != null) createFromSource(ctx, appType, name, iconPath, sourceDir)
+                else createFromManifest(ctx, appType, name, iconPath, manifest)
+            else -> createFromManifest(ctx, appType, name, iconPath, manifest)
+        }
+    }
+
+    private suspend fun createFromManifest(
+        ctx: ToolContext,
+        appType: AppType,
+        name: String,
+        iconPath: String?,
+        manifest: String?
+    ): ToolResult {
+        if (manifest.isNullOrBlank()) {
+            return ToolResult.error(
+                "CreateApp: $appType needs `manifest` JSON (e.g. {\"url\":\"https://example.com\"} for WEB)."
+            )
+        }
+        val base = ManifestUtils.fromManifestJson(manifest)
+            ?: return ToolResult.error("CreateApp: `manifest` is not valid JSON.")
+        val now = System.currentTimeMillis()
+        val app = base.copy(
+            id = 0,
+            appType = appType,
+            name = name,
+            iconPath = iconPath ?: base.iconPath,
+            createdAt = now,
+            updatedAt = now
+        )
+        val id = ctx.appRepository.createWebApp(app)
+        return ToolResult.ok("Created $appType app id=$id name=\"$name\".")
+    }
+
+    private suspend fun createFromSource(
+        ctx: ToolContext,
+        appType: AppType,
+        name: String,
+        iconPath: String?,
+        sourceDir: String?
+    ): ToolResult {
+        if (sourceDir == null) {
+            return ToolResult.error(
+                "CreateApp: $appType needs `sourceDir` — write the project files into the sandbox first, then pass that folder."
+            )
+        }
+        val fileConfig = appType == AppType.GALLERY || appType == AppType.MULTI_WEB
+        val kind = when (appType) {
+            AppType.HTML -> DetectedArtifact.Kind.Html
+            AppType.FRONTEND -> DetectedArtifact.Kind.FrontendReact
+            AppType.NODEJS_APP -> DetectedArtifact.Kind.NodeJs
+            AppType.PHP_APP -> DetectedArtifact.Kind.Php
+            AppType.PYTHON_APP -> DetectedArtifact.Kind.Python
+            AppType.GO_APP -> DetectedArtifact.Kind.Go
+            AppType.GALLERY -> DetectedArtifact.Kind.Gallery
+            AppType.MULTI_WEB -> DetectedArtifact.Kind.MultiWeb
+            else -> return ToolResult.error("CreateApp: $appType cannot be created from a source dir.")
+        }
+        val entryFile = when (appType) {
+            AppType.HTML, AppType.FRONTEND -> "index.html"
+            AppType.NODEJS_APP -> "index.js"
+            AppType.PHP_APP -> "index.php"
+            AppType.GALLERY -> "$sourceDir/gallery.json"
+            AppType.MULTI_WEB -> "$sourceDir/multi-web.json"
+            else -> ""
+        }
+        val artifact = DetectedArtifact(
+            id = UUID.randomUUID().toString(),
+            kind = kind,
+            displayName = name,
+            rootPath = if (fileConfig) "" else sourceDir,
+            entryFile = entryFile,
+            fileCount = 0,
+            totalSizeBytes = 0
+        )
+        val useCase = SaveSessionAsAppUseCase(ctx.androidContext, ctx.fileManager, ctx.appRepository)
+        return when (val result = useCase.save(ctx.sessionId, artifact, name, iconUri = null)) {
+            is SaveSessionAsAppUseCase.Result.Success -> {
+                if (iconPath != null) {
+                    ctx.appRepository.getWebApp(result.appId)?.let { app ->
+                        ctx.appRepository.updateWebApp(app.copy(iconPath = iconPath))
+                    }
+                }
+                ToolResult.ok("Created $appType app id=${result.appId} name=\"${result.name}\".")
+            }
+            is SaveSessionAsAppUseCase.Result.Failure ->
+                ToolResult.error("CreateApp failed: ${result.message}")
+        }
+    }
+
+    private suspend fun createWordPress(
+        ctx: ToolContext,
+        name: String,
+        iconPath: String?,
+        manifest: String?
+    ): ToolResult {
+        var siteTitle = name
+        var adminUser = "admin"
+        var adminEmail = ""
+        if (!manifest.isNullOrBlank()) {
+            runCatching { JsonParser.parseString(manifest).asJsonObject }.getOrNull()?.let { obj ->
+                obj.get("siteTitle")?.asString?.takeIf { it.isNotBlank() }?.let { siteTitle = it }
+                obj.get("adminUser")?.asString?.takeIf { it.isNotBlank() }?.let { adminUser = it }
+                obj.get("adminEmail")?.asString?.let { adminEmail = it }
+            }
+        }
+        val projectId = WordPressManager.createProject(ctx.androidContext, siteTitle, adminUser, adminEmail)
+            ?: return ToolResult.error(
+                "CreateApp: WordPress dependencies are not ready. Install them in the Linux Environment first."
+            )
+        val port = PortManager.allocateForPhp(projectId)
+        val app = WebApp(
+            name = name,
+            url = "",
+            iconPath = iconPath,
+            appType = AppType.WORDPRESS,
+            wordpressConfig = WordPressConfig(
+                projectId = projectId,
+                projectName = name,
+                siteTitle = siteTitle,
+                adminUser = adminUser,
+                adminEmail = adminEmail,
+                phpPort = port
+            ),
+            themeType = DEFAULT_THEME
+        )
+        val id = ctx.appRepository.createWebApp(app)
+        return ToolResult.ok("Created WORDPRESS app id=$id name=\"$name\" (project $projectId).")
+    }
+
+    companion object {
+        private const val DEFAULT_THEME = "AURORA"
+        private val PROJECT_TYPES = setOf(
+            AppType.HTML,
+            AppType.FRONTEND,
+            AppType.NODEJS_APP,
+            AppType.PHP_APP,
+            AppType.PYTHON_APP,
+            AppType.GO_APP
+        )
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/GetAppTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/GetAppTool.kt
@@ -1,0 +1,36 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.data.model.toManifestJson
+
+class GetAppTool : Tool {
+    override val name = "GetApp"
+    override val description = """
+        Get the full configuration of an app as JSON (its manifest), covering both core
+        (type-specific) config and common config. Use ListApps to find the id. The returned
+        JSON is the exact shape UpdateApp accepts as a patch.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        integer("appId", "The app id (from ListApps).", required = true)
+    }
+
+    override fun isReadOnly() = true
+
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("appId")?.asString?.let { "Reading app $it" }
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val appId = args.get("appId")?.asLong
+            ?: return ToolResult.error("GetApp: missing `appId`.")
+        val app = ctx.appRepository.getWebApp(appId)
+            ?: return ToolResult.error("GetApp: no app with id $appId.")
+        return ToolResult.ok(
+            "App id=${app.id} name=\"${app.name}\" type=${app.appType}\n\n${app.toManifestJson()}"
+        )
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/ListAppsTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/ListAppsTool.kt
@@ -1,0 +1,36 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import kotlinx.coroutines.flow.first
+
+class ListAppsTool : Tool {
+    override val name = "ListApps"
+    override val description = """
+        List the apps in the user's WebToApp app list. Returns each app's id, type, and name.
+        Use this to find an app's id before calling GetApp or UpdateApp.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        string("query", "Optional substring to filter apps by name.")
+    }
+
+    override fun isReadOnly() = true
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val query = args.get("query")?.asString?.trim().orEmpty()
+        val apps = ctx.appRepository.allWebApps.first()
+        val filtered = if (query.isEmpty()) apps
+            else apps.filter { it.name.contains(query, ignoreCase = true) }
+        if (filtered.isEmpty()) {
+            return ToolResult.ok("No apps found${if (query.isEmpty()) "" else " matching \"$query\""}.")
+        }
+        val lines = filtered.joinToString("\n") {
+            "- id=${it.id}  type=${it.appType}  name=\"${it.name}\""
+        }
+        return ToolResult.ok("${filtered.size} app(s):\n$lines")
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/UpdateAppTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/UpdateAppTool.kt
@@ -1,0 +1,53 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.data.converter.Converters
+import com.webtoapp.data.model.WebApp
+
+class UpdateAppTool : Tool {
+    override val name = "UpdateApp"
+    override val description = """
+        Edit an existing app's configuration. Provide a partial manifest JSON patch; only the
+        fields you include are changed and everything else is preserved. This edits both core
+        (type-specific) config and common config. Inspect the current shape with GetApp first.
+        The app's id and type are always preserved.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        integer("appId", "The app id (from ListApps).", required = true)
+        string("patch", "Partial WebApp manifest JSON containing only the fields to change.", required = true)
+    }
+
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("appId")?.asString?.let { "Updating app $it" }
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val appId = args.get("appId")?.asLong
+            ?: return ToolResult.error("UpdateApp: missing `appId`.")
+        val patchStr = args.get("patch")?.asString
+            ?: return ToolResult.error("UpdateApp: missing `patch`.")
+        val existing = ctx.appRepository.getWebApp(appId)
+            ?: return ToolResult.error("UpdateApp: no app with id $appId.")
+        val patch = runCatching { JsonParser.parseString(patchStr) }.getOrNull()
+            ?: return ToolResult.error("UpdateApp: `patch` is not valid JSON.")
+
+        val existingTree = Converters.gson.toJsonTree(existing)
+        val merged = Converters.mergeMissingDefaults(existingTree, patch)
+        val updated = runCatching { Converters.gson.fromJson(merged, WebApp::class.java) }.getOrNull()
+            ?: return ToolResult.error("UpdateApp: failed to apply the patch.")
+
+        val safe = updated.copy(
+            id = existing.id,
+            appType = existing.appType,
+            createdAt = existing.createdAt,
+            updatedAt = System.currentTimeMillis()
+        )
+        ctx.appRepository.updateWebApp(safe)
+        return ToolResult.ok("Updated app id=${safe.id} name=\"${safe.name}\" (type ${safe.appType}).")
+    }
+}

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -1091,6 +1091,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
             imageApiKey = imageKey,
             prompter = service!!.permissionPrompter,
             todos = todoManager,
+            appRepository = webAppRepository,
             readFiles = readFilesThisTurn,
             activePlanFile = planState.activePlanPath
         )


### PR DESCRIPTION
Fixes #375

## Summary

Step 4 of the Agent upgrade. Adds tools so the Agent can **directly create and edit apps** in the app list — all 12 app types, both core (type-specific) and common config. The `WebApp` manifest JSON is the interchange format, so one mechanism covers every config field.

## New tools

- **`ListApps`** (read-only): list apps (id / type / name), optional name filter.
- **`GetApp`** (read-only): an app's full manifest JSON (core + common config).
- **`CreateApp`**:
  - Config-only types (WEB/IMAGE/VIDEO/GALLERY/MULTI_WEB) → partial manifest via `ManifestUtils.fromManifestJson`.
  - Project types (HTML/FRONTEND/NODEJS/PHP/PYTHON/GO) → scaffold from a sandbox source dir, reusing `SaveSessionAsAppUseCase` (no change to that class).
  - WORDPRESS → `WordPressManager.createProject` + a `PortManager` php port.
  - Optional `iconRef` → `IconStorage.saveIconFromBytes`.
- **`UpdateApp`**: merge a partial manifest patch onto the existing app via `Converters.mergeMissingDefaults` (unspecified fields preserved; id/type kept) — edit any core/common field with no data loss.

## Wiring

- `ToolContext` gains `appRepository` (wired in `AgentViewModel` + `AgentService`).
- Registered in `ToolRegistryFactory`. `CreateApp`/`UpdateApp` are non-read-only → permission prompt.

## Notes

- `update_app` merges onto the **existing** app's manifest tree (not defaults), which is what prevents the field-wiping data-loss trap.
- Project-type creation reuses the battle-tested `SaveSessionAsAppUseCase` scaffolding (runtime `createProject` + port allocation), so behavior matches the existing "save as app" flow.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: agent lists/gets apps, creates a WEB app from a URL, edits an existing app's common config, and a partial patch leaves other fields intact