### PR TITLE
fix(agent): don't lose permission/choice prompts (loop froze after a question)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/permission/PermissionPrompter.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/permission/PermissionPrompter.kt
@@ -1,19 +1,23 @@
 package com.webtoapp.core.agent.permission
 
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 class PermissionPrompter {
 
-    private val _requests = MutableSharedFlow<PermissionRequest>(replay = 0, extraBufferCapacity = 4)
-    val requests: SharedFlow<PermissionRequest> = _requests.asSharedFlow()
+    // Requests/choices are delivered to the UI through Channels (exposed as flows via
+    // receiveAsFlow) rather than replay-0 SharedFlows. A Channel guarantees each emitted
+    // request is received by the UI collector (buffered until consumed), so a request can
+    // never be lost to a subscribe/emit race — which previously left request()/askChoice()
+    // suspended forever on the response channel, freezing the agent loop after a prompt.
+    private val requestChannel = Channel<PermissionRequest>(Channel.UNLIMITED)
+    val requests: Flow<PermissionRequest> = requestChannel.receiveAsFlow()
 
-    private val _choices = MutableSharedFlow<ChoiceRequest>(replay = 0, extraBufferCapacity = 4)
-    val choices: SharedFlow<ChoiceRequest> = _choices.asSharedFlow()
+    private val choiceChannel = Channel<ChoiceRequest>(Channel.UNLIMITED)
+    val choices: Flow<ChoiceRequest> = choiceChannel.receiveAsFlow()
 
     private val responseChannel = Channel<Pair<String, PermissionResponse>>(Channel.UNLIMITED)
     private val choiceResponseChannel = Channel<Pair<String, ChoiceResponse>>(Channel.UNLIMITED)
@@ -21,7 +25,7 @@ class PermissionPrompter {
     private val singleFlight = Mutex()
 
     suspend fun request(req: PermissionRequest): PermissionResponse = singleFlight.withLock {
-        _requests.emit(req)
+        requestChannel.send(req)
 
         while (true) {
             val (id, resp) = responseChannel.receive()
@@ -35,7 +39,7 @@ class PermissionPrompter {
     }
 
     suspend fun askChoice(req: ChoiceRequest): ChoiceResponse = singleFlight.withLock {
-        _choices.emit(req)
+        choiceChannel.send(req)
         while (true) {
             val (id, resp) = choiceResponseChannel.receive()
             if (id == req.id) return resp

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -115,6 +115,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     private var service: AgentService? = null
     private var bound = false
     private var eventCollectionJob: Job? = null
+    private var permissionCollectionJob: Job? = null
+    private var choiceCollectionJob: Job? = null
     private var streamingSessionId: String? = null
     private val streamText = StringBuilder()
     private val streamThinking = StringBuilder()
@@ -1328,12 +1330,16 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         eventCollectionJob = viewModelScope.launch {
             service?.events?.collect { handleAgentEvent(it) }
         }
-        viewModelScope.launch {
+        // The prompter delivers requests/choices via Channels (single consumer), so cancel
+        // any previous collectors before starting new ones to avoid competing consumers.
+        permissionCollectionJob?.cancel()
+        permissionCollectionJob = viewModelScope.launch {
             service?.permissionPrompter?.requests?.collect { req ->
                 _ui.update { it.copy(pendingPermission = req) }
             }
         }
-        viewModelScope.launch {
+        choiceCollectionJob?.cancel()
+        choiceCollectionJob = viewModelScope.launch {
             service?.permissionPrompter?.choices?.collect { req ->
                 _ui.update { it.copy(pendingChoice = req) }
             }
@@ -1770,6 +1776,8 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     override fun onCleared() {
         super.onCleared()
         eventCollectionJob?.cancel()
+        permissionCollectionJob?.cancel()
+        choiceCollectionJob?.cancel()
         if (bound) runCatching { ctx.unbindService(connection) }
     }
 


### PR DESCRIPTION
Fixes #388

## Summary

Fixes the agentic loop freezing right after the agent asks a question (`AskUserQuestion`) or prompts for a tool permission.

## Root cause

`PermissionPrompter` delivered permission/choice requests to the UI via `MutableSharedFlow(replay = 0)`. With `replay = 0`, an emission made while the UI collector isn't actively subscribed is buffered but **never replayed** to a (re)subscriber. If the request/choice was lost to that subscribe/emit race, `request()`/`askChoice()` waited forever on its response channel (the UI never showed the prompt → no response ever came), leaving the engine suspended and the loop frozen right after the prompt.

## Fix

- Deliver requests/choices through `Channel`s (exposed via `receiveAsFlow()`) so each emitted request is guaranteed to reach the UI collector (buffered until consumed) — no more lost emission. The `singleFlight` mutex (one prompt at a time) is unchanged.
- Track the permission/choice collector jobs in `AgentViewModel` (cancel on re-attach and in `onCleared`) so a service reconnect doesn't leave competing consumers on the single-consumer channels.

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [ ] Manual: agent asks a question → dialog appears → answering resumes the loop (no freeze)