### PR TITLE
fix(agent): multi-select choice options only allow picking one

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/agent/components/PermissionDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/PermissionDialogs.kt
@@ -175,9 +175,12 @@ fun ChoiceBottomSheet(
                             multi = q.multiSelect,
                             onToggle = {
                                 if (q.multiSelect) {
-                                    val set = multiSelections.getOrPut(qIdx) { mutableSetOf() }
-                                    if (!set.add(opt.label)) set.remove(opt.label)
-                                    multiSelections[qIdx] = set
+                                    val current = multiSelections[qIdx] ?: emptySet()
+                                    multiSelections[qIdx] = if (opt.label in current) {
+                                        current - opt.label
+                                    } else {
+                                        current + opt.label
+                                    }.toMutableSet()
                                 } else {
                                     singleSelections[qIdx] = opt.label
                                 }


### PR DESCRIPTION
Fixes #411

Root cause:  does not detect mutations to the same  reference. The multi-select toggle mutated the existing set and re-assigned the same reference, so the UI never recomposed.

Fix: create a new  on each toggle.