### PR TITLE
improve(agent): context picker — tabs for apps/modules + category filter

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1444,6 +1444,7 @@ object Strings {
     val agentContextModulesHeader: String get() = StringsB.agentContextModulesHeader
     val agentContextEmpty: String get() = StringsB.agentContextEmpty
     val agentContextPickerDone: String get() = StringsB.agentContextPickerDone
+    val agentContextAllCategories: String get() = StringsB.agentContextAllCategories
     val agentSaveAsApp: String get() = StringsB.agentSaveAsApp
     val agentSaveAsAppTitle: String get() = StringsB.agentSaveAsAppTitle
     val agentSaveAsAppDescription: String get() = StringsB.agentSaveAsAppDescription
@@ -22968,6 +22969,18 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Готово"
         AppLanguage.JAPANESE -> "完了"
         AppLanguage.KOREAN -> "완료"
+    }
+    val agentContextAllCategories: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "全部"
+        AppLanguage.ENGLISH -> "All"
+        AppLanguage.ARABIC -> "الكل"
+        AppLanguage.PORTUGUESE -> "Todos"
+        AppLanguage.SPANISH -> "Todos"
+        AppLanguage.FRENCH -> "Tous"
+        AppLanguage.GERMAN -> "Alle"
+        AppLanguage.RUSSIAN -> "Все"
+        AppLanguage.JAPANESE -> "すべて"
+        AppLanguage.KOREAN -> "전체"
     }
     val agentSaveAsApp: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "保存为应用"

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -347,6 +347,7 @@ fun AgentScreen(
         ContextPickerDialog(
             apps = state.availableContextApps,
             modules = state.availableContextModules,
+            categories = state.availableCategories,
             selectedAppIds = state.contextAppIds,
             selectedModuleIds = state.contextModuleIds,
             onToggleApp = vm::toggleContextApp,

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -90,7 +90,8 @@ data class AgentUiState(
     val contextAppIds: List<Long> = emptyList(),
     val contextModuleIds: List<String> = emptyList(),
     val availableContextApps: List<ContextAppItem> = emptyList(),
-    val availableContextModules: List<ContextModuleItem> = emptyList()
+    val availableContextModules: List<ContextModuleItem> = emptyList(),
+    val availableCategories: List<ContextCategoryItem> = emptyList()
 ) {
     enum class Phase { Idle, Connecting, Streaming, AwaitingTool, AwaitingUser, Error }
     enum class DrawerTab { Sessions, Files }
@@ -102,13 +103,20 @@ data class AgentUiState(
 data class ContextAppItem(
     val id: Long,
     val name: String,
-    val appType: String
+    val appType: String,
+    val categoryId: Long? = null
 )
 
 data class ContextModuleItem(
     val id: String,
     val name: String,
     val sourceType: String
+)
+
+data class ContextCategoryItem(
+    val id: Long,
+    val name: String,
+    val icon: String
 )
 
 data class PlanReview(

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -66,6 +66,11 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
             com.webtoapp.data.repository.WebAppRepository::class.java
         )
     }
+    private val categoryRepository: com.webtoapp.data.repository.AppCategoryRepository by lazy {
+        org.koin.java.KoinJavaComponent.get(
+            com.webtoapp.data.repository.AppCategoryRepository::class.java
+        )
+    }
     private val saveSessionAsAppUseCase by lazy {
         com.webtoapp.core.agent.export.SaveSessionAsAppUseCase(
             context = ctx,
@@ -899,7 +904,10 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val session = ensureActiveSession() ?: return@launch
             val apps = webAppRepository.allWebApps.first()
-                .map { ContextAppItem(it.id, it.name, it.appType.name) }
+                .map { ContextAppItem(it.id, it.name, it.appType.name, it.categoryId) }
+            val categories = categoryRepository.allCategories.first()
+                .sortedBy { it.sortOrder }
+                .map { ContextCategoryItem(it.id, it.name, it.icon) }
             val mgr = com.webtoapp.core.extension.ExtensionManager.getInstance(ctx)
             mgr.awaitLoaded()
             val modules = mgr.getAllModules()
@@ -909,6 +917,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                     contextPickerOpen = true,
                     availableContextApps = apps,
                     availableContextModules = modules,
+                    availableCategories = categories,
                     contextAppIds = session.config.contextAppIds,
                     contextModuleIds = session.config.contextModuleIds
                 )

--- a/app/src/main/java/com/webtoapp/ui/agent/components/ContextPickerDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/ContextPickerDialog.kt
@@ -1,5 +1,6 @@
 package com.webtoapp.ui.agent.components
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,12 +11,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -23,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.agent.ContextAppItem
+import com.webtoapp.ui.agent.ContextCategoryItem
 import com.webtoapp.ui.agent.ContextModuleItem
 import com.webtoapp.ui.design.WtaSpacing
 
@@ -30,12 +40,16 @@ import com.webtoapp.ui.design.WtaSpacing
 fun ContextPickerDialog(
     apps: List<ContextAppItem>,
     modules: List<ContextModuleItem>,
+    categories: List<ContextCategoryItem>,
     selectedAppIds: List<Long>,
     selectedModuleIds: List<String>,
     onToggleApp: (Long) -> Unit,
     onToggleModule: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
+    var selectedTab by remember { mutableStateOf(0) }
+    var selectedCategory by remember { mutableStateOf<Long?>(null) }
+
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = MaterialTheme.shapes.large,
@@ -53,59 +67,36 @@ fun ContextPickerDialog(
                     fontWeight = FontWeight.SemiBold
                 )
                 Spacer(Modifier.padding(top = WtaSpacing.Small))
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 420.dp),
-                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
-                ) {
-                if (apps.isNotEmpty()) {
-                    item("apps-header") {
-                        Text(
-                            text = Strings.agentContextAppsHeader,
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(top = WtaSpacing.Small)
-                        )
-                    }
-                    items(apps, key = { "app-${it.id}" }) { app ->
-                        ContextRow(
-                            title = app.name,
-                            subtitle = app.appType,
-                            checked = app.id in selectedAppIds,
-                            onToggle = { onToggleApp(app.id) }
-                        )
-                    }
+
+                TabRow(selectedTabIndex = selectedTab) {
+                    Tab(
+                        selected = selectedTab == 0,
+                        onClick = { selectedTab = 0 },
+                        text = { Text("${Strings.agentContextAppsHeader} (${apps.size})") }
+                    )
+                    Tab(
+                        selected = selectedTab == 1,
+                        onClick = { selectedTab = 1 },
+                        text = { Text("${Strings.agentContextModulesHeader} (${modules.size})") }
+                    )
                 }
-                if (modules.isNotEmpty()) {
-                    item("modules-header") {
-                        Text(
-                            text = Strings.agentContextModulesHeader,
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(top = WtaSpacing.Small)
-                        )
-                    }
-                    items(modules, key = { "mod-${it.id}" }) { module ->
-                        ContextRow(
-                            title = module.name,
-                            subtitle = module.sourceType,
-                            checked = module.id in selectedModuleIds,
-                            onToggle = { onToggleModule(module.id) }
-                        )
-                    }
+
+                when (selectedTab) {
+                    0 -> AppsPage(
+                        apps = apps,
+                        categories = categories,
+                        selectedCategory = selectedCategory,
+                        onSelectCategory = { selectedCategory = it },
+                        selectedAppIds = selectedAppIds,
+                        onToggleApp = onToggleApp
+                    )
+                    1 -> ModulesPage(
+                        modules = modules,
+                        selectedModuleIds = selectedModuleIds,
+                        onToggleModule = onToggleModule
+                    )
                 }
-                if (apps.isEmpty() && modules.isEmpty()) {
-                    item("empty") {
-                        Text(
-                            text = Strings.agentContextEmpty,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(vertical = WtaSpacing.Medium)
-                        )
-                    }
-                }
-                }
+
                 Spacer(Modifier.padding(top = WtaSpacing.Small))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -116,6 +107,102 @@ fun ContextPickerDialog(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AppsPage(
+    apps: List<ContextAppItem>,
+    categories: List<ContextCategoryItem>,
+    selectedCategory: Long?,
+    onSelectCategory: (Long?) -> Unit,
+    selectedAppIds: List<Long>,
+    onToggleApp: (Long) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (categories.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(vertical = WtaSpacing.Small),
+                horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+            ) {
+                FilterChip(
+                    selected = selectedCategory == null,
+                    onClick = { onSelectCategory(null) },
+                    label = { Text(Strings.agentContextAllCategories) }
+                )
+                categories.forEach { category ->
+                    FilterChip(
+                        selected = selectedCategory == category.id,
+                        onClick = { onSelectCategory(category.id) },
+                        label = { Text("${category.icon} ${category.name}") }
+                    )
+                }
+            }
+        }
+
+        val filtered = if (selectedCategory == null) apps
+            else apps.filter { it.categoryId == selectedCategory }
+
+        if (filtered.isEmpty()) {
+            Text(
+                text = Strings.agentContextEmpty,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = WtaSpacing.Medium)
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp),
+                verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
+            ) {
+                items(filtered, key = { "app-${it.id}" }) { app ->
+                    ContextRow(
+                        title = app.name,
+                        subtitle = app.appType,
+                        checked = app.id in selectedAppIds,
+                        onToggle = { onToggleApp(app.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModulesPage(
+    modules: List<ContextModuleItem>,
+    selectedModuleIds: List<String>,
+    onToggleModule: (String) -> Unit
+) {
+    if (modules.isEmpty()) {
+        Text(
+            text = Strings.agentContextEmpty,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(vertical = WtaSpacing.Medium)
+        )
+        return
+    }
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 420.dp)
+            .padding(top = WtaSpacing.Small),
+        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Tiny)
+    ) {
+        items(modules, key = { "mod-${it.id}" }) { module ->
+            ContextRow(
+                title = module.name,
+                subtitle = module.sourceType,
+                checked = module.id in selectedModuleIds,
+                onToggle = { onToggleModule(module.id) }
+            )
         }
     }
 }


### PR DESCRIPTION
Fixes #382

## Summary

Reworks the context picker dialog (from #381) so it is no longer one long stacked list.

- **Tabs**: Apps and Modules, each showing its count.
- **Category filter** on the Apps tab: chips for "All" + each app category, so apps can be browsed/selected by category.

## Supporting changes

- `ContextAppItem` carries `categoryId`; `AgentUiState` gains `availableCategories` (`ContextCategoryItem`); `AgentViewModel.openContextPicker` loads app categories via `AppCategoryRepository` (Koin).
- `Strings`: add `agentContextAllCategories` in all 10 languages.

Selection behavior (persist per session, inject into the system prompt) is unchanged.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: open the picker — Apps/Modules tabs; filter apps by category; selection still persists and reaches the system prompt