### PR TITLE
docs: sync documentation with Agent tool system, remove stale skill references

### DIFF
--- a/.github/docs/README_CN.md
+++ b/.github/docs/README_CN.md
@@ -61,7 +61,7 @@
 | **本地运行时** | 原生 Node.js 18.20、PHP 8.4 + Composer 2.10、Python 3.14、官方 Go 1.26、WordPress 7.x over SQLite |
 | **扩展能力** | 内置模块、`GM_*` 油猴脚本、MV3 Chrome 扩展、Chrome 网上应用店实时搜索 |
 | **APK/AAB 产物** | 设备端 V1/V2/V3 签名、Google Play AAB 导出(自动改写 targetSdk)、密钥库管理 |
-| **Agent** | 通过 prompt 生成网页、扩展模块、油猴脚本和本地运行时项目;429/5xx 自动重试 |
+| **Agent** | 通过 40+ 工具全面操控应用:生成、构建、导出、端口/引擎/运行时管理、应用克隆、广告拦截等;429/5xx 自动重试 |
 | **宿主语言** | **10 种界面语言** —— 中文 · English · العربية · Português · Español · Français · Deutsch · Русский · 日本語 · 한국어(阿语 RTL) |
 
 ---
@@ -137,7 +137,7 @@ WebToApp 的开关非常多。下面按使用场景分组,并用可折叠区段�
 - **MV3 Chrome 扩展运行时**,支持 manifest 内容脚本在 isolated 或 main world 注入,并提供覆盖 runtime、storage、tabs、scripting 和 declarative network request 解析的 `chrome.*` polyfill。
 - **应用内 Chrome 网上应用店搜索** —— 按关键词浏览并安装浏览器扩展(也可粘贴商店链接 / 扩展 ID),离线时回退到手动导入。
 - **分享码**(`WTA1:` gzip + Base64)和 ZXing 二维码传播。
-- **Agent** skill 可生成扩展模块、油猴脚本、MV3 扩展、前端应用和本地运行时项目;对 429/5xx 自动退避重试,计划模式退出会真正停住等待用户确认。
+- **Agent** —— 工具调用型助手,内置 40+ 工具覆盖应用全部功能:创建/编辑/构建/导出应用、管理端口与浏览器引擎、安装/清理运行时、广告拦截 hosts 规则、使用统计、应用克隆、批量导入、Play 合规检查、模块开发。计划模式等待用户确认;对 429/5xx 自动退避重试。
 
 </details>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,41 @@ Checklist in order:
 2. Go: ensure `injectGoExecLoaderNativeLib` embeds `libgo_exec_loader.so`.
 3. `NodeService` runs in a dedicated `:nodejs` OS process so V8 lifecycle is isolated from the host.
 
+### 11. Change a feature that has an Agent tool
+
+The in-app Agent exposes 40+ tools that wrap host service classes. When you change a feature, trace the tool chain:
+
+```text
+LLM response (tool_calls)
+  → AgentEngine.executeToolCall()
+  → PermissionPrompter (write tools ask user; read-only run silently)
+  → Tool.execute(args, ctx)
+  → Service class (ApkBuilder, AppExporter, PortManager, EngineManager, AdBlocker, …)
+  → ToolResult → back to LLM
+```
+
+Checklist when touching a feature that an Agent tool wraps:
+
+1. **API signature drift.** If the service class constructor, method signature, or return type changes, update the tool's `execute()` in `app/.../agent/tool/builtin/`. A stale call compiles only if the old overload still exists; otherwise it's a build break.
+2. **`parametersSchema` ↔ `execute()` alignment.** The JSON schema advertised to the LLM must match what `execute()` actually reads from `args`. Adding a parameter to the service call without exposing it in the schema means the LLM can never pass it.
+3. **`description` accuracy.** The LLM decides *when* and *how* to call a tool solely from `description` + `parametersSchema`. If the feature's behavior changed, update the description text — a misleading description causes silent misuse.
+4. **`isReadOnly()` correctness.** `true` → runs without user confirmation; `false` → triggers `PermissionPrompter` dialog. If a tool gains write side-effects, flip it to `false`.
+5. **Registration.** New tools must be added to `ToolRegistryFactory.baseTools()` (grouped by domain comment). Forgotten registration = tool invisible to the LLM.
+6. **Removed features.** If a feature is deleted, remove or disable its tool. A tool that calls a dead class crashes at runtime inside the agent loop.
+7. **Host-only.** Agent tools live under `core/agent/` and are never shell-synced. Do not add them to `syncShellRuntimeSources`.
+
+Key paths:
+
+| Concern | Path |
+|---------|------|
+| Tool interface | `app/.../agent/tool/Tool.kt` |
+| Tool registry | `app/.../agent/tool/ToolRegistryFactory.kt` |
+| Tool context (services access) | `app/.../agent/tool/ToolContext.kt` |
+| Built-in tools (by domain) | `app/.../agent/tool/builtin/*.kt` |
+| Agent loop / execution | `app/.../agent/engine/AgentEngine.kt` |
+| Permission prompt (Channel-based) | `app/.../agent/permission/PermissionPrompter.kt` |
+| LLM provider (SSE streaming) | `app/.../agent/llm/OpenAiCompatProvider.kt` |
+
 ---
 
 ## Easy-to-miss points
@@ -211,6 +246,7 @@ Checklist in order:
 - **Runtime permissions are feature-driven.** `RuntimePermissionSync` derives the permission list from enabled features; do not revert to a static template.
 - **Splash preview media path.** Preview reads splash media from the host filesystem (`splashMediaPath`); export packages it into assets. Do not hardcode `assets/splash_media.*` as the only source.
 - **Port conflict policy.** Local server runtimes must allocate through `PortManager` and clean up on stop; do not bind ports directly.
+- **Agent tool ↔ service drift.** When a service class API changes, the corresponding Agent tool in `core/agent/tool/builtin/` must be updated in the same PR. A stale tool either fails to compile or silently passes wrong arguments at runtime. Check `ToolRegistryFactory.baseTools()` for the full tool list.
 
 ---
 
@@ -265,3 +301,4 @@ Landed:
 - Config field drift detection (`checkConfigFieldDrift`)
 - Module Market: Chrome Web Store live search + GreasyFork browse
 - Code editor find-and-replace
+- Agent tool system: 40+ tools (app lifecycle, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files) with Channel-based permission prompting, per-section SSE parse resilience, and plan mode

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A quick scan of what's in the box. Each links to the detailed feature map below.
 | **Local runtimes** | Native Node.js 18.20, PHP 8.4 + Composer 2.10, Python 3.14, official Go 1.26, WordPress 7.x over SQLite |
 | **Extensions** | Built-in modules, userscripts with `GM_*`, MV3 Chrome extensions, live Chrome Web Store search |
 | **APK/AAB output** | On-device V1/V2/V3 signing, Google Play AAB export with targetSdk rewrite, keystore management |
-| **Agent** | Prompt-driven generation of web apps, modules, userscripts, and runtime projects; auto-retry on 429/5xx |
+| **Agent** | Full-app automation via 40+ tools: generate, build, export, manage ports/engines/runtimes, clone apps, ad-block rules, and more; auto-retry on 429/5xx |
 | **Host languages** | **10 UI languages** — 中文 · English · العربية · Português · Español · Français · Deutsch · Русский · 日本語 · 한국어 (Arabic RTL) |
 
 ---
@@ -137,7 +137,7 @@ WebToApp has a large number of switches. The sections below group them by use ca
 - **MV3 Chrome extension runtime** for manifest content scripts in isolated or main worlds, with `chrome.*` polyfills for runtime, storage, tabs, scripting, and declarative network-request parsing.
 - **In-app Chrome Web Store search** — browse and install browser extensions by keyword (or paste a store URL / extension ID), with offline fallback to manual import.
 - **Export codes** (`WTA1:` gzip + Base64) and QR sharing via ZXing.
-- **Agent** skills to generate modules, userscripts, MV3 extensions, front-end apps, and local runtime projects, with automatic retry/backoff on 429/5xx and plan-mode exit that waits for user approval.
+- **Agent** — a tool-calling assistant with 40+ built-in tools covering the entire app surface: create/edit/build/export apps, manage ports and browser engines, install/clear runtimes, ad-block hosts rules, usage stats, app cloning, batch import, Play policy checks, and module development. Plan mode waits for user approval; automatic retry/backoff on 429/5xx.
 
 </details>
 

--- a/docs/guide/more-features/agent.md
+++ b/docs/guide/more-features/agent.md
@@ -1,15 +1,25 @@
 # Agent
 
-A prompt-driven coding assistant inside the app. Open it from [⋮ → Agent](/guide/main-screen/more).
+A tool-calling assistant inside the app that can operate the entire WebToApp surface. Open it from [⋮ → Agent](/guide/main-screen/more).
 
-## What it generates
+## What it can do
 
-Web apps, extension modules, userscripts, MV3 Chrome extensions, and local runtime projects.
+Beyond generating web apps, extension modules, userscripts, MV3 Chrome extensions, and local runtime projects, the Agent can directly perform actions across the app:
+
+- **App lifecycle** — create, edit, duplicate, delete, build APK/AAB, export, share, create shortcuts, move to categories.
+- **Ports & engines** — scan/kill ports, check/select/delete browser engines (WebView, GeckoView).
+- **Runtimes** — check status, install, and clear caches for Node.js, PHP, Python, Go, WordPress, and the Linux environment.
+- **Ad-block** — view rule counts and sources, import/remove/enable/disable hosts subscriptions.
+- **Stats & health** — usage statistics, URL health checks.
+- **App modifier** — list installed apps, clone/rebrand apps, batch import from text, export templates.
+- **Build environment & compliance** — initialize the Linux build environment, install components, run Google Play policy checks.
+- **Modules** — list, create, and update extension modules.
+- **Files** — read, write, edit, delete, list, glob, and grep project files.
 
 ## Features
 
 - **Sessions** — each conversation has its own title and history.
-- **Skills** — built-in skills guide generation: `debug`, `explain`, `optimize`, `refactor`, `i18n`, `imagery`, plus stack-specific skills (`react-app`, `nodejs-app`, `php-app`, `python-app`, `go-app`, `vue-app`, `wordpress-app`, `html-app`, `multi-web-app`) and module skills (`module-js`, `module-style`, `module-userscript`, `module-chrome-mv3`). You can edit or add skills in the skill editor.
+- **40+ built-in tools** — grouped by domain (files, apps, lifecycle, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules). Read-only tools run without confirmation; write tools ask for permission first.
 - **Plan mode** — proposes a plan and waits for your approval before applying changes (shown with a plan-mode badge).
 - **Resilience** — automatic retry with backoff on 429/5xx responses.
 
@@ -19,4 +29,4 @@ Agent uses the model and keys configured in [AI Settings](/guide/more-features/a
 
 ## Notes
 
-Agent produces *source*. To install a generated extension, save it through the [Extension Modules](/guide/more-features/extension-modules) flow.
+Agent produces *source* and performs *actions*. To install a generated extension, save it through the [Extension Modules](/guide/more-features/extension-modules) flow.

--- a/docs/zh/guide/more-features/agent.md
+++ b/docs/zh/guide/more-features/agent.md
@@ -1,22 +1,32 @@
 # Agent
 
-应用内的提示词驱动编码助手。从 [⋮ → Agent](/zh/guide/main-screen/more) 打开。
+应用内的工具调用型助手,可操控 WebToApp 的全部功能。从 [⋮ → Agent](/zh/guide/main-screen/more) 打开。
 
-## 能生成什么
+## 能做什么
 
-网页应用、扩展模块、油猴脚本、MV3 Chrome 扩展和本地运行时项目。
+除了生成网页应用、扩展模块、油猴脚本、MV3 Chrome 扩展和本地运行时项目之外,Agent 还能直接执行应用内的各种操作:
+
+- **应用生命周期** —— 创建、编辑、复制、删除、构建 APK/AAB、导出、分享、创建快捷方式、移动分类。
+- **端口与引擎** —— 扫描/终止端口,查看/切换/删除浏览器引擎(WebView、GeckoView)。
+- **运行时** —— 查看状态、安装、清理 Node.js、PHP、Python、Go、WordPress 和 Linux 环境的缓存。
+- **广告拦截** —— 查看规则数量和订阅源,导入/删除/启用/停用 hosts 订阅。
+- **统计与健康** —— 使用统计、URL 健康检查。
+- **应用修改器** —— 列出已安装应用、克隆/换壳应用、批量文本导入、导出模板。
+- **构建环境与合规** —— 初始化 Linux 构建环境、安装组件、运行 Google Play 合规检查。
+- **模块** —— 列出、创建、更新扩展模块。
+- **文件** —— 读取、写入、编辑、删除、列出、glob 和 grep 项目文件。
 
 ## 功能
 
 - **会话** —— 每段对话有自己的标题和历史。
-- **技能** —— 内置技能引导生成:`debug`、`explain`、`optimize`、`refactor`、`i18n`、`imagery`,加上各技术栈技能(`react-app`、`nodejs-app`、`php-app`、`python-app`、`go-app`、`vue-app`、`wordpress-app`、`html-app`、`multi-web-app`)和模块技能(`module-js`、`module-style`、`module-userscript`、`module-chrome-mv3`)。你可以在技能编辑器中编辑或添加技能。
+- **40+ 内置工具** —— 按功能域分组(文件、应用、生命周期、端口/引擎、hosts/运行时、统计/修改器/导入、构建环境/Play、模块)。只读工具无需确认直接执行;写入工具会先请求权限。
 - **计划模式** —— 先提出计划,等你批准后再应用改动(以计划模式徽标显示)。
 - **韧性** —— 遇到 429/5xx 响应自动退避重试。
 
 ## 配置
 
-Agent使用 [AI 设置](/zh/guide/more-features/ai-settings) 中配置的模型和密钥。
+Agent 使用 [AI 设置](/zh/guide/more-features/ai-settings) 中配置的模型和密钥。
 
 ## 说明
 
-Agent生成的是*源码*。要安装生成的扩展,请通过[扩展模块](/zh/guide/more-features/extension-modules)流程保存。
+Agent 既生成*源码*也执行*操作*。要安装生成的扩展,请通过[扩展模块](/zh/guide/more-features/extension-modules)流程保存。


### PR DESCRIPTION
Closes #415

## Summary

Syncs all documentation with the current Agent implementation (40+ tools, skills removed):

| File | Change |
|------|--------|
| `README.md` | Feature table: "Full-app automation via 40+ tools"; feature-map bullet: tool-calling assistant description |
| `.github/docs/README_CN.md` | Same in Chinese |
| `docs/guide/more-features/agent.md` | Rewrite: removed Skills section, added 9 tool-domain capability list, "40+ built-in tools" feature |
| `docs/zh/guide/more-features/agent.md` | Same in Chinese |
| `AGENTS.md` | New recipe #11 (Agent tool chain maintenance), easy-to-miss point, implementation snapshot entry |

## Verification

- `grep -rn "skill" docs/ README.md .github/docs/ AGENTS.md` → zero hits (excluding node_modules/dist)
- No code changes; docs-only PR