### PR TITLE
feat(ai): AI Settings tab layout + models.dev model catalog browser

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2407,6 +2407,25 @@ object Strings {
     val chineseSeparator: String get() = StringsC.chineseSeparator
     val test: String get() = StringsC.test
     val savedModels: String get() = StringsC.savedModels
+    val aiModelCatalog: String get() = StringsC.aiModelCatalog
+    val aiCatalogSource: String get() = StringsC.aiCatalogSource
+    val aiCatalogCount: String get() = StringsC.aiCatalogCount
+    val aiCatalogRefresh: String get() = StringsC.aiCatalogRefresh
+    val aiCatalogSearchHint: String get() = StringsC.aiCatalogSearchHint
+    val aiCatalogAllProviders: String get() = StringsC.aiCatalogAllProviders
+    val aiCatalogLoading: String get() = StringsC.aiCatalogLoading
+    val aiCatalogEmpty: String get() = StringsC.aiCatalogEmpty
+    val aiCatalogAdd: String get() = StringsC.aiCatalogAdd
+    val aiCatalogAdded: String get() = StringsC.aiCatalogAdded
+    val aiCatalogBadgeVision: String get() = StringsC.aiCatalogBadgeVision
+    val aiCatalogBadgeReasoning: String get() = StringsC.aiCatalogBadgeReasoning
+    val aiCatalogBadgeToolCall: String get() = StringsC.aiCatalogBadgeToolCall
+    val aiCatalogBadgeImageGen: String get() = StringsC.aiCatalogBadgeImageGen
+    val aiCatalogContext: String get() = StringsC.aiCatalogContext
+    val aiCatalogPrice: String get() = StringsC.aiCatalogPrice
+    val aiCatalogAddTitle: String get() = StringsC.aiCatalogAddTitle
+    val aiCatalogPickKey: String get() = StringsC.aiCatalogPickKey
+    val aiCatalogAliasHint: String get() = StringsC.aiCatalogAliasHint
     val configModelCapabilities: String get() = StringsC.configModelCapabilities
     val pleaseAddApiKeyFirst: String get() = StringsC.pleaseAddApiKeyFirst
     val noSavedModelsHint: String get() = StringsC.noSavedModelsHint
@@ -34716,6 +34735,235 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Сохранённые модели"
         AppLanguage.JAPANESE -> "保存済みモデル"
         AppLanguage.KOREAN -> "저장된 모델"
+    }
+
+    val aiModelCatalog: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "模型目录"
+        AppLanguage.ENGLISH -> "Model Catalog"
+        AppLanguage.ARABIC -> "كتالوج النماذج"
+        AppLanguage.PORTUGUESE -> "Catálogo de Modelos"
+        AppLanguage.SPANISH -> "Catálogo de Modelos"
+        AppLanguage.FRENCH -> "Catalogue de Modèles"
+        AppLanguage.GERMAN -> "Modellkatalog"
+        AppLanguage.RUSSIAN -> "Каталог моделей"
+        AppLanguage.JAPANESE -> "モデルカタログ"
+        AppLanguage.KOREAN -> "모델 카탈로그"
+    }
+    val aiCatalogSource: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "数据来源：models.dev"
+        AppLanguage.ENGLISH -> "Source: models.dev"
+        AppLanguage.ARABIC -> "المصدر: models.dev"
+        AppLanguage.PORTUGUESE -> "Fonte: models.dev"
+        AppLanguage.SPANISH -> "Fuente: models.dev"
+        AppLanguage.FRENCH -> "Source : models.dev"
+        AppLanguage.GERMAN -> "Quelle: models.dev"
+        AppLanguage.RUSSIAN -> "Источник: models.dev"
+        AppLanguage.JAPANESE -> "出典：models.dev"
+        AppLanguage.KOREAN -> "출처: models.dev"
+    }
+    val aiCatalogCount: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "%d 个模型"
+        AppLanguage.ENGLISH -> "%d models"
+        AppLanguage.ARABIC -> "%d نموذج"
+        AppLanguage.PORTUGUESE -> "%d modelos"
+        AppLanguage.SPANISH -> "%d modelos"
+        AppLanguage.FRENCH -> "%d modèles"
+        AppLanguage.GERMAN -> "%d Modelle"
+        AppLanguage.RUSSIAN -> "%d моделей"
+        AppLanguage.JAPANESE -> "%d モデル"
+        AppLanguage.KOREAN -> "%d개 모델"
+    }
+    val aiCatalogRefresh: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "刷新"
+        AppLanguage.ENGLISH -> "Refresh"
+        AppLanguage.ARABIC -> "تحديث"
+        AppLanguage.PORTUGUESE -> "Atualizar"
+        AppLanguage.SPANISH -> "Actualizar"
+        AppLanguage.FRENCH -> "Actualiser"
+        AppLanguage.GERMAN -> "Aktualisieren"
+        AppLanguage.RUSSIAN -> "Обновить"
+        AppLanguage.JAPANESE -> "更新"
+        AppLanguage.KOREAN -> "새로고침"
+    }
+    val aiCatalogSearchHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "搜索模型…"
+        AppLanguage.ENGLISH -> "Search models…"
+        AppLanguage.ARABIC -> "البحث عن نماذج…"
+        AppLanguage.PORTUGUESE -> "Buscar modelos…"
+        AppLanguage.SPANISH -> "Buscar modelos…"
+        AppLanguage.FRENCH -> "Rechercher des modèles…"
+        AppLanguage.GERMAN -> "Modelle suchen…"
+        AppLanguage.RUSSIAN -> "Поиск моделей…"
+        AppLanguage.JAPANESE -> "モデルを検索…"
+        AppLanguage.KOREAN -> "모델 검색…"
+    }
+    val aiCatalogAllProviders: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "全部"
+        AppLanguage.ENGLISH -> "All"
+        AppLanguage.ARABIC -> "الكل"
+        AppLanguage.PORTUGUESE -> "Todos"
+        AppLanguage.SPANISH -> "Todos"
+        AppLanguage.FRENCH -> "Tous"
+        AppLanguage.GERMAN -> "Alle"
+        AppLanguage.RUSSIAN -> "Все"
+        AppLanguage.JAPANESE -> "すべて"
+        AppLanguage.KOREAN -> "전체"
+    }
+    val aiCatalogLoading: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "加载目录…"
+        AppLanguage.ENGLISH -> "Loading catalog…"
+        AppLanguage.ARABIC -> "جارٍ تحميل الكتالوج…"
+        AppLanguage.PORTUGUESE -> "Carregando catálogo…"
+        AppLanguage.SPANISH -> "Cargando catálogo…"
+        AppLanguage.FRENCH -> "Chargement du catalogue…"
+        AppLanguage.GERMAN -> "Katalog wird geladen…"
+        AppLanguage.RUSSIAN -> "Загрузка каталога…"
+        AppLanguage.JAPANESE -> "カタログを読み込み中…"
+        AppLanguage.KOREAN -> "카탈로그 로드 중…"
+    }
+    val aiCatalogEmpty: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "没有匹配的模型。"
+        AppLanguage.ENGLISH -> "No models match."
+        AppLanguage.ARABIC -> "لا توجد نماذج مطابقة."
+        AppLanguage.PORTUGUESE -> "Nenhum modelo corresponde."
+        AppLanguage.SPANISH -> "No hay modelos que coincidan."
+        AppLanguage.FRENCH -> "Aucun modèle correspondant."
+        AppLanguage.GERMAN -> "Keine passenden Modelle."
+        AppLanguage.RUSSIAN -> "Нет подходящих моделей."
+        AppLanguage.JAPANESE -> "一致するモデルがありません。"
+        AppLanguage.KOREAN -> "일치하는 모델이 없습니다."
+    }
+    val aiCatalogAdd: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "添加"
+        AppLanguage.ENGLISH -> "Add"
+        AppLanguage.ARABIC -> "إضافة"
+        AppLanguage.PORTUGUESE -> "Adicionar"
+        AppLanguage.SPANISH -> "Añadir"
+        AppLanguage.FRENCH -> "Ajouter"
+        AppLanguage.GERMAN -> "Hinzufügen"
+        AppLanguage.RUSSIAN -> "Добавить"
+        AppLanguage.JAPANESE -> "追加"
+        AppLanguage.KOREAN -> "추가"
+    }
+    val aiCatalogAdded: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "已添加 %s"
+        AppLanguage.ENGLISH -> "Added %s"
+        AppLanguage.ARABIC -> "تمت إضافة %s"
+        AppLanguage.PORTUGUESE -> "Adicionado %s"
+        AppLanguage.SPANISH -> "Añadido %s"
+        AppLanguage.FRENCH -> "Ajouté %s"
+        AppLanguage.GERMAN -> "Hinzugefügt %s"
+        AppLanguage.RUSSIAN -> "Добавлено %s"
+        AppLanguage.JAPANESE -> "追加しました %s"
+        AppLanguage.KOREAN -> "추가됨 %s"
+    }
+    val aiCatalogBadgeVision: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "视觉"
+        AppLanguage.ENGLISH -> "Vision"
+        AppLanguage.ARABIC -> "رؤية"
+        AppLanguage.PORTUGUESE -> "Visão"
+        AppLanguage.SPANISH -> "Visión"
+        AppLanguage.FRENCH -> "Vision"
+        AppLanguage.GERMAN -> "Vision"
+        AppLanguage.RUSSIAN -> "Зрение"
+        AppLanguage.JAPANESE -> "画像認識"
+        AppLanguage.KOREAN -> "비전"
+    }
+    val aiCatalogBadgeReasoning: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "推理"
+        AppLanguage.ENGLISH -> "Reasoning"
+        AppLanguage.ARABIC -> "استدلال"
+        AppLanguage.PORTUGUESE -> "Raciocínio"
+        AppLanguage.SPANISH -> "Razonamiento"
+        AppLanguage.FRENCH -> "Raisonnement"
+        AppLanguage.GERMAN -> "Reasoning"
+        AppLanguage.RUSSIAN -> "Рассуждение"
+        AppLanguage.JAPANESE -> "推論"
+        AppLanguage.KOREAN -> "추론"
+    }
+    val aiCatalogBadgeToolCall: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "工具"
+        AppLanguage.ENGLISH -> "Tools"
+        AppLanguage.ARABIC -> "أدوات"
+        AppLanguage.PORTUGUESE -> "Ferramentas"
+        AppLanguage.SPANISH -> "Herramientas"
+        AppLanguage.FRENCH -> "Outils"
+        AppLanguage.GERMAN -> "Tools"
+        AppLanguage.RUSSIAN -> "Инструменты"
+        AppLanguage.JAPANESE -> "ツール"
+        AppLanguage.KOREAN -> "도구"
+    }
+    val aiCatalogBadgeImageGen: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "图像"
+        AppLanguage.ENGLISH -> "Image"
+        AppLanguage.ARABIC -> "صورة"
+        AppLanguage.PORTUGUESE -> "Imagem"
+        AppLanguage.SPANISH -> "Imagen"
+        AppLanguage.FRENCH -> "Image"
+        AppLanguage.GERMAN -> "Bild"
+        AppLanguage.RUSSIAN -> "Изображение"
+        AppLanguage.JAPANESE -> "画像"
+        AppLanguage.KOREAN -> "이미지"
+    }
+    val aiCatalogContext: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "%d 上下文"
+        AppLanguage.ENGLISH -> "%d ctx"
+        AppLanguage.ARABIC -> "%d سياق"
+        AppLanguage.PORTUGUESE -> "%d ctx"
+        AppLanguage.SPANISH -> "%d ctx"
+        AppLanguage.FRENCH -> "%d ctx"
+        AppLanguage.GERMAN -> "%d ctx"
+        AppLanguage.RUSSIAN -> "%d ctx"
+        AppLanguage.JAPANESE -> "%d ctx"
+        AppLanguage.KOREAN -> "%d ctx"
+    }
+    val aiCatalogPrice: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "$%.2f/$%.2f 每百万"
+        AppLanguage.ENGLISH -> "$%.2f/$%.2f per M"
+        AppLanguage.ARABIC -> "$%.2f/$%.2f لكل مليون"
+        AppLanguage.PORTUGUESE -> "$%.2f/$%.2f por M"
+        AppLanguage.SPANISH -> "$%.2f/$%.2f por M"
+        AppLanguage.FRENCH -> "$%.2f/$%.2f par M"
+        AppLanguage.GERMAN -> "$%.2f/$%.2f pro M"
+        AppLanguage.RUSSIAN -> "$%.2f/$%.2f за M"
+        AppLanguage.JAPANESE -> "$%.2f/$%.2f /M"
+        AppLanguage.KOREAN -> "$%.2f/$%.2f /M"
+    }
+    val aiCatalogAddTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "添加模型"
+        AppLanguage.ENGLISH -> "Add model"
+        AppLanguage.ARABIC -> "إضافة نموذج"
+        AppLanguage.PORTUGUESE -> "Adicionar modelo"
+        AppLanguage.SPANISH -> "Añadir modelo"
+        AppLanguage.FRENCH -> "Ajouter un modèle"
+        AppLanguage.GERMAN -> "Modell hinzufügen"
+        AppLanguage.RUSSIAN -> "Добавить модель"
+        AppLanguage.JAPANESE -> "モデルを追加"
+        AppLanguage.KOREAN -> "모델 추가"
+    }
+    val aiCatalogPickKey: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "选择 API 密钥"
+        AppLanguage.ENGLISH -> "Choose an API key"
+        AppLanguage.ARABIC -> "اختر مفتاح API"
+        AppLanguage.PORTUGUESE -> "Escolha uma chave de API"
+        AppLanguage.SPANISH -> "Elige una clave de API"
+        AppLanguage.FRENCH -> "Choisissez une clé API"
+        AppLanguage.GERMAN -> "API-Schlüssel wählen"
+        AppLanguage.RUSSIAN -> "Выберите API-ключ"
+        AppLanguage.JAPANESE -> "APIキーを選択"
+        AppLanguage.KOREAN -> "API 키 선택"
+    }
+    val aiCatalogAliasHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "别名（可选）"
+        AppLanguage.ENGLISH -> "Alias (optional)"
+        AppLanguage.ARABIC -> "الاسم المستعار (اختياري)"
+        AppLanguage.PORTUGUESE -> "Apelido (opcional)"
+        AppLanguage.SPANISH -> "Alias (opcional)"
+        AppLanguage.FRENCH -> "Alias (facultatif)"
+        AppLanguage.GERMAN -> "Alias (optional)"
+        AppLanguage.RUSSIAN -> "Псевдоним (необязательно)"
+        AppLanguage.JAPANESE -> "別名（任意）"
+        AppLanguage.KOREAN -> "별칭 (선택)"
     }
 
     val configModelCapabilities: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/AiSettingsScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AiSettingsScreen.kt
@@ -59,67 +59,92 @@ fun AiSettingsScreen(
     var editingModel by remember { mutableStateOf<SavedModel?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
 
+    var selectedTab by remember { mutableStateOf(0) }
+    val catalogRepo = remember { com.webtoapp.core.ai.ModelsDevRepository.getInstance(context) }
+    val catalogState by catalogRepo.state.collectAsStateWithLifecycle()
+
     WtaScreen(
         title = Strings.aiSettings,
         snackbarHostState = snackbarHostState,
         onBack = onBack
     ) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = WtaSpacing.ScreenHorizontal),
-            contentPadding = PaddingValues(vertical = WtaSpacing.ScreenVertical),
-            verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
-        ) {
-
-            item {
-                ApiKeysSection(
-                    apiKeys = apiKeys,
-                    onAddClick = { showAddApiKeyDialog = true },
-                    onEditClick = { editingApiKey = it },
-                    onDeleteClick = { key ->
-                        scope.launch { configManager.deleteApiKey(key.id) }
-                    },
-                    onTestClick = { key ->
-                        scope.launch {
-                            val result = apiClient.testConnection(key)
-                            result.onSuccess {
-                                snackbarHostState.showSnackbar(
-                                    message = Strings.aiConnectionOk.format(key.provider.name),
-                                    duration = SnackbarDuration.Short
-                                )
-                            }.onFailure { error ->
-                                snackbarHostState.showSnackbar(
-                                    message = Strings.aiConnectionFail.format(error.message),
-                                    duration = SnackbarDuration.Long
-                                )
+        Column(modifier = Modifier.fillMaxSize()) {
+            TabRow(selectedTabIndex = selectedTab) {
+                Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }, text = { Text(Strings.apiKeys) })
+                Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }, text = { Text(Strings.savedModels) })
+                Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 }, text = { Text(Strings.aiModelCatalog) })
+            }
+            when (selectedTab) {
+                0 -> LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = WtaSpacing.ScreenHorizontal),
+                    contentPadding = PaddingValues(vertical = WtaSpacing.ScreenVertical),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
+                ) {
+                    item {
+                        ApiKeysSection(
+                            apiKeys = apiKeys,
+                            onAddClick = { showAddApiKeyDialog = true },
+                            onEditClick = { editingApiKey = it },
+                            onDeleteClick = { key ->
+                                scope.launch { configManager.deleteApiKey(key.id) }
+                            },
+                            onTestClick = { key ->
+                                scope.launch {
+                                    val result = apiClient.testConnection(key)
+                                    result.onSuccess {
+                                        snackbarHostState.showSnackbar(
+                                            message = Strings.aiConnectionOk.format(key.provider.name),
+                                            duration = SnackbarDuration.Short
+                                        )
+                                    }.onFailure { error ->
+                                        snackbarHostState.showSnackbar(
+                                            message = Strings.aiConnectionFail.format(error.message),
+                                            duration = SnackbarDuration.Long
+                                        )
+                                    }
+                                }
                             }
-                        }
+                        )
                     }
-                )
-            }
-
-            item {
-                SavedModelsSection(
-                    models = savedModels,
+                }
+                1 -> LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = WtaSpacing.ScreenHorizontal),
+                    contentPadding = PaddingValues(vertical = WtaSpacing.ScreenVertical),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.SectionGap)
+                ) {
+                    item {
+                        SavedModelsSection(
+                            models = savedModels,
+                            apiKeys = apiKeys,
+                            onAddClick = {
+                                if (apiKeys.isNotEmpty()) {
+                                    selectedApiKey = null
+                                    showAddModelDialog = true
+                                }
+                            },
+                            onEditClick = { editingModel = it },
+                            onDeleteClick = { model ->
+                                scope.launch { configManager.deleteSavedModel(model.id) }
+                            },
+                            onSetDefaultClick = { model ->
+                                scope.launch { configManager.setDefaultModel(model.id) }
+                            }
+                        )
+                    }
+                }
+                2 -> ModelCatalogSection(
+                    repo = catalogRepo,
+                    state = catalogState,
                     apiKeys = apiKeys,
-                    onAddClick = {
-                        if (apiKeys.isNotEmpty()) {
-                            selectedApiKey = null
-                            showAddModelDialog = true
-                        }
-                    },
-                    onEditClick = { editingModel = it },
-                    onDeleteClick = { model ->
-                        scope.launch { configManager.deleteSavedModel(model.id) }
-                    },
-                    onSetDefaultClick = { model ->
-                        scope.launch { configManager.setDefaultModel(model.id) }
-                    }
+                    configManager = configManager,
+                    scope = scope,
+                    snackbarHostState = snackbarHostState
                 )
             }
-
-            item { Spacer(modifier = Modifier.height(32.dp)) }
         }
 
     if (showAddApiKeyDialog) {

--- a/app/src/main/java/com/webtoapp/ui/screens/ModelCatalogSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModelCatalogSection.kt
@@ -1,0 +1,438 @@
+package com.webtoapp.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.webtoapp.core.ai.CatalogModel
+import com.webtoapp.core.ai.ModelCatalogState
+import com.webtoapp.core.ai.ModelsDevRepository
+import com.webtoapp.core.ai.AiConfigManager
+import com.webtoapp.core.i18n.Strings
+import com.webtoapp.data.model.AiFeature
+import com.webtoapp.data.model.AiModel
+import com.webtoapp.data.model.ApiKeyConfig
+import com.webtoapp.data.model.ModelCapability
+import com.webtoapp.data.model.SavedModel
+import com.webtoapp.ui.design.WtaSpacing
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+
+private enum class CapabilityFilter { ALL, VISION, REASONING, TOOL_CALL, IMAGE_GEN }
+
+@Composable
+fun ModelCatalogSection(
+    repo: ModelsDevRepository,
+    state: ModelCatalogState,
+    apiKeys: List<ApiKeyConfig>,
+    configManager: AiConfigManager,
+    scope: CoroutineScope,
+    snackbarHostState: SnackbarHostState
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    var selectedProvider by remember { mutableStateOf<String?>(null) }
+    var capabilityFilter by remember { mutableStateOf(CapabilityFilter.ALL) }
+    var modelToAdd by remember { mutableStateOf<CatalogModel?>(null) }
+
+    val providers = remember(state) { repo.allProviders() }
+    val allModels = remember(state) { repo.allModels() }
+
+    val filtered = remember(allModels, searchQuery, selectedProvider, capabilityFilter) {
+        allModels.filter { m ->
+            val matchesProvider = selectedProvider == null || m.providerId == selectedProvider
+            val matchesQuery = searchQuery.isBlank() ||
+                m.name.contains(searchQuery, ignoreCase = true) ||
+                m.id.contains(searchQuery, ignoreCase = true)
+            val matchesCapability = when (capabilityFilter) {
+                CapabilityFilter.ALL -> true
+                CapabilityFilter.VISION -> m.supportsVision
+                CapabilityFilter.REASONING -> m.reasoning
+                CapabilityFilter.TOOL_CALL -> m.toolCall
+                CapabilityFilter.IMAGE_GEN -> m.isImageGeneration
+            }
+            matchesProvider && matchesQuery && matchesCapability
+        }.sortedWith(compareBy({ it.providerName }, { it.name }))
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Header: count + refresh + attribution
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = WtaSpacing.ScreenHorizontal, vertical = WtaSpacing.Small),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = Strings.aiCatalogSource,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (state is ModelCatalogState.Loaded) {
+                    Text(
+                        text = Strings.aiCatalogCount.format(state.modelCount),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            IconButton(onClick = { scope.launch { repo.refresh(force = true) } }) {
+                Icon(Icons.Outlined.Refresh, contentDescription = Strings.aiCatalogRefresh)
+            }
+        }
+
+        // Search
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = { searchQuery = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = WtaSpacing.ScreenHorizontal),
+            placeholder = { Text(Strings.aiCatalogSearchHint) },
+            singleLine = true
+        )
+
+        // Provider filter
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = WtaSpacing.ScreenHorizontal, vertical = WtaSpacing.Small),
+            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+        ) {
+            FilterChip(
+                selected = selectedProvider == null,
+                onClick = { selectedProvider = null },
+                label = { Text(Strings.aiCatalogAllProviders) }
+            )
+            providers.forEach { p ->
+                FilterChip(
+                    selected = selectedProvider == p.id,
+                    onClick = { selectedProvider = if (selectedProvider == p.id) null else p.id },
+                    label = { Text(p.name) }
+                )
+            }
+        }
+
+        // Capability filter
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = WtaSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+        ) {
+            CapabilityFilter.entries.forEach { f ->
+                FilterChip(
+                    selected = capabilityFilter == f,
+                    onClick = { capabilityFilter = f },
+                    label = { Text(catalogCapabilityLabel(f)) }
+                )
+            }
+        }
+
+        Spacer(Modifier.padding(top = WtaSpacing.Small))
+
+        when {
+            state is ModelCatalogState.Loading && allModels.isEmpty() -> {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    CircularProgressIndicator()
+                    Spacer(Modifier.padding(top = WtaSpacing.Medium))
+                    Text(Strings.aiCatalogLoading, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            state is ModelCatalogState.Error && allModels.isEmpty() -> {
+                Column(
+                    modifier = Modifier.fillMaxSize().padding(WtaSpacing.ScreenHorizontal),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(state.message, color = MaterialTheme.colorScheme.error)
+                    Spacer(Modifier.padding(top = WtaSpacing.Small))
+                    Button(onClick = { scope.launch { repo.refresh(force = true) } }) {
+                        Text(Strings.aiCatalogRefresh)
+                    }
+                }
+            }
+            filtered.isEmpty() -> {
+                Text(
+                    text = Strings.aiCatalogEmpty,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(WtaSpacing.ScreenHorizontal),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        horizontal = WtaSpacing.ScreenHorizontal,
+                        vertical = WtaSpacing.Small
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
+                ) {
+                    items(filtered, key = { "${it.providerId}/${it.id}" }) { model ->
+                        CatalogModelRow(
+                            model = model,
+                            canAdd = apiKeys.isNotEmpty(),
+                            onAdd = { modelToAdd = model }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    modelToAdd?.let { model ->
+        CatalogAddModelDialog(
+            model = model,
+            apiKeys = apiKeys,
+            onDismiss = { modelToAdd = null },
+            onConfirm = { key, alias ->
+                scope.launch {
+                    val saved = buildSavedModel(model, key, alias)
+                    if (configManager.saveModel(saved)) {
+                        snackbarHostState.showSnackbar(
+                            Strings.aiCatalogAdded.format(model.name),
+                            duration = SnackbarDuration.Short
+                        )
+                    } else {
+                        snackbarHostState.showSnackbar(
+                            Strings.saveFailed,
+                            duration = SnackbarDuration.Short
+                        )
+                    }
+                    modelToAdd = null
+                }
+            }
+        )
+    }
+}
+
+private fun buildSavedModel(model: CatalogModel, key: ApiKeyConfig, alias: String?): SavedModel {
+    val aiModel = AiModel(
+        id = model.id,
+        name = model.name,
+        provider = key.provider,
+        capabilities = model.capabilities,
+        contextLength = model.contextLength.takeIf { it > 0 } ?: 4096,
+        inputPrice = model.inputPrice,
+        outputPrice = model.outputPrice
+    )
+    val category = aiModel.capabilities.firstOrNull() ?: ModelCapability.TEXT
+    val featureMappings = mapOf(
+        category to AiFeature.entries.filter { it.defaultCapabilities.contains(category) }.toSet()
+    )
+    return SavedModel(
+        model = aiModel,
+        apiKeyId = key.id,
+        alias = alias?.ifBlank { null },
+        capabilities = listOf(category),
+        featureMappings = featureMappings
+    )
+}
+
+@Composable
+private fun CatalogModelRow(
+    model: CatalogModel,
+    canAdd: Boolean,
+    onAdd: () -> Unit
+) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(WtaSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = model.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1
+                )
+                Text(
+                    text = model.providerName,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.padding(top = 2.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                    if (model.supportsVision) CatalogBadge(Strings.aiCatalogBadgeVision)
+                    if (model.reasoning) CatalogBadge(Strings.aiCatalogBadgeReasoning)
+                    if (model.toolCall) CatalogBadge(Strings.aiCatalogBadgeToolCall)
+                    if (model.isImageGeneration) CatalogBadge(Strings.aiCatalogBadgeImageGen)
+                }
+                val meta = buildList {
+                    if (model.contextLength > 0) add(Strings.aiCatalogContext.format(model.contextLength))
+                    if (model.inputPrice > 0.0 || model.outputPrice > 0.0)
+                        add(Strings.aiCatalogPrice.format(model.inputPrice, model.outputPrice))
+                }.joinToString(" · ")
+                if (meta.isNotBlank()) {
+                    Spacer(Modifier.padding(top = 2.dp))
+                    Text(
+                        text = meta,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Spacer(Modifier.width(WtaSpacing.Small))
+            IconButton(onClick = onAdd, enabled = canAdd) {
+                Icon(Icons.Outlined.Add, contentDescription = Strings.aiCatalogAdd)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CatalogBadge(label: String) {
+    Surface(
+        shape = MaterialTheme.shapes.extraSmall,
+        color = MaterialTheme.colorScheme.secondaryContainer
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer
+        )
+    }
+}
+
+@Composable
+private fun CatalogAddModelDialog(
+    model: CatalogModel,
+    apiKeys: List<ApiKeyConfig>,
+    onDismiss: () -> Unit,
+    onConfirm: (ApiKeyConfig, String?) -> Unit
+) {
+    var selectedKey by remember { mutableStateOf(apiKeys.firstOrNull()) }
+    var alias by remember { mutableStateOf("") }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(modifier = Modifier.padding(WtaSpacing.Medium)) {
+                Text(
+                    text = Strings.aiCatalogAddTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(Modifier.padding(top = WtaSpacing.Small))
+                Text(
+                    text = "${model.name} · ${model.providerName}",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(Modifier.padding(top = WtaSpacing.Medium))
+                Text(
+                    text = Strings.aiCatalogPickKey,
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Spacer(Modifier.padding(top = WtaSpacing.Small))
+                LazyColumn(modifier = Modifier.heightIn(max = 220.dp)) {
+                    items(apiKeys, key = { it.id }) { key ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = selectedKey?.id == key.id,
+                                    onClick = { selectedKey = key }
+                                )
+                                .padding(vertical = WtaSpacing.Tiny),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = selectedKey?.id == key.id,
+                                onClick = { selectedKey = key }
+                            )
+                            Spacer(Modifier.width(WtaSpacing.Small))
+                            Text(
+                                text = key.displayName,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.padding(top = WtaSpacing.Small))
+                OutlinedTextField(
+                    value = alias,
+                    onValueChange = { alias = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text(Strings.aiCatalogAliasHint) },
+                    singleLine = true
+                )
+                Spacer(Modifier.padding(top = WtaSpacing.Medium))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onDismiss) { Text(Strings.btnCancel) }
+                    Spacer(Modifier.width(WtaSpacing.Small))
+                    Button(
+                        onClick = { selectedKey?.let { onConfirm(it, alias) } },
+                        enabled = selectedKey != null
+                    ) { Text(Strings.aiCatalogAdd) }
+                }
+            }
+        }
+    }
+}
+
+private fun catalogCapabilityLabel(filter: CapabilityFilter): String = when (filter) {
+    CapabilityFilter.ALL -> Strings.aiCatalogAllProviders
+    CapabilityFilter.VISION -> Strings.aiCatalogBadgeVision
+    CapabilityFilter.REASONING -> Strings.aiCatalogBadgeReasoning
+    CapabilityFilter.TOOL_CALL -> Strings.aiCatalogBadgeToolCall
+    CapabilityFilter.IMAGE_GEN -> Strings.aiCatalogBadgeImageGen
+}


### PR DESCRIPTION
Fixes #386

## Summary

Step 2 of the models.dev integration (after the registry swap in #385). Refactors AI Settings into a tab layout and adds a model catalog browser backed by models.dev.

## What changed

- **`AiSettingsScreen`**: replace the stacked sections with a `TabRow` of three tabs — **API Keys**, **Saved Models**, and a new **Model Catalog**.
- **New `ModelCatalogSection`**: browse/search the models.dev catalog, filter by provider and by capability (vision / reasoning / tool-call / image-gen); add a model by picking one of the user's API keys — the model is saved with accurate capabilities, context length, and pricing from the catalog (`featureMappings` derived as in the existing add-model flow).
- **`Strings`**: catalog UI strings in all 10 languages.

## Notes

- The catalog data comes from `ModelsDevRepository` (#385): cached (24h TTL), loaded synchronously from cache + refreshed asynchronously; loading/error/empty states are handled.
- Adding requires ≥1 API key (the add button is disabled otherwise), matching the existing add-model behavior.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: three tabs render; catalog search + provider/capability filters work; adding a catalog model with a key saves it with correct metadata