### PR TITLE
feat(agent): context picker — select apps and modules as agent context

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/prompt/SystemPromptBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/prompt/SystemPromptBuilder.kt
@@ -18,7 +18,9 @@ object SystemPromptBuilder {
         val tools: List<Tool>,
         val projectFiles: List<ProjectFilesSection.FileSummary>,
 
-        val planMode: PlanMode? = null
+        val planMode: PlanMode? = null,
+
+        val selectedContext: String = ""
     )
 
     data class PlanMode(
@@ -33,6 +35,7 @@ object SystemPromptBuilder {
             add(BehaviorSection.build(lang))
             add(ToolUsageSection.build(lang, input.tools))
             add(EnvironmentSection.build(lang, input.modelName, input.sessionDir))
+            if (input.selectedContext.isNotBlank()) add(input.selectedContext)
             add(ProjectFilesSection.build(lang, input.projectFiles))
             input.planMode?.let { add(PlanModeSection.build(lang, it.planFilePath, it.planExists)) }
         }

--- a/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
@@ -24,7 +24,10 @@ data class SessionConfig(
     val temperature: Float = 0.7f,
     val maxTurns: Int = 24,
 
-    val customRules: List<String> = emptyList()
+    val customRules: List<String> = emptyList(),
+
+    val contextAppIds: List<Long> = emptyList(),
+    val contextModuleIds: List<String> = emptyList()
 )
 
 data class AgentMessage(

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1438,6 +1438,12 @@ object Strings {
     val agentAttachImage: String get() = StringsB.agentAttachImage
     val agentAttachFile: String get() = StringsB.agentAttachFile
     val agentAttachFolder: String get() = StringsB.agentAttachFolder
+    val agentContextChipLabel: String get() = StringsB.agentContextChipLabel
+    val agentContextPickerTitle: String get() = StringsB.agentContextPickerTitle
+    val agentContextAppsHeader: String get() = StringsB.agentContextAppsHeader
+    val agentContextModulesHeader: String get() = StringsB.agentContextModulesHeader
+    val agentContextEmpty: String get() = StringsB.agentContextEmpty
+    val agentContextPickerDone: String get() = StringsB.agentContextPickerDone
     val agentSaveAsApp: String get() = StringsB.agentSaveAsApp
     val agentSaveAsAppTitle: String get() = StringsB.agentSaveAsAppTitle
     val agentSaveAsAppDescription: String get() = StringsB.agentSaveAsAppDescription
@@ -22890,6 +22896,78 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Папка"
         AppLanguage.JAPANESE -> "フォルダー"
         AppLanguage.KOREAN -> "폴더"
+    }
+    val agentContextChipLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "上下文"
+        AppLanguage.ENGLISH -> "Context"
+        AppLanguage.ARABIC -> "السياق"
+        AppLanguage.PORTUGUESE -> "Contexto"
+        AppLanguage.SPANISH -> "Contexto"
+        AppLanguage.FRENCH -> "Contexte"
+        AppLanguage.GERMAN -> "Kontext"
+        AppLanguage.RUSSIAN -> "Контекст"
+        AppLanguage.JAPANESE -> "コンテキスト"
+        AppLanguage.KOREAN -> "컨텍스트"
+    }
+    val agentContextPickerTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "选择上下文"
+        AppLanguage.ENGLISH -> "Select context"
+        AppLanguage.ARABIC -> "اختيار السياق"
+        AppLanguage.PORTUGUESE -> "Selecionar contexto"
+        AppLanguage.SPANISH -> "Seleccionar contexto"
+        AppLanguage.FRENCH -> "Sélectionner le contexte"
+        AppLanguage.GERMAN -> "Kontext auswählen"
+        AppLanguage.RUSSIAN -> "Выбрать контекст"
+        AppLanguage.JAPANESE -> "コンテキストを選択"
+        AppLanguage.KOREAN -> "컨텍스트 선택"
+    }
+    val agentContextAppsHeader: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "应用"
+        AppLanguage.ENGLISH -> "Apps"
+        AppLanguage.ARABIC -> "التطبيقات"
+        AppLanguage.PORTUGUESE -> "Apps"
+        AppLanguage.SPANISH -> "Apps"
+        AppLanguage.FRENCH -> "Apps"
+        AppLanguage.GERMAN -> "Apps"
+        AppLanguage.RUSSIAN -> "Приложения"
+        AppLanguage.JAPANESE -> "アプリ"
+        AppLanguage.KOREAN -> "앱"
+    }
+    val agentContextModulesHeader: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "扩展模块"
+        AppLanguage.ENGLISH -> "Modules"
+        AppLanguage.ARABIC -> "الوحدات"
+        AppLanguage.PORTUGUESE -> "Módulos"
+        AppLanguage.SPANISH -> "Módulos"
+        AppLanguage.FRENCH -> "Modules"
+        AppLanguage.GERMAN -> "Module"
+        AppLanguage.RUSSIAN -> "Модули"
+        AppLanguage.JAPANESE -> "モジュール"
+        AppLanguage.KOREAN -> "모듈"
+    }
+    val agentContextEmpty: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "还没有应用或模块。"
+        AppLanguage.ENGLISH -> "No apps or modules yet."
+        AppLanguage.ARABIC -> "لا توجد تطبيقات أو وحدات بعد."
+        AppLanguage.PORTUGUESE -> "Nenhum app ou módulo ainda."
+        AppLanguage.SPANISH -> "Aún no hay apps ni módulos."
+        AppLanguage.FRENCH -> "Pas encore d'apps ni de modules."
+        AppLanguage.GERMAN -> "Noch keine Apps oder Module."
+        AppLanguage.RUSSIAN -> "Пока нет приложений или модулей."
+        AppLanguage.JAPANESE -> "アプリやモジュールはまだありません。"
+        AppLanguage.KOREAN -> "아직 앱이나 모듈이 없습니다."
+    }
+    val agentContextPickerDone: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "完成"
+        AppLanguage.ENGLISH -> "Done"
+        AppLanguage.ARABIC -> "تم"
+        AppLanguage.PORTUGUESE -> "Concluído"
+        AppLanguage.SPANISH -> "Listo"
+        AppLanguage.FRENCH -> "Terminé"
+        AppLanguage.GERMAN -> "Fertig"
+        AppLanguage.RUSSIAN -> "Готово"
+        AppLanguage.JAPANESE -> "完了"
+        AppLanguage.KOREAN -> "완료"
     }
     val agentSaveAsApp: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "保存为应用"

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -76,6 +76,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.agent.components.ChoiceBottomSheet
 import com.webtoapp.ui.agent.components.Composer
+import com.webtoapp.ui.agent.components.ContextPickerDialog
 import com.webtoapp.ui.agent.components.MaterialIconBadgeRound
 import com.webtoapp.ui.agent.components.MessageActions
 import com.webtoapp.ui.agent.components.MessageBubble
@@ -333,11 +334,25 @@ fun AgentScreen(
                     onAttachFolder = { folderPicker.launch(null) },
                     onRemoveAttachment = vm::removePendingAttachment,
 
+                    onOpenContextPicker = vm::openContextPicker,
+
                     onOpenModelPicker = vm::openModelPicker,
                     onCompactContext = vm::compactNow
                 )
             }
         }
+    }
+
+    if (state.contextPickerOpen) {
+        ContextPickerDialog(
+            apps = state.availableContextApps,
+            modules = state.availableContextModules,
+            selectedAppIds = state.contextAppIds,
+            selectedModuleIds = state.contextModuleIds,
+            onToggleApp = vm::toggleContextApp,
+            onToggleModule = vm::toggleContextModule,
+            onDismiss = vm::closeContextPicker
+        )
     }
 
     PreviewSheet(

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -84,7 +84,13 @@ data class AgentUiState(
     val outputTokens: Int = 0,
     val estimatedContextTokens: Int = 0,
     val contextCapacity: Int = 0,
-    val compacting: Boolean = false
+    val compacting: Boolean = false,
+
+    val contextPickerOpen: Boolean = false,
+    val contextAppIds: List<Long> = emptyList(),
+    val contextModuleIds: List<String> = emptyList(),
+    val availableContextApps: List<ContextAppItem> = emptyList(),
+    val availableContextModules: List<ContextModuleItem> = emptyList()
 ) {
     enum class Phase { Idle, Connecting, Streaming, AwaitingTool, AwaitingUser, Error }
     enum class DrawerTab { Sessions, Files }
@@ -92,6 +98,18 @@ data class AgentUiState(
     val canSend: Boolean get() = phase == Phase.Idle
     val isWorking: Boolean get() = phase != Phase.Idle && phase != Phase.Error
 }
+
+data class ContextAppItem(
+    val id: Long,
+    val name: String,
+    val appType: String
+)
+
+data class ContextModuleItem(
+    val id: String,
+    val name: String,
+    val sourceType: String
+)
 
 data class PlanReview(
     val planPath: String,

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -26,6 +26,7 @@ import com.webtoapp.core.agent.runtime.AgentService
 import com.webtoapp.core.agent.session.AgentMessage
 import com.webtoapp.core.agent.session.AgentSession
 import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.core.agent.session.SessionConfig
 import com.webtoapp.core.agent.session.SessionStore
 import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.agent.todo.TodoManager
@@ -34,6 +35,7 @@ import com.webtoapp.core.agent.tool.ToolRegistryFactory
 import com.webtoapp.core.agent.prompt.SystemPromptBuilder
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.AiFeature
+import com.webtoapp.data.model.toManifestJson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -893,6 +895,81 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     private fun isTextUpload(mime: String): Boolean =
         mime.startsWith("text/") || mime == "application/json" || mime == "application/xml"
 
+    fun openContextPicker() {
+        viewModelScope.launch {
+            val session = ensureActiveSession() ?: return@launch
+            val apps = webAppRepository.allWebApps.first()
+                .map { ContextAppItem(it.id, it.name, it.appType.name) }
+            val mgr = com.webtoapp.core.extension.ExtensionManager.getInstance(ctx)
+            mgr.awaitLoaded()
+            val modules = mgr.getAllModules()
+                .map { ContextModuleItem(it.id, it.name, it.sourceType.name) }
+            _ui.update {
+                it.copy(
+                    contextPickerOpen = true,
+                    availableContextApps = apps,
+                    availableContextModules = modules,
+                    contextAppIds = session.config.contextAppIds,
+                    contextModuleIds = session.config.contextModuleIds
+                )
+            }
+        }
+    }
+
+    fun closeContextPicker() {
+        _ui.update { it.copy(contextPickerOpen = false) }
+    }
+
+    fun toggleContextApp(id: Long) {
+        val sid = _ui.value.currentSession?.id ?: return
+        viewModelScope.launch {
+            val newIds = _ui.value.contextAppIds.let { if (id in it) it - id else it + id }
+            _ui.update { it.copy(contextAppIds = newIds) }
+            val session = sessionStore.get(sid) ?: return@launch
+            sessionStore.updateConfig(sid, session.config.copy(contextAppIds = newIds))
+        }
+    }
+
+    fun toggleContextModule(id: String) {
+        val sid = _ui.value.currentSession?.id ?: return
+        viewModelScope.launch {
+            val newIds = _ui.value.contextModuleIds.let { if (id in it) it - id else it + id }
+            _ui.update { it.copy(contextModuleIds = newIds) }
+            val session = sessionStore.get(sid) ?: return@launch
+            sessionStore.updateConfig(sid, session.config.copy(contextModuleIds = newIds))
+        }
+    }
+
+    private suspend fun buildSelectedContext(config: SessionConfig): String {
+        if (config.contextAppIds.isEmpty() && config.contextModuleIds.isEmpty()) return ""
+        val sb = StringBuilder()
+        sb.appendLine("# Selected apps & modules (current context)")
+        sb.appendLine("The user selected these as the working context. Use GetApp/UpdateApp and GetModule/UpdateModule with these ids to inspect or edit them.")
+        if (config.contextAppIds.isNotEmpty()) {
+            sb.appendLine()
+            sb.appendLine("## Apps")
+            config.contextAppIds.forEach { id ->
+                val app = webAppRepository.getWebApp(id) ?: return@forEach
+                sb.appendLine()
+                sb.appendLine("### App id=${app.id} name=\"${app.name}\" type=${app.appType}")
+                sb.appendLine(app.toManifestJson())
+            }
+        }
+        if (config.contextModuleIds.isNotEmpty()) {
+            val mgr = com.webtoapp.core.extension.ExtensionManager.getInstance(ctx)
+            mgr.awaitLoaded()
+            sb.appendLine()
+            sb.appendLine("## Modules")
+            config.contextModuleIds.forEach { id ->
+                val module = mgr.getModuleById(id)?.let { mgr.ensureCodeLoaded(it) } ?: return@forEach
+                sb.appendLine()
+                sb.appendLine("### Module id=${module.id} name=\"${module.name}\" type=${module.sourceType}")
+                sb.appendLine(com.webtoapp.util.GsonProvider.gson.toJson(module))
+            }
+        }
+        return sb.toString().trimEnd()
+    }
+
     fun deleteFromMessage(messageId: String) {
         val sid = _ui.value.currentSession?.id ?: return
         viewModelScope.launch {
@@ -1007,6 +1084,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         } else null
 
         val sessionRoot = files.getSessionRoot(workingSession.id).absolutePath
+        val selectedContext = buildSelectedContext(workingSession.config)
         val systemPrompt = SystemPromptBuilder.build(
             SystemPromptBuilder.Input(
                 language = Strings.currentLanguage.value,
@@ -1015,7 +1093,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 tools = registry.all,
                 projectFiles = projectSummary,
 
-                planMode = planMode
+                planMode = planMode,
+                selectedContext = selectedContext
             )
         )
 

--- a/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.AttachFile
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.DataUsage
@@ -83,6 +84,8 @@ fun Composer(
     onAttachFile: () -> Unit,
     onAttachFolder: () -> Unit,
     onRemoveAttachment: (String) -> Unit,
+
+    onOpenContextPicker: () -> Unit,
 
     onOpenModelPicker: () -> Unit = {},
     onCompactContext: () -> Unit = {}
@@ -156,7 +159,9 @@ fun Composer(
             estimatedTokens = state.estimatedContextTokens,
             contextCapacity = state.contextCapacity,
             compacting = state.compacting,
-            onCompactContext = onCompactContext
+            onCompactContext = onCompactContext,
+            selectedContextCount = state.contextAppIds.size + state.contextModuleIds.size,
+            onOpenContextPicker = onOpenContextPicker
         )
     }
 }
@@ -438,7 +443,9 @@ private fun ModeChipRow(
     estimatedTokens: Int,
     contextCapacity: Int,
     compacting: Boolean,
-    onCompactContext: () -> Unit
+    onCompactContext: () -> Unit,
+    selectedContextCount: Int,
+    onOpenContextPicker: () -> Unit
 ) {
     var showCompactMenu by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
 
@@ -465,6 +472,15 @@ private fun ModeChipRow(
             icon = Icons.Outlined.AutoAwesome,
             primary = false,
             onClick = onTriggerSlash
+        )
+
+        ModeChip(
+            label = if (selectedContextCount > 0)
+                "${Strings.agentContextChipLabel} · $selectedContextCount"
+            else Strings.agentContextChipLabel,
+            icon = Icons.Outlined.BookmarkBorder,
+            primary = selectedContextCount > 0,
+            onClick = onOpenContextPicker
         )
 
         if (contextCapacity > 0) {

--- a/app/src/main/java/com/webtoapp/ui/agent/components/ContextPickerDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/ContextPickerDialog.kt
@@ -1,0 +1,152 @@
+package com.webtoapp.ui.agent.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.webtoapp.core.i18n.Strings
+import com.webtoapp.ui.agent.ContextAppItem
+import com.webtoapp.ui.agent.ContextModuleItem
+import com.webtoapp.ui.design.WtaSpacing
+
+@Composable
+fun ContextPickerDialog(
+    apps: List<ContextAppItem>,
+    modules: List<ContextModuleItem>,
+    selectedAppIds: List<Long>,
+    selectedModuleIds: List<String>,
+    onToggleApp: (Long) -> Unit,
+    onToggleModule: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(WtaSpacing.Medium)
+            ) {
+                Text(
+                    text = Strings.agentContextPickerTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.padding(top = WtaSpacing.Small))
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 420.dp),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
+                ) {
+                if (apps.isNotEmpty()) {
+                    item("apps-header") {
+                        Text(
+                            text = Strings.agentContextAppsHeader,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(top = WtaSpacing.Small)
+                        )
+                    }
+                    items(apps, key = { "app-${it.id}" }) { app ->
+                        ContextRow(
+                            title = app.name,
+                            subtitle = app.appType,
+                            checked = app.id in selectedAppIds,
+                            onToggle = { onToggleApp(app.id) }
+                        )
+                    }
+                }
+                if (modules.isNotEmpty()) {
+                    item("modules-header") {
+                        Text(
+                            text = Strings.agentContextModulesHeader,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(top = WtaSpacing.Small)
+                        )
+                    }
+                    items(modules, key = { "mod-${it.id}" }) { module ->
+                        ContextRow(
+                            title = module.name,
+                            subtitle = module.sourceType,
+                            checked = module.id in selectedModuleIds,
+                            onToggle = { onToggleModule(module.id) }
+                        )
+                    }
+                }
+                if (apps.isEmpty() && modules.isEmpty()) {
+                    item("empty") {
+                        Text(
+                            text = Strings.agentContextEmpty,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(vertical = WtaSpacing.Medium)
+                        )
+                    }
+                }
+                }
+                Spacer(Modifier.padding(top = WtaSpacing.Small))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(Strings.agentContextPickerDone)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContextRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onToggle: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = WtaSpacing.Tiny),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(checked = checked, onCheckedChange = { onToggle() })
+        Spacer(Modifier.width(WtaSpacing.Small))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #380

## Summary

Final step of the Agent upgrade. The user can now **select apps and extension modules as the working context** for a conversation. Selected items are injected into the system prompt with their full manifest/definition, so the agent knows what the user is working on and can edit them directly via the app/module tools (#376/#378).

## What changed

- **`SessionConfig`**: persist `contextAppIds` / `contextModuleIds` per session (Gson-safe for old data).
- **`AgentViewModel`**: `openContextPicker` loads available apps/modules + current selection; `toggleContextApp`/`toggleContextModule` persist the selection; `buildSelectedContext` renders selected apps (manifest via `toManifestJson`) and modules (definition via `ensureCodeLoaded`) into a system-prompt section.
- **`SystemPromptBuilder`**: new `selectedContext` section.
- **`AgentUiState`**: context-picker state + `ContextAppItem`/`ContextModuleItem`.
- **`Composer`**: a "Context" chip (shows the selected count) opens the picker.
- **`ContextPickerDialog`**: multi-select apps and modules with checkboxes.
- **`Strings`**: context-picker labels in all 10 languages.

## Notes

- Context is per-session and survives across turns (stored in `SessionConfig`).
- The injected context tells the agent to use `GetApp`/`UpdateApp` and `GetModule`/`UpdateModule` with the selected ids.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: select an app + a module as context; the chip shows the count; the agent's system prompt includes their manifest/definition and it can edit them