### PR TITLE
fix(agent): OpenAI-compat tool-call streaming dropped the tool call

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -84,13 +84,17 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
                             }
 
                             delta.getAsJsonArray("tool_calls")?.forEach { tcEl ->
-                                val tc = tcEl.asJsonObject; val idx = tc.get("index")?.asInt ?: 0
-                                val id = tc.get("id")?.asString ?: toolIndexToId[idx] ?: "call_$idx"
+                                val tc = tcEl.asJsonObject; val idx = tc.get("index")?.takeUnless { it.isJsonNull }?.asInt ?: 0
+                                val id = tc.get("id")?.takeUnless { it.isJsonNull }?.asString ?: toolIndexToId[idx] ?: "call_$idx"
                                 toolIndexToId[idx] = id
                                 val func = tc.getAsJsonObject("function")
-                                val name = func?.get("name")?.asString
-                                val args = func?.get("arguments")?.asString.orEmpty()
-                                if (name != null && toolNames[id] == null) { toolNames[id] = name; trySend(LlmEvent.ToolCallBegin(id, name)) }
+                                val name = func?.get("name")?.takeUnless { it.isJsonNull }?.asString?.takeIf { it.isNotEmpty() }
+                                val args = func?.get("arguments")?.takeUnless { it.isJsonNull }?.asString.orEmpty()
+                                if (name != null) {
+                                    if (toolNames[id] == null) { toolNames[id] = name; trySend(LlmEvent.ToolCallBegin(id, name)) }
+                                } else if (id !in toolNames) {
+                                    // Defer Begin until we learn the name from a later chunk.
+                                }
                                 if (args.isNotEmpty()) { toolArgsAccum.getOrPut(id) { StringBuilder() }.append(args); trySend(LlmEvent.ToolCallArgsDelta(id, args)) }
                             }
                             choice.get("finish_reason")?.takeUnless { it.isJsonNull }?.asString?.let { r ->


### PR DESCRIPTION
Fixes #394

## Summary

Fixes the agent loop ending immediately after the model decides to call a tool, on DeepSeek (via OpenRouter) and GPT — every conversation ran only one LLM request.

## Root cause

OpenAI-compatible providers emit the first tool-call streaming chunk as `{"function":{"name":"Write","arguments":null}}`. `OpenAiCompatProvider` parsed this with `func.get("arguments")?.asString`, which throws `UnsupportedOperationException` on JSON `null`. The whole-chunk `catch(_:Exception){}` swallowed it, so `ToolCallBegin` was never emitted → the engine saw zero pending tool calls → loop ended (`Completed`) even though `finish_reason` was `tool_calls`.

## Fix

Parse each field defensively (`takeUnless { it.isJsonNull }`), so a null `arguments` (first chunk) or null `id`/empty `name` (subsequent delta chunks) no longer kills the chunk.

## Verification

On-device with DeepSeek-V4-Flash via OpenRouter:
- Before: `turn=1 ... pendingToolCalls=0` → `no tool calls -> Completed`
- After: `turn=1 ... pendingToolCalls=1` → tool executes → `turn=2 start`

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:checkConfigFieldDrift` OK
- [x] On-device: agent now calls tools and the loop continues across turns