### PR TITLE
docs: reference the published documentation site in README and AGENTS.md

### DIFF
--- a/.github/docs/README_CN.md
+++ b/.github/docs/README_CN.md
@@ -23,6 +23,7 @@
   <a href="#能打包什么">能打包什么</a> ·
   <a href="#完整能力地图">完整能力地图</a> ·
   <a href="#模块市场">模块市场</a> ·
+  <a href="#文档站点">文档站点</a> ·
   <a href="#架构说明">架构说明</a> ·
   <a href="#从源码构建">构建</a>
 </p>
@@ -210,6 +211,26 @@ App 会同时拉取 `registry.json` 和 `submissions.json`,只展示两边都存
 这里保留的是模块市场的高层说明;真正的投稿规则、字段 schema、审核 Checklist 和 CI 校验细节统一写在 [`modules/README.md`](../../modules/README.md)。
 
 社区市场只承载 JS/CSS 扩展模块。**浏览器扩展(MV3)**不再是社区目录 —— **浏览器扩展** Tab 直接实时搜索 Chrome 网上应用店:输入关键词、浏览结果、通过现有的 CRX 下载链路按需安装。如果实时搜索不可达,也可以粘贴商店链接或 32 位扩展 ID 直接安装。实时搜索需要能访问 Google 的网络。
+
+## 文档站点
+
+官方文档站点发布在 **[shiaho777.github.io/web-to-app](https://shiaho777.github.io/web-to-app/)**,中英双语:
+
+| 板块 | 地址 | 内容 |
+| --- | --- | --- |
+| 使用指南 | [/zh/guide/introduction](https://shiaho777.github.io/web-to-app/zh/guide/introduction) | 快速上手、主界面、应用类型、单应用操作与通用配置、FAQ |
+| 开发者文档 | [/zh/developer/](https://shiaho777.github.io/web-to-app/zh/developer/) | 架构、导出管线、shell 同步、配置漂移、i18n、常见改动配方 |
+| 扩展开发 | [/zh/extensions/](https://shiaho777.github.io/web-to-app/zh/extensions/) | JS/CSS 模块、油猴脚本、Chrome MV3、API 参考、发布流程 |
+| English | [/](https://shiaho777.github.io/web-to-app/) | 上述全部页面的英文原版 |
+
+站点是基于 VitePress 的文档工程,源码在本仓库的 [`docs/`](../../docs/) 目录下。[`.github/workflows/docs-deploy.yml`](../workflows/docs-deploy.yml) 会在每次触及 `docs/` 的 push 到 `main` 时构建并发布到 GitHub Pages(Pull Request 只构建不部署,提前拦截坏链)。URL 路径与源文件一一对应——`/zh/guide/introduction` 对应 `docs/zh/guide/introduction.md`,英文原版是 `docs/guide/introduction.md`。本地预览:
+
+```bash
+cd docs
+npm ci
+npm run dev        # 本地开发服务器(热更新)
+npm run build      # 生产构建,输出到 docs/.vitepress/dist
+```
 
 ## 架构说明
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,12 @@ Instructions for coding agents working in this repository.
 | `shell/` | Runtime template. Built to `app/src/main/assets/template/webview_shell.apk` via `:shell:assembleRelease` + `:app:syncShellTemplateApk`. |
 | `clone-host/` | Host-side APK clone / identity reshape support library (compiled to a DEX asset). |
 | `modules/` | Module Market catalog (`registry.json` + per-module folders). |
+| `docs/` | VitePress documentation site (guide / developer / extensions, EN + ZH), published to https://shiaho777.github.io/web-to-app/ by `.github/workflows/docs-deploy.yml`. Site URL paths map 1:1 to files under `docs/` (`/zh/...` → `docs/zh/...`). |
 | `scripts/` | Build helpers and gates (`check_config_field_drift.py`). |
 
 Runtime Kotlin is authored under `app/` and synced into `shell` by `syncShellRuntimeSources`. Edit the `app/` source once; do not permanently fork copies under shell.
 
-User-facing product docs: `README.md`, `.github/docs/README_CN.md`, `.github/CONTRIBUTING.md`, `modules/README.md`.
+User-facing product docs: `README.md`, `.github/docs/README_CN.md`, `.github/CONTRIBUTING.md`, `modules/README.md`. The published documentation site is https://shiaho777.github.io/web-to-app/ (source: `docs/`, deployed by `.github/workflows/docs-deploy.yml`).
 
 ## How the main pieces connect
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   <a href="#capability-overview">Capability overview</a> ·
   <a href="#full-feature-map">Feature map</a> ·
   <a href="#module-market">Module market</a> ·
+  <a href="#documentation">Documentation</a> ·
   <a href="#architecture">Architecture</a> ·
   <a href="#build-from-source">Build</a>
 </p>
@@ -210,6 +211,26 @@ The app fetches both `registry.json` and `submissions.json` and only shows modul
 The high-level architecture lives here; the canonical submission rules, field schemas, reviewer checklist, and CI validation details live in [`modules/README.md`](modules/README.md).
 
 The community market carries only JS/CSS extension modules. **Browser extensions (MV3)** are no longer a community catalog — instead the **Browser Extensions** tab searches the Chrome Web Store live: type a keyword, browse results, and install on demand through the existing CRX pipeline. Live search requires a network that can reach Google.
+
+## Documentation
+
+The official documentation site is published at **[shiaho777.github.io/web-to-app](https://shiaho777.github.io/web-to-app/)**, in English and 简体中文:
+
+| Section | URL | Covers |
+| --- | --- | --- |
+| Guide | [/guide/introduction](https://shiaho777.github.io/web-to-app/guide/introduction) | Getting started, main screen, app types, per-app actions and common config, FAQ |
+| Developer | [/developer/](https://shiaho777.github.io/web-to-app/developer/) | Architecture, export pipeline, shell sync, config drift, i18n, change recipes |
+| Extensions | [/extensions/](https://shiaho777.github.io/web-to-app/extensions/) | JS/CSS modules, userscripts, Chrome MV3, API reference, publishing |
+| 简体中文 | [/zh/](https://shiaho777.github.io/web-to-app/zh/) | Full Chinese mirror of every page above |
+
+The site is a VitePress app authored under [`docs/`](docs/) in this repository. [`.github/workflows/docs-deploy.yml`](.github/workflows/docs-deploy.yml) builds and deploys it to GitHub Pages on every push to `main` that touches `docs/` (pull requests only build, to catch breakage early). URL paths map 1:1 to source files — `/guide/introduction` is `docs/guide/introduction.md`, and its Chinese twin `/zh/guide/introduction` is `docs/zh/guide/introduction.md`. To preview locally:
+
+```bash
+cd docs
+npm ci
+npm run dev        # dev server with hot reload
+npm run build      # production build into docs/.vitepress/dist
+```
 
 ## Architecture
 


### PR DESCRIPTION
Closes #398.

## User-visible effect

Readers of the GitHub READMEs (English and 简体中文) now see a **Documentation** section that links to the published documentation site at https://shiaho777.github.io/web-to-app/ and explains how it fits into the repository:

- Per-section URL table — Guide, Developer, Extensions, and the 简体中文 mirror (Chinese README links the `/zh/` paths; English README links the English paths).
- Where the docs source lives (`docs/`, VitePress), how it is deployed (`.github/workflows/docs-deploy.yml` → GitHub Pages on pushes to `main`; PRs only build), the 1:1 URL-to-source-file mapping, and the local preview commands (`npm run dev` / `npm run build`).

For agents and contributors, `AGENTS.md` gains the previously missing `docs/` row in the project-layout table (with the site URL and URL→file mapping) and a pointer to the published site in the product-docs line.

## Changes

| File | Change |
| --- | --- |
| `README.md` | TOC entry + new `## Documentation` section |
| `.github/docs/README_CN.md` | TOC entry + mirrored `## 文档站点` section (relative links adjusted for the file's location) |
| `AGENTS.md` | `docs/` row in project layout; published-site note in the product-docs line |

## Verification

- All URLs checked against the live VitePress config (`base = '/web-to-app/'`) and the actual page tree under `docs/` (~170 pages, EN + ZH).
- Docs-only change: no code, build, shell-sync, or packaging impact; `checkConfigFieldDrift` unaffected.