### PR TITLE
feat(agent): port manager + browser engine tools

### DIFF
--- a/.github/docs/README_CN.md
+++ b/.github/docs/README_CN.md
@@ -223,14 +223,7 @@ App 会同时拉取 `registry.json` 和 `submissions.json`,只展示两边都存
 | 扩展开发 | [/zh/extensions/](https://shiaho777.github.io/web-to-app/zh/extensions/) | JS/CSS 模块、油猴脚本、Chrome MV3、API 参考、发布流程 |
 | English | [/](https://shiaho777.github.io/web-to-app/) | 上述全部页面的英文原版 |
 
-站点是基于 VitePress 的文档工程,源码在本仓库的 [`docs/`](../../docs/) 目录下。[`.github/workflows/docs-deploy.yml`](../workflows/docs-deploy.yml) 会在每次触及 `docs/` 的 push 到 `main` 时构建并发布到 GitHub Pages(Pull Request 只构建不部署,提前拦截坏链)。URL 路径与源文件一一对应——`/zh/guide/introduction` 对应 `docs/zh/guide/introduction.md`,英文原版是 `docs/guide/introduction.md`。本地预览:
-
-```bash
-cd docs
-npm ci
-npm run dev        # 本地开发服务器(热更新)
-npm run build      # 生产构建,输出到 docs/.vitepress/dist
-```
+站点是基于 VitePress 的文档工程,源码在本仓库的 [`docs/`](../../docs/) 目录下。[`.github/workflows/docs-deploy.yml`](../workflows/docs-deploy.yml) 会在每次触及 `docs/` 的 push 到 `main` 时构建并发布到 GitHub Pages(Pull Request 只构建不部署,提前拦截坏链)。
 
 ## 架构说明
 

--- a/README.md
+++ b/README.md
@@ -223,14 +223,7 @@ The official documentation site is published at **[shiaho777.github.io/web-to-ap
 | Extensions | [/extensions/](https://shiaho777.github.io/web-to-app/extensions/) | JS/CSS modules, userscripts, Chrome MV3, API reference, publishing |
 | 简体中文 | [/zh/](https://shiaho777.github.io/web-to-app/zh/) | Full Chinese mirror of every page above |
 
-The site is a VitePress app authored under [`docs/`](docs/) in this repository. [`.github/workflows/docs-deploy.yml`](.github/workflows/docs-deploy.yml) builds and deploys it to GitHub Pages on every push to `main` that touches `docs/` (pull requests only build, to catch breakage early). URL paths map 1:1 to source files — `/guide/introduction` is `docs/guide/introduction.md`, and its Chinese twin `/zh/guide/introduction` is `docs/zh/guide/introduction.md`. To preview locally:
-
-```bash
-cd docs
-npm ci
-npm run dev        # dev server with hot reload
-npm run build      # production build into docs/.vitepress/dist
-```
+The site is a VitePress app authored under [`docs/`](docs/) in this repository. [`.github/workflows/docs-deploy.yml`](.github/workflows/docs-deploy.yml) builds and deploys it to GitHub Pages on every push to `main` that touches `docs/` (pull requests only build, to catch breakage early).
 
 ## Architecture
 

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
@@ -8,6 +8,7 @@ import com.webtoapp.core.agent.tool.builtin.CreateAppTool
 import com.webtoapp.core.agent.tool.builtin.CreateModuleTool
 import com.webtoapp.core.agent.tool.builtin.CreateShortcutTool
 import com.webtoapp.core.agent.tool.builtin.DeleteAppTool
+import com.webtoapp.core.agent.tool.builtin.DeleteEngineTool
 import com.webtoapp.core.agent.tool.builtin.DeleteFileTool
 import com.webtoapp.core.agent.tool.builtin.DuplicateAppTool
 import com.webtoapp.core.agent.tool.builtin.EditFileTool
@@ -16,15 +17,20 @@ import com.webtoapp.core.agent.tool.builtin.ExitPlanModeTool
 import com.webtoapp.core.agent.tool.builtin.ExportAabTool
 import com.webtoapp.core.agent.tool.builtin.ExportAppTool
 import com.webtoapp.core.agent.tool.builtin.GetAppTool
+import com.webtoapp.core.agent.tool.builtin.GetEngineStatusTool
 import com.webtoapp.core.agent.tool.builtin.GetModuleTool
 import com.webtoapp.core.agent.tool.builtin.GlobTool
 import com.webtoapp.core.agent.tool.builtin.GrepTool
+import com.webtoapp.core.agent.tool.builtin.KillAllPortsTool
+import com.webtoapp.core.agent.tool.builtin.KillPortTool
 import com.webtoapp.core.agent.tool.builtin.ListAppsTool
 import com.webtoapp.core.agent.tool.builtin.ListFilesTool
 import com.webtoapp.core.agent.tool.builtin.ListModulesTool
 import com.webtoapp.core.agent.tool.builtin.MoveToCategoryTool
 import com.webtoapp.core.agent.tool.builtin.ReadFileTool
 import com.webtoapp.core.agent.tool.builtin.ReadAppFileTool
+import com.webtoapp.core.agent.tool.builtin.ScanPortsTool
+import com.webtoapp.core.agent.tool.builtin.SelectEngineTool
 import com.webtoapp.core.agent.tool.builtin.ShareApkTool
 import com.webtoapp.core.agent.tool.builtin.TodoUpdateTool
 import com.webtoapp.core.agent.tool.builtin.TodoWriteTool
@@ -74,6 +80,13 @@ class ToolRegistryFactory(
         DeleteAppTool(),
         DuplicateAppTool(),
         ExportAabTool(),
+        // Ports & engine
+        ScanPortsTool(),
+        KillPortTool(),
+        KillAllPortsTool(),
+        GetEngineStatusTool(),
+        SelectEngineTool(),
+        DeleteEngineTool(),
         // Modules
         ListModulesTool(),
         GetModuleTool(),

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/PortEngineTools.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/PortEngineTools.kt
@@ -1,0 +1,124 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.Tool
+import com.webtoapp.core.agent.tool.ToolContext
+import com.webtoapp.core.agent.tool.ToolResult
+import com.webtoapp.core.engine.EngineManager
+import com.webtoapp.core.engine.EngineType
+import com.webtoapp.core.port.ProcessPortScanner
+
+class ScanPortsTool : Tool {
+    override val name = "ScanPorts"
+    override val description = """
+        Scan all allocated local ports and return running services (port, type, owner, responding status).
+        Use this to diagnose port conflicts or check which runtimes are active.
+    """.trimIndent()
+    override val parametersSchema: JsonElement = jsonSchema {}
+    override fun isReadOnly() = true
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val services = ProcessPortScanner.scanAllPorts(ctx.androidContext)
+        if (services.isEmpty()) return ToolResult.ok("No running services on any allocated ports.")
+        val lines = services.joinToString("\n") { s ->
+            "- port=${s.port} type=${s.type} owner=${s.owner} responding=${s.isResponding} pid=${s.pid}"
+        }
+        return ToolResult.ok("${services.size} running service(s):\n$lines")
+    }
+}
+
+class KillPortTool : Tool {
+    override val name = "KillPort"
+    override val description = "Kill the process occupying a specific port."
+    override val parametersSchema: JsonElement = jsonSchema {
+        integer("port", "The port number to free.", required = true)
+    }
+    override fun isReadOnly() = false
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("port")?.asString?.let { "Killing process on port $it" }
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val port = args.get("port")?.asInt ?: return ToolResult.error("KillPort: missing `port`.")
+        val killed = ProcessPortScanner.killProcess(port)
+        return if (killed) ToolResult.ok("Killed process on port $port.")
+        else ToolResult.error("KillPort: no process found on port $port or kill failed.")
+    }
+}
+
+class KillAllPortsTool : Tool {
+    override val name = "KillAllPorts"
+    override val description = "Kill all running local server processes (release all allocated ports)."
+    override val parametersSchema: JsonElement = jsonSchema {}
+    override fun isReadOnly() = false
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val count = ProcessPortScanner.killAllProcesses(ctx.androidContext)
+        return ToolResult.ok("Killed $count running service(s).")
+    }
+}
+
+class GetEngineStatusTool : Tool {
+    override val name = "GetEngineStatus"
+    override val description = """
+        Check the status of browser engines (System WebView and GeckoView). Returns availability,
+        download status, and disk size for each engine, plus the currently selected engine.
+    """.trimIndent()
+    override val parametersSchema: JsonElement = jsonSchema {
+        enum("engineType", listOf("SYSTEM_WEBVIEW", "GECKOVIEW"), "Check a specific engine only.")
+    }
+    override fun isReadOnly() = true
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val mgr = EngineManager.getInstance(ctx.androidContext)
+        val types = args.get("engineType")?.asString?.let { listOf(EngineType.valueOf(it)) }
+            ?: EngineType.entries
+        val lines = types.joinToString("\n") { t ->
+            val status = mgr.getEngineStatus(t)
+            val size = mgr.getEngineSize(t) / (1024 * 1024)
+            "- ${t.name}: status=$status, size=${size}MB, available=${mgr.isEngineAvailable(t)}"
+        }
+        val selected = mgr.selectedEngine.value.name
+        return ToolResult.ok("Selected engine: $selected\n$lines")
+    }
+}
+
+class SelectEngineTool : Tool {
+    override val name = "SelectEngine"
+    override val description = """
+        Select the active browser engine. SYSTEM_WEBVIEW is always available.
+        GECKOVIEW requires downloading ~55MB of native libraries on first use.
+    """.trimIndent()
+    override val parametersSchema: JsonElement = jsonSchema {
+        enum("engineType", listOf("SYSTEM_WEBVIEW", "GECKOVIEW"), "The engine to activate.", required = true)
+    }
+    override fun isReadOnly() = false
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("engineType")?.asString?.let { "Selecting engine $it" }
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val typeName = args.get("engineType")?.asString ?: return ToolResult.error("SelectEngine: missing `engineType`.")
+        val type = runCatching { EngineType.valueOf(typeName) }.getOrNull()
+            ?: return ToolResult.error("SelectEngine: unknown engine `$typeName`.")
+        val mgr = EngineManager.getInstance(ctx.androidContext)
+        if (type == EngineType.GECKOVIEW && !mgr.isEngineAvailable(type)) {
+            return ToolResult.error("SelectEngine: GeckoView is not downloaded yet. Ask the user to download it from Browser Kernel settings.")
+        }
+        mgr.selectEngine(type)
+        return ToolResult.ok("Active engine set to ${type.name}.")
+    }
+}
+
+class DeleteEngineTool : Tool {
+    override val name = "DeleteEngine"
+    override val description = "Delete a downloaded browser engine (e.g. GeckoView) to free disk space."
+    override val parametersSchema: JsonElement = jsonSchema {
+        enum("engineType", listOf("GECKOVIEW"), "The engine to delete.", required = true)
+    }
+    override fun isReadOnly() = false
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("engineType")?.asString?.let { "Deleting engine $it" }
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val typeName = args.get("engineType")?.asString ?: return ToolResult.error("DeleteEngine: missing `engineType`.")
+        val type = runCatching { EngineType.valueOf(typeName) }.getOrNull()
+            ?: return ToolResult.error("DeleteEngine: unknown engine `$typeName`.")
+        val mgr = EngineManager.getInstance(ctx.androidContext)
+        return if (mgr.deleteEngine(type)) ToolResult.ok("Deleted ${type.name} engine.")
+        else ToolResult.error("DeleteEngine: failed to delete ${type.name} (not downloaded?).")
+    }
+}


### PR DESCRIPTION
Fixes #402

6 new tools: ScanPorts, KillPort, KillAllPorts (ProcessPortScanner), GetEngineStatus, SelectEngine, DeleteEngine (EngineManager).

- [x] compileDebugKotlin, testDebugUnitTest, checkConfigFieldDrift pass