### PR TITLE
feat(agent): module tools — let the agent create and edit extension modules

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
@@ -4,19 +4,23 @@ import com.webtoapp.core.agent.imagery.ImageGeneratorRegistry
 import com.webtoapp.core.agent.plan.PlanManager
 import com.webtoapp.core.agent.tool.builtin.AskUserTool
 import com.webtoapp.core.agent.tool.builtin.CreateAppTool
+import com.webtoapp.core.agent.tool.builtin.CreateModuleTool
 import com.webtoapp.core.agent.tool.builtin.DeleteFileTool
 import com.webtoapp.core.agent.tool.builtin.EditFileTool
 import com.webtoapp.core.agent.tool.builtin.EnterPlanModeTool
 import com.webtoapp.core.agent.tool.builtin.ExitPlanModeTool
 import com.webtoapp.core.agent.tool.builtin.GetAppTool
+import com.webtoapp.core.agent.tool.builtin.GetModuleTool
 import com.webtoapp.core.agent.tool.builtin.GlobTool
 import com.webtoapp.core.agent.tool.builtin.GrepTool
 import com.webtoapp.core.agent.tool.builtin.ListAppsTool
 import com.webtoapp.core.agent.tool.builtin.ListFilesTool
+import com.webtoapp.core.agent.tool.builtin.ListModulesTool
 import com.webtoapp.core.agent.tool.builtin.ReadFileTool
 import com.webtoapp.core.agent.tool.builtin.TodoUpdateTool
 import com.webtoapp.core.agent.tool.builtin.TodoWriteTool
 import com.webtoapp.core.agent.tool.builtin.UpdateAppTool
+import com.webtoapp.core.agent.tool.builtin.UpdateModuleTool
 import com.webtoapp.core.agent.tool.builtin.WriteFileTool
 import com.webtoapp.core.agent.tool.builtin.imagery.GenerateImageTool
 import com.webtoapp.core.agent.tool.builtin.imagery.ListImagesTool
@@ -50,6 +54,10 @@ class ToolRegistryFactory(
         GetAppTool(),
         CreateAppTool(),
         UpdateAppTool(),
+        ListModulesTool(),
+        GetModuleTool(),
+        CreateModuleTool(),
+        UpdateModuleTool(),
     )
 
     private fun planTools(): List<Tool> = listOf(

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/CreateModuleTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/CreateModuleTool.kt
@@ -1,0 +1,44 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.core.extension.ExtensionManager
+import com.webtoapp.core.extension.ExtensionModule
+import com.webtoapp.util.GsonProvider
+import java.util.UUID
+
+class CreateModuleTool : Tool {
+    override val name = "CreateModule"
+    override val description = """
+        Create a new extension module. Provide a module definition JSON: at minimum
+        {"name":"...","code":"..."} (use cssCode instead of code for a pure CSS module).
+        Optional fields include description, runAt (DOCUMENT_START / DOCUMENT_END / DOCUMENT_IDLE),
+        urlMatches, permissions, configItems, and sourceType (default CUSTOM). Use GetModule to see
+        the full shape. A new id is assigned automatically.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        string("module", "Module definition JSON (ExtensionModule shape).", required = true)
+    }
+
+    override fun activityDescription(args: JsonObject): String? = "Creating module"
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val json = args.get("module")?.asString
+            ?: return ToolResult.error("CreateModule: missing `module`.")
+        val mgr = ExtensionManager.getInstance(ctx.androidContext)
+        val parsed = runCatching { GsonProvider.gson.fromJson(json, ExtensionModule::class.java) }.getOrNull()
+            ?: return ToolResult.error("CreateModule: `module` is not valid JSON.")
+        val module = parsed.sanitized().copy(id = UUID.randomUUID().toString())
+        if (module.name.isBlank()) {
+            return ToolResult.error("CreateModule: module `name` is required.")
+        }
+        return mgr.addModule(module).fold(
+            onSuccess = { ToolResult.ok("Created module id=${it.id} name=\"${it.name}\" (type ${it.sourceType}).") },
+            onFailure = { ToolResult.error("CreateModule failed: ${it.message}") }
+        )
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/GetModuleTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/GetModuleTool.kt
@@ -1,0 +1,39 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.core.extension.ExtensionManager
+import com.webtoapp.util.GsonProvider
+
+class GetModuleTool : Tool {
+    override val name = "GetModule"
+    override val description = """
+        Get a module's full definition as JSON, including its code/css. Use ListModules to find
+        the id. The returned JSON is the exact shape CreateModule and UpdateModule accept.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        string("moduleId", "The module id (from ListModules).", required = true)
+    }
+
+    override fun isReadOnly() = true
+
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("moduleId")?.asString?.let { "Reading module $it" }
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val moduleId = args.get("moduleId")?.asString
+            ?: return ToolResult.error("GetModule: missing `moduleId`.")
+        val mgr = ExtensionManager.getInstance(ctx.androidContext)
+        mgr.awaitLoaded()
+        val module = mgr.getModuleById(moduleId)?.let { mgr.ensureCodeLoaded(it) }
+            ?: return ToolResult.error("GetModule: no module with id $moduleId.")
+        return ToolResult.ok(
+            "Module id=${module.id} name=\"${module.name}\" type=${module.sourceType}\n\n" +
+                GsonProvider.gson.toJson(module)
+        )
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/ListModulesTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/ListModulesTool.kt
@@ -1,0 +1,38 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.core.extension.ExtensionManager
+
+class ListModulesTool : Tool {
+    override val name = "ListModules"
+    override val description = """
+        List the installed extension modules. Returns each module's id, sourceType, category,
+        enabled flag, and name. Use this to find a module id before GetModule or UpdateModule.
+    """.trimIndent()
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        string("query", "Optional substring to filter modules by name.")
+    }
+
+    override fun isReadOnly() = true
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val query = args.get("query")?.asString?.trim().orEmpty()
+        val mgr = ExtensionManager.getInstance(ctx.androidContext)
+        mgr.awaitLoaded()
+        val all = mgr.getAllModules()
+        val filtered = if (query.isEmpty()) all
+            else all.filter { it.name.contains(query, ignoreCase = true) }
+        if (filtered.isEmpty()) {
+            return ToolResult.ok("No modules found${if (query.isEmpty()) "" else " matching \"$query\""}.")
+        }
+        val lines = filtered.joinToString("\n") {
+            "- id=${it.id}  type=${it.sourceType}  category=${it.category}  enabled=${it.enabled}  name=\"${it.name}\""
+        }
+        return ToolResult.ok("${filtered.size} module(s):\n$lines")
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/UpdateModuleTool.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/UpdateModuleTool.kt
@@ -1,0 +1,55 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.core.extension.ExtensionManager
+import com.webtoapp.core.extension.ExtensionModule
+import com.webtoapp.data.converter.Converters
+import com.webtoapp.util.GsonProvider
+
+class UpdateModuleTool : Tool {
+    override val description = """
+        Edit an existing extension module. Provide a partial module JSON patch; only the fields
+        you include are changed and everything else is preserved. The module id is always kept.
+        Inspect the current shape with GetModule first.
+    """.trimIndent()
+
+    override val name = "UpdateModule"
+
+    override val parametersSchema: JsonElement = jsonSchema {
+        string("moduleId", "The module id (from ListModules).", required = true)
+        string("patch", "Partial module JSON containing only the fields to change.", required = true)
+    }
+
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("moduleId")?.asString?.let { "Updating module $it" }
+
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val moduleId = args.get("moduleId")?.asString
+            ?: return ToolResult.error("UpdateModule: missing `moduleId`.")
+        val patchStr = args.get("patch")?.asString
+            ?: return ToolResult.error("UpdateModule: missing `patch`.")
+        val mgr = ExtensionManager.getInstance(ctx.androidContext)
+        mgr.awaitLoaded()
+        val existing = mgr.getModuleById(moduleId)?.let { mgr.ensureCodeLoaded(it) }
+            ?: return ToolResult.error("UpdateModule: no module with id $moduleId.")
+        val patch = runCatching { JsonParser.parseString(patchStr) }.getOrNull()
+            ?: return ToolResult.error("UpdateModule: `patch` is not valid JSON.")
+
+        val existingTree = GsonProvider.gson.toJsonTree(existing)
+        val merged = Converters.mergeMissingDefaults(existingTree, patch)
+        val updated = runCatching { GsonProvider.gson.fromJson(merged, ExtensionModule::class.java) }
+            .getOrNull()?.sanitized()
+            ?: return ToolResult.error("UpdateModule: failed to apply the patch.")
+
+        val safe = updated.copy(id = existing.id)
+        return mgr.updateModule(safe).fold(
+            onSuccess = { ToolResult.ok("Updated module id=${it.id} name=\"${it.name}\".") },
+            onFailure = { ToolResult.error("UpdateModule failed: ${it.message}") }
+        )
+    }
+}


### PR DESCRIPTION
Fixes #377

## Summary

Step 5 of the Agent upgrade. Mirrors the app tools (#376) for the second artifact domain — **extension modules** — so the Agent can list, read, create, and edit modules.

## New tools

- **`ListModules`** (read-only): list modules (id / sourceType / category / enabled / name), optional name filter.
- **`GetModule`** (read-only): a module's full definition JSON, code/css reattached via `ensureCodeLoaded`.
- **`CreateModule`**: parse a module definition JSON (`ExtensionModule` shape), sanitize, assign a fresh id, `addModule` (validates name + code/css).
- **`UpdateModule`**: merge a partial JSON patch onto the existing module via `Converters.mergeMissingDefaults` (other fields preserved, id kept), `updateModule`.

## Notes

- Modules accessed via `ExtensionManager.getInstance(context)`.
- `CreateModule`/`UpdateModule` are non-read-only → permission prompt.
- `update_module` merges onto the **existing** module (not defaults), so unspecified fields are preserved.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: agent lists/gets modules, creates a JS module from JSON, patches an existing module leaving other fields intact