### PR TITLE
fix(ui): unify card title font sizes in FloatingWindow/DNS/AutoStart

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/AutoStartCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/AutoStartCard.kt
@@ -139,7 +139,7 @@ fun AutoStartCard(
                         Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
                             Text(
                                 Strings.bootAutoStart,
-                                style = MaterialTheme.typography.bodyLarge
+                                style = MaterialTheme.typography.bodyMedium
                             )
                             Text(
                                 Strings.bootAutoStartHint,
@@ -197,7 +197,7 @@ fun AutoStartCard(
                         Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
                             Text(
                                 Strings.scheduledAutoStart,
-                                style = MaterialTheme.typography.bodyLarge
+                                style = MaterialTheme.typography.bodyMedium
                             )
                             Text(
                                 Strings.scheduledAutoStartHint,

--- a/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/DnsConfigCard.kt
@@ -123,6 +123,7 @@ fun DnsConfigCard(
                     WtaSettingRow(
                         title = Strings.dnsBypassSystemDns,
                         subtitle = Strings.dnsBypassSystemDnsDesc,
+                        titleStyle = MaterialTheme.typography.bodyMedium,
                         onClick = {
                             onDnsConfigChange(dnsConfig.copy(bypassSystemDns = !dnsConfig.bypassSystemDns))
                         },
@@ -140,6 +141,7 @@ fun DnsConfigCard(
                         title = Strings.dnsEchLabel,
                         subtitle = Strings.dnsEchDesc,
                         icon = Icons.Outlined.Shield,
+                        titleStyle = MaterialTheme.typography.bodyMedium,
                         onClick = { toggleEch(!dnsConfig.echEnabled) },
                         trailingMaxWidth = 200.dp
                     ) {
@@ -204,8 +206,8 @@ private fun DnsHeader(
             Spacer(Modifier.width(WtaSpacing.IconTextGap))
             Text(
                 text = Strings.dnsConfigTitle,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
             )
         }

--- a/app/src/main/java/com/webtoapp/ui/design/WtaDisplay.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaDisplay.kt
@@ -137,7 +137,7 @@ fun WtaIconTitle(
         Column {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium)
             )
             if (!subtitle.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(2.dp))
@@ -188,7 +188,7 @@ fun WtaIconTitle(
         Column {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold)
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium)
             )
             if (!subtitle.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(2.dp))

--- a/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaSettings.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -317,6 +318,7 @@ fun WtaSettingRow(
     tone: WtaRowTone = WtaRowTone.Normal,
     titleMaxLines: Int = 2,
     subtitleMaxLines: Int = 3,
+    titleStyle: TextStyle? = null,
     trailingMaxWidth: Dp = WtaSize.RowTrailingMaxWidth,
     contentPadding: PaddingValues = PaddingValues(
         horizontal = WtaSpacing.RowHorizontal,
@@ -388,7 +390,7 @@ fun WtaSettingRow(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                    style = titleStyle ?: MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
                     color = contentColor,
                     maxLines = titleMaxLines,
                     overflow = TextOverflow.Ellipsis


### PR DESCRIPTION
## Summary

Card **titles** of Floating Window, Custom DNS and Auto-Start settings render noticeably larger than every other feature card in the editor. Root cause: they render titles via `WtaFeatureCardHeader`/`DnsHeader` with `titleMedium` (16sp SemiBold), while the rest of the feature cards use `WtaToggleRow`/`WtaSettingRow` (`bodyLarge`, 15sp Medium).

## Changes

- `ui/design/WtaDisplay.kt` — `WtaIconTitle` (both overloads): `titleMedium` → `bodyLarge` + Medium. Also normalizes the shared-card title size for Notification, Background Run, Extension Module selector, Data Backup cards.
- `ui/components/DnsConfigCard.kt` — `DnsHeader` title `titleMedium` → `bodyLarge` + Medium; inner `WtaSettingRow`s pass the new optional `titleStyle = bodyMedium`.
- `ui/design/WtaSettings.kt` — `WtaSettingRow` gains optional `titleStyle` param (default unchanged for all other callers).
- `ui/components/AutoStartCard.kt` — inner toggle-row titles `bodyLarge` → `bodyMedium` (matching Floating Window rows).

## Test plan

- `:app:compileDebugKotlin` passed locally
- Shell template rebuilt (`:shell:assembleRelease` + `:app:syncShellTemplateApk`) since `ui/design` is synced into shell
- Visual check: the three cards' titles now match BGM / Splash / Toolbar card title size

Fixes #390