### PR TITLE
feat(ui): overhaul editor config cards and announcement system

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -594,6 +594,7 @@ class ApkBuilder(private val context: Context) {
             }
 
             val errorPageMediaPath = webApp.webViewConfig.errorPageConfig.customMediaPath
+            val announcementIconPath = webApp.announcement?.customIconPath
                 ?.takeIf { it.isNotBlank() && !it.startsWith("data:") && !it.startsWith("http") && !it.startsWith("file://") }
             val multiWebProjectDir = config.multiWebProjectId.takeIf { it.isNotBlank() }
                 ?.let { File(context.filesDir, "html_projects/$it") }
@@ -680,6 +681,7 @@ class ApkBuilder(private val context: Context) {
                             htmlProjectDir = htmlProjectDir,
                             staticPackDir = staticPackDir,
                             errorPageMediaPath = errorPageMediaPath,
+                            announcementIconPath = announcementIconPath,
                             perfConfig = perfConfig,
                             mode = ModifyApkMode.CONTENT_OVERLAY
                         ) { progress, stageMessage ->
@@ -718,6 +720,7 @@ class ApkBuilder(private val context: Context) {
                             htmlProjectDir = htmlProjectDir,
                             staticPackDir = staticPackDir,
                             errorPageMediaPath = errorPageMediaPath,
+                            announcementIconPath = announcementIconPath,
                             perfConfig = perfConfig,
                             mode = ModifyApkMode.FULL
                         ) { progress, stageMessage ->
@@ -759,6 +762,7 @@ class ApkBuilder(private val context: Context) {
                         htmlProjectDir = htmlProjectDir,
                         staticPackDir = staticPackDir,
                         errorPageMediaPath = errorPageMediaPath,
+                        announcementIconPath = announcementIconPath,
                         perfConfig = perfConfig,
                         mode = ModifyApkMode.FULL
                     ) { progress, stageMessage ->
@@ -1052,6 +1056,7 @@ class ApkBuilder(private val context: Context) {
         htmlProjectDir: File? = null,
         staticPackDir: File? = null,
         errorPageMediaPath: String? = null,
+        announcementIconPath: String? = null,
         perfConfig: com.webtoapp.core.linux.PerformanceOptimizer.OptimizeConfig? = null,
         mode: ModifyApkMode = ModifyApkMode.FULL,
         onProgress: (Int, String) -> Unit
@@ -1300,6 +1305,10 @@ class ApkBuilder(private val context: Context) {
 
                 if (errorPageMediaPath != null) {
                     addErrorPageMediaToAssets(zipOut, errorPageMediaPath, assetEncryptor, encryptionConfig)
+                }
+
+                if (config.announcement.hasCustomIcon && announcementIconPath != null) {
+                    addAnnouncementIconToAssets(zipOut, announcementIconPath, assetEncryptor, encryptionConfig)
                 }
 
                 if (config.statusBarBackgroundType == "IMAGE" && !config.statusBarBackgroundImage.isNullOrEmpty()) {
@@ -1571,6 +1580,32 @@ class ApkBuilder(private val context: Context) {
             }
         } catch (e: Exception) {
             AppLogger.e("ApkBuilder", "Failed to embed splash media: ${e.message}", e)
+        }
+    }
+
+    private fun addAnnouncementIconToAssets(
+        zipOut: ZipOutputStream,
+        iconPath: String,
+        encryptor: AssetEncryptor? = null,
+        encryptionConfig: EncryptionConfig = EncryptionConfig.DISABLED
+    ) {
+        val iconFile = File(iconPath)
+        if (!iconFile.exists() || !iconFile.canRead() || iconFile.length() == 0L) {
+            AppLogger.w("ApkBuilder", "Announcement icon skipped: invalid file $iconPath")
+            return
+        }
+        val assetPath = "announcement_icon.png"
+        try {
+            val bytes = iconFile.readBytes()
+            if (encryptionConfig.enabled && encryptor != null) {
+                val encrypted = encryptor.encrypt(bytes, assetPath)
+                writeEntryDeflated(zipOut, "assets/$assetPath.enc", encrypted)
+            } else {
+                writeEntryStoredSimple(zipOut, "assets/$assetPath", bytes)
+            }
+            AppLogger.d("ApkBuilder", "Announcement icon embedded: assets/$assetPath (${bytes.size} bytes)")
+        } catch (e: Exception) {
+            AppLogger.e("ApkBuilder", "Failed to embed announcement icon: ${e.message}", e)
         }
     }
 
@@ -3502,7 +3537,9 @@ private fun WebApp.buildAnnouncementBlock(): AnnouncementBlock = AnnouncementBlo
     triggerOnNoNetwork = announcement?.triggerOnNoNetwork ?: false,
     triggerIntervalMinutes = announcement?.triggerIntervalMinutes ?: 0,
     version = announcement?.version ?: 1,
-    triggerIntervalIncludeLaunch = announcement?.triggerIntervalIncludeLaunch ?: false
+    triggerIntervalIncludeLaunch = announcement?.triggerIntervalIncludeLaunch ?: false,
+    showIcon = announcement?.showIcon ?: true,
+    hasCustomIcon = !announcement?.customIconPath.isNullOrBlank()
 )
 
 private fun WebApp.buildAdsBlock(): AdsBlock = AdsBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -438,7 +438,9 @@ data class AnnouncementBlock(
     val triggerOnNoNetwork: Boolean = false,
     val triggerIntervalMinutes: Int = 0,
     val version: Int = 1,
-    val triggerIntervalIncludeLaunch: Boolean = false
+    val triggerIntervalIncludeLaunch: Boolean = false,
+    val showIcon: Boolean = true,
+    val hasCustomIcon: Boolean = false
 )
 
 data class AdsBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -62,6 +62,8 @@ internal object ApkConfigJsonFactory {
         "announcementTriggerIntervalMinutes" to announcement.triggerIntervalMinutes,
         "announcementVersion" to announcement.version,
         "announcementTriggerIntervalIncludeLaunch" to announcement.triggerIntervalIncludeLaunch,
+        "announcementShowIcon" to announcement.showIcon,
+        "announcementHasCustomIcon" to announcement.hasCustomIcon,
         "adsEnabled" to ads.enabled,
         "adBannerEnabled" to ads.bannerEnabled,
         "adBannerId" to ads.bannerId,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2393,6 +2393,10 @@ object Strings {
     val announcementStyleAccentDesc: String get() = StringsC.announcementStyleAccentDesc
     val announcementStyleDark: String get() = StringsC.announcementStyleDark
     val announcementStyleDarkDesc: String get() = StringsC.announcementStyleDarkDesc
+    val announcementShowIcon: String get() = StringsC.announcementShowIcon
+    val announcementShowIconHint: String get() = StringsC.announcementShowIconHint
+    val announcementCustomIcon: String get() = StringsC.announcementCustomIcon
+    val announcementRemoveCustomIcon: String get() = StringsC.announcementRemoveCustomIcon
     val langEnglish: String get() = StringsC.langEnglish
     val langJapanese: String get() = StringsC.langJapanese
     val langArabic: String get() = StringsC.langArabic
@@ -34480,29 +34484,29 @@ object StringsC {
     }
 
     val announcementStyleClean: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "简洁"
-        AppLanguage.ENGLISH -> "Clean"
-        AppLanguage.ARABIC -> "نظيف"
-        AppLanguage.PORTUGUESE -> "Limpo"
-        AppLanguage.SPANISH -> "Limpio"
-        AppLanguage.FRENCH -> "Épuré"
-        AppLanguage.GERMAN -> "Klar"
-        AppLanguage.RUSSIAN -> "Чистый"
-        AppLanguage.JAPANESE -> "クリーン"
-        AppLanguage.KOREAN -> "깔끔함"
+        AppLanguage.CHINESE -> "浅色"
+        AppLanguage.ENGLISH -> "Light"
+        AppLanguage.ARABIC -> "فاتح"
+        AppLanguage.PORTUGUESE -> "Claro"
+        AppLanguage.SPANISH -> "Claro"
+        AppLanguage.FRENCH -> "Clair"
+        AppLanguage.GERMAN -> "Hell"
+        AppLanguage.RUSSIAN -> "Светлый"
+        AppLanguage.JAPANESE -> "ライト"
+        AppLanguage.KOREAN -> "라이트"
     }
 
     val announcementStyleCleanDesc: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "清晰、克制、适合常规提示"
-        AppLanguage.ENGLISH -> "Clear and restrained for routine notices"
-        AppLanguage.ARABIC -> "واضح ومقتصد للإشعارات العادية"
-        AppLanguage.PORTUGUESE -> "Claro e contido para avisos rotineiros"
-        AppLanguage.SPANISH -> "Claro y contenido para avisos rutinarios"
-        AppLanguage.FRENCH -> "Clair et retenu pour les avis de routine"
-        AppLanguage.GERMAN -> "Klar und zurückhaltend für routinemäßige Hinweise"
-        AppLanguage.RUSSIAN -> "Чёткий и сдержанный для обычных уведомлений"
-        AppLanguage.JAPANESE -> "定例通知に適した明確で控えめなスタイル"
-        AppLanguage.KOREAN -> "일반 공지에 적합한 명확하고 절제된 스타일"
+        AppLanguage.CHINESE -> "清爽明亮，适合常规提示"
+        AppLanguage.ENGLISH -> "Bright and clean for routine notices"
+        AppLanguage.ARABIC -> "مشرق وواضح للإشعارات العادية"
+        AppLanguage.PORTUGUESE -> "Brilhante e limpo para avisos rotineiros"
+        AppLanguage.SPANISH -> "Brillante y limpio para avisos rutinarios"
+        AppLanguage.FRENCH -> "Lumineux et net pour les avis de routine"
+        AppLanguage.GERMAN -> "Hell und klar für routinemäßige Hinweise"
+        AppLanguage.RUSSIAN -> "Яркий и чистый для обычных уведомлений"
+        AppLanguage.JAPANESE -> "明るくクリーン、定例通知に最適"
+        AppLanguage.KOREAN -> "밝고 깔끔한 일반 공지 스타일"
     }
 
     val announcementStyleAccent: String get() = when (Strings.lang) {
@@ -34555,6 +34559,58 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Высокий контраст для важных оповещений"
         AppLanguage.JAPANESE -> "重要な通知に適した高コントラスト"
         AppLanguage.KOREAN -> "중요한 알림에 적합한 고대비"
+    }
+
+    val announcementShowIcon: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "显示图标"
+        AppLanguage.ENGLISH -> "Show Icon"
+        AppLanguage.ARABIC -> "إظهار الأيقونة"
+        AppLanguage.PORTUGUESE -> "Mostrar Ícone"
+        AppLanguage.SPANISH -> "Mostrar Icono"
+        AppLanguage.FRENCH -> "Afficher l'icône"
+        AppLanguage.GERMAN -> "Symbol anzeigen"
+        AppLanguage.RUSSIAN -> "Показать значок"
+        AppLanguage.JAPANESE -> "アイコンを表示"
+        AppLanguage.KOREAN -> "아이콘 표시"
+    }
+
+    val announcementShowIconHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "在弹窗左上角显示图标"
+        AppLanguage.ENGLISH -> "Show icon in the top-left of the popup"
+        AppLanguage.ARABIC -> "إظهار الأيقونة في أعلى يسار النافذة"
+        AppLanguage.PORTUGUESE -> "Mostrar ícone no canto superior esquerdo"
+        AppLanguage.SPANISH -> "Mostrar icono en la esquina superior izquierda"
+        AppLanguage.FRENCH -> "Afficher l'icône en haut à gauche"
+        AppLanguage.GERMAN -> "Symbol oben links im Popup anzeigen"
+        AppLanguage.RUSSIAN -> "Показать значок в левом верхнем углу"
+        AppLanguage.JAPANESE -> "ポップアップの左上にアイコンを表示"
+        AppLanguage.KOREAN -> "팝업 왼쪽 상단에 아이콘 표시"
+    }
+
+    val announcementCustomIcon: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "自定义图标"
+        AppLanguage.ENGLISH -> "Custom Icon"
+        AppLanguage.ARABIC -> "أيقونة مخصصة"
+        AppLanguage.PORTUGUESE -> "Ícone Personalizado"
+        AppLanguage.SPANISH -> "Icono Personalizado"
+        AppLanguage.FRENCH -> "Icône personnalisée"
+        AppLanguage.GERMAN -> "Eigenes Symbol"
+        AppLanguage.RUSSIAN -> "Свой значок"
+        AppLanguage.JAPANESE -> "カスタムアイコン"
+        AppLanguage.KOREAN -> "커스텀 아이콘"
+    }
+
+    val announcementRemoveCustomIcon: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "移除自定义图标"
+        AppLanguage.ENGLISH -> "Remove Custom Icon"
+        AppLanguage.ARABIC -> "إزالة الأيقونة المخصصة"
+        AppLanguage.PORTUGUESE -> "Remover Ícone Personalizado"
+        AppLanguage.SPANISH -> "Eliminar Icono Personalizado"
+        AppLanguage.FRENCH -> "Supprimer l'icône personnalisée"
+        AppLanguage.GERMAN -> "Eigenes Symbol entfernen"
+        AppLanguage.RUSSIAN -> "Удалить свой значок"
+        AppLanguage.JAPANESE -> "カスタムアイコンを削除"
+        AppLanguage.KOREAN -> "커스텀 아이콘 제거"
     }
 
     val langEnglish: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -250,6 +250,12 @@ data class ShellConfig(
     @SerializedName("announcementTriggerIntervalIncludeLaunch")
     val announcementTriggerIntervalIncludeLaunch: Boolean = false,
 
+    @SerializedName("announcementShowIcon")
+    val announcementShowIcon: Boolean = true,
+
+    @SerializedName("announcementHasCustomIcon")
+    val announcementHasCustomIcon: Boolean = false,
+
     @SerializedName("adsEnabled")
     val adsEnabled: Boolean = false,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -142,7 +142,9 @@ data class Announcement(
     val triggerOnLaunch: Boolean = true,
     val triggerOnNoNetwork: Boolean = false,
     val triggerIntervalMinutes: Int = 0,
-    val triggerIntervalIncludeLaunch: Boolean = false
+    val triggerIntervalIncludeLaunch: Boolean = false,
+    val showIcon: Boolean = true,
+    val customIconPath: String? = null
 )
 
 enum class StatusBarColorMode {

--- a/app/src/main/java/com/webtoapp/ui/components/AutoStartCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/AutoStartCard.kt
@@ -24,9 +24,9 @@ import androidx.lifecycle.LifecycleEventObserver
 import com.webtoapp.core.autostart.AutoStartManager
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.AutoStartConfig
-import com.webtoapp.ui.design.WtaDivider
-import com.webtoapp.ui.design.WtaFeatureCard
-import com.webtoapp.ui.design.WtaFeatureCardHeader
+import com.webtoapp.ui.design.WtaSettingCard
+import com.webtoapp.ui.design.WtaToggleRow
+import com.webtoapp.ui.design.WtaSectionDivider
 import com.webtoapp.ui.design.WtaSpacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -37,7 +37,6 @@ fun AutoStartCard(
 ) {
     val context = LocalContext.current
 
-    var expanded by remember { mutableStateOf(config != null && (config.bootStartEnabled || config.scheduledStartEnabled)) }
     var bootStartEnabled by remember(config) { mutableStateOf(config?.bootStartEnabled ?: false) }
     var scheduledStartEnabled by remember(config) { mutableStateOf(config?.scheduledStartEnabled ?: false) }
     var scheduledTime by remember(config) { mutableStateOf(config?.scheduledTime ?: "08:00") }
@@ -111,42 +110,40 @@ fun AutoStartCard(
     }
 
     val isEnabled = bootStartEnabled || scheduledStartEnabled
-    WtaFeatureCard(modifier = Modifier) {
-        WtaFeatureCardHeader(
+
+    WtaSettingCard {
+        WtaToggleRow(
             icon = Icons.Outlined.RocketLaunch,
             title = Strings.autoStartSettings,
-            subtitle = if (!isEnabled) Strings.notEnabled else null,
-            enabled = isEnabled,
-            onClick = { expanded = !expanded },
-            trailing = {
-                Icon(
-                    imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                    contentDescription = null
-                )
+            checked = isEnabled,
+            onCheckedChange = { checked ->
+                if (checked) {
+                    bootStartEnabled = true
+                } else {
+                    bootStartEnabled = false
+                    scheduledStartEnabled = false
+                }
+                updateConfig()
             }
         )
 
-        AnimatedVisibility(visible = expanded) {
-            Column(modifier = Modifier.padding(top = WtaSpacing.Large)) {
-                WtaDivider()
-                Spacer(modifier = Modifier.height(WtaSpacing.Large))
+        AnimatedVisibility(visible = isEnabled) {
+            Column {
+                WtaSectionDivider()
 
-                Row(
+                Column(modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal)) {
+                    Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
+
+                    Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
-                            Text(
-                                Strings.bootAutoStart,
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            Text(
-                                Strings.bootAutoStartHint,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
+                        Text(
+                            Strings.bootAutoStart,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(weight = 1f, fill = true)
+                        )
                         WtaSwitch(
                             checked = bootStartEnabled,
                             onCheckedChange = {
@@ -185,26 +182,20 @@ fun AutoStartCard(
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(modifier = Modifier.height(12.dp))
                     HorizontalDivider()
-                    Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(modifier = Modifier.height(12.dp))
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
-                            Text(
-                                Strings.scheduledAutoStart,
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            Text(
-                                Strings.scheduledAutoStartHint,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
+                        Text(
+                            Strings.scheduledAutoStart,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(weight = 1f, fill = true)
+                        )
                         WtaSwitch(
                             checked = scheduledStartEnabled,
                             onCheckedChange = {
@@ -282,28 +273,22 @@ fun AutoStartCard(
                             }
 
                             nextTriggerDisplay?.let { display ->
-                                Spacer(modifier = Modifier.height(12.dp))
-                                Surface(
-                                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-                                    shape = RoundedCornerShape(8.dp)
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Row(
-                                        modifier = Modifier.padding(12.dp),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Icon(
-                                            Icons.Outlined.Alarm,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(16.dp),
-                                            tint = MaterialTheme.colorScheme.onPrimaryContainer
-                                        )
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        Text(
-                                            "${Strings.nextLaunchTime}: $display",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                                        )
-                                    }
+                                    Icon(
+                                        Icons.Outlined.Alarm,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(14.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                    Spacer(modifier = Modifier.width(6.dp))
+                                    Text(
+                                        "${Strings.nextLaunchTime}: $display",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
                                 }
                             }
                         }
@@ -322,7 +307,6 @@ fun AutoStartCard(
                                         try {
                                             context.startActivity(oemAutoStartIntent)
                                         } catch (e: Exception) {
-
                                             try {
                                                 val fallback = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                                                     data = Uri.parse("package:${context.packageName}")
@@ -333,7 +317,7 @@ fun AutoStartCard(
                                     }
                             ) {
                                 Row(
-                                    modifier = Modifier.padding(12.dp),
+                                    modifier = Modifier.padding(8.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Icon(
@@ -343,13 +327,12 @@ fun AutoStartCard(
                                         tint = MaterialTheme.colorScheme.onSecondaryContainer
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
-                                    Column(modifier = Modifier.weight(1f)) {
-                                        Text(
-                                            Strings.oemAutoStartHint.replace("%s", oemBrandName),
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSecondaryContainer
-                                        )
-                                    }
+                                    Text(
+                                        Strings.oemAutoStartHint.replace("%s", oemBrandName),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                        modifier = Modifier.weight(1f)
+                                    )
                                     Icon(
                                         Icons.Outlined.NavigateNext,
                                         contentDescription = null,
@@ -358,7 +341,7 @@ fun AutoStartCard(
                                     )
                                 }
                             }
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(6.dp))
                         }
 
                         if (!canScheduleExact && scheduledStartEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -377,7 +360,7 @@ fun AutoStartCard(
                                     }
                             ) {
                                 Row(
-                                    modifier = Modifier.padding(12.dp),
+                                    modifier = Modifier.padding(8.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Icon(
@@ -390,9 +373,9 @@ fun AutoStartCard(
                                     Text(
                                         Strings.exactAlarmPermissionHint,
                                         style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onErrorContainer
+                                        color = MaterialTheme.colorScheme.onErrorContainer,
+                                        modifier = Modifier.weight(1f)
                                     )
-                                    Spacer(modifier = Modifier.weight(1f))
                                     Icon(
                                         Icons.Outlined.NavigateNext,
                                         contentDescription = null,
@@ -401,7 +384,7 @@ fun AutoStartCard(
                                     )
                                 }
                             }
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(6.dp))
                         }
 
                         if (!ignoringBatteryOpt) {
@@ -417,7 +400,6 @@ fun AutoStartCard(
                                             }
                                             context.startActivity(intent)
                                         } catch (e: Exception) {
-
                                             try {
                                                 context.startActivity(Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS))
                                             } catch (_: Exception) { }
@@ -425,7 +407,7 @@ fun AutoStartCard(
                                     }
                             ) {
                                 Row(
-                                    modifier = Modifier.padding(12.dp),
+                                    modifier = Modifier.padding(8.dp),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Icon(
@@ -438,9 +420,9 @@ fun AutoStartCard(
                                     Text(
                                         Strings.batteryOptimizationHint,
                                         style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                        modifier = Modifier.weight(1f)
                                     )
-                                    Spacer(modifier = Modifier.weight(1f))
                                     Icon(
                                         Icons.Outlined.NavigateNext,
                                         contentDescription = null,
@@ -449,61 +431,14 @@ fun AutoStartCard(
                                     )
                                 }
                             }
-                            Spacer(modifier = Modifier.height(8.dp))
-                        }
-
-                        if (canScheduleExact && ignoringBatteryOpt) {
-                            Surface(
-                                color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                                shape = RoundedCornerShape(8.dp)
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(12.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Icon(
-                                        Icons.Outlined.CheckCircle,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp),
-                                        tint = MaterialTheme.colorScheme.primary
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Text(
-                                        Strings.autoStartPermissionReady,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onPrimaryContainer
-                                    )
-                                }
-                            }
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(6.dp))
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Surface(
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                        shape = RoundedCornerShape(8.dp)
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(12.dp),
-                            verticalAlignment = Alignment.Top
-                        ) {
-                            Icon(
-                                Icons.Outlined.Info,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                Strings.autoStartNote,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
+                    Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
                 }
             }
+        }
     }
 
     if (showTimePicker) {

--- a/app/src/main/java/com/webtoapp/ui/components/announcement/AnnouncementTemplates.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/announcement/AnnouncementTemplates.kt
@@ -13,48 +13,32 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DarkMode
-import androidx.compose.material.icons.outlined.Bolt
-import androidx.compose.material.icons.outlined.Campaign
-import androidx.compose.material.icons.outlined.Celebration
 import androidx.compose.material.icons.outlined.CropSquare
-import androidx.compose.material.icons.outlined.Diamond
-import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material.icons.outlined.Gradient
-import androidx.compose.material.icons.outlined.MenuBook
-import androidx.compose.material.icons.outlined.Park
-import androidx.compose.material.icons.outlined.PhoneIphone
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.foundation.Image
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -62,157 +46,69 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.graphics.toArgb
-import com.webtoapp.core.i18n.AppLanguage
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.Announcement
 import com.webtoapp.data.model.AnnouncementTemplateType
+import com.webtoapp.ui.design.WtaSpacing
 
 enum class AnnouncementTemplate(
     val type: AnnouncementTemplateType,
     val icon: ImageVector
 ) {
     MINIMAL(AnnouncementTemplateType.MINIMAL, Icons.Outlined.CropSquare),
-    XIAOHONGSHU(AnnouncementTemplateType.XIAOHONGSHU, Icons.AutoMirrored.Filled.ArrowForward),
-    GRADIENT(AnnouncementTemplateType.GRADIENT, Icons.Outlined.Gradient),
-    GLASSMORPHISM(AnnouncementTemplateType.GLASSMORPHISM, Icons.Outlined.PhoneIphone),
-    NEON(AnnouncementTemplateType.NEON, Icons.Outlined.Bolt),
-    CUTE(AnnouncementTemplateType.CUTE, Icons.Outlined.FavoriteBorder),
-    ELEGANT(AnnouncementTemplateType.ELEGANT, Icons.Outlined.Diamond),
-    FESTIVE(AnnouncementTemplateType.FESTIVE, Icons.Outlined.Celebration),
-    DARK(AnnouncementTemplateType.DARK, Icons.Filled.DarkMode),
-    NATURE(AnnouncementTemplateType.NATURE, Icons.Outlined.Park)
+    DARK(AnnouncementTemplateType.DARK, Icons.Filled.DarkMode)
 }
 
 data class AnnouncementConfig(
     val announcement: Announcement,
     val template: AnnouncementTemplate = AnnouncementTemplate.MINIMAL,
-    val primaryColor: Color = Color(0xFF4F46E5)
+    val primaryColor: Color = Color(0xFF4F46E5),
+    val customIconBitmap: android.graphics.Bitmap? = null
 )
 
 private val announcementStyleTemplates = listOf(
     AnnouncementTemplate.MINIMAL,
-    AnnouncementTemplate.GRADIENT,
     AnnouncementTemplate.DARK
 )
 
-private fun styleTemplate(template: AnnouncementTemplate): AnnouncementTemplate = when (template) {
-    AnnouncementTemplate.MINIMAL,
-    AnnouncementTemplate.CUTE,
-    AnnouncementTemplate.ELEGANT -> AnnouncementTemplate.MINIMAL
-
-    AnnouncementTemplate.XIAOHONGSHU,
-    AnnouncementTemplate.GRADIENT,
-    AnnouncementTemplate.GLASSMORPHISM,
-    AnnouncementTemplate.FESTIVE,
-    AnnouncementTemplate.NATURE -> AnnouncementTemplate.GRADIENT
-
-    AnnouncementTemplate.NEON,
-    AnnouncementTemplate.DARK -> AnnouncementTemplate.DARK
-}
-
-private fun currentStyleName(style: AnnouncementTemplate): String = when (style) {
-    AnnouncementTemplate.MINIMAL -> when (Strings.currentLanguage.value) {
-        AppLanguage.CHINESE -> Strings.announcementStyleClean
-        AppLanguage.ENGLISH -> Strings.announcementStyleClean
-        AppLanguage.ARABIC -> Strings.announcementStyleClean
-        AppLanguage.PORTUGUESE ->Strings.announcementStyleClean
-        AppLanguage.SPANISH ->Strings.announcementStyleClean
-        AppLanguage.FRENCH ->Strings.announcementStyleClean
-        AppLanguage.GERMAN ->Strings.announcementStyleClean
-        AppLanguage.RUSSIAN ->Strings.announcementStyleClean
-        AppLanguage.JAPANESE ->Strings.announcementStyleClean
-        AppLanguage.KOREAN ->Strings.announcementStyleClean
-    }
-    AnnouncementTemplate.GRADIENT -> when (Strings.currentLanguage.value) {
-        AppLanguage.CHINESE -> Strings.announcementStyleAccent
-        AppLanguage.ENGLISH -> Strings.announcementStyleAccent
-        AppLanguage.ARABIC -> Strings.announcementStyleAccent
-        AppLanguage.PORTUGUESE ->Strings.announcementStyleAccent
-        AppLanguage.SPANISH ->Strings.announcementStyleAccent
-        AppLanguage.FRENCH ->Strings.announcementStyleAccent
-        AppLanguage.GERMAN ->Strings.announcementStyleAccent
-        AppLanguage.RUSSIAN ->Strings.announcementStyleAccent
-        AppLanguage.JAPANESE ->Strings.announcementStyleAccent
-        AppLanguage.KOREAN ->Strings.announcementStyleAccent
-    }
-    AnnouncementTemplate.DARK -> when (Strings.currentLanguage.value) {
-        AppLanguage.CHINESE -> Strings.announcementStyleDark
-        AppLanguage.ENGLISH -> Strings.announcementStyleDark
-        AppLanguage.ARABIC -> Strings.announcementStyleDark
-        AppLanguage.PORTUGUESE ->Strings.announcementStyleDark
-        AppLanguage.SPANISH ->Strings.announcementStyleDark
-        AppLanguage.FRENCH ->Strings.announcementStyleDark
-        AppLanguage.GERMAN ->Strings.announcementStyleDark
-        AppLanguage.RUSSIAN ->Strings.announcementStyleDark
-        AppLanguage.JAPANESE ->Strings.announcementStyleDark
-        AppLanguage.KOREAN ->Strings.announcementStyleDark
-    }
-    else -> ""
-}
-
-private fun currentStyleDesc(style: AnnouncementTemplate): String = when (style) {
-    AnnouncementTemplate.MINIMAL -> Strings.announcementStyleCleanDesc
-    AnnouncementTemplate.GRADIENT -> Strings.announcementStyleAccentDesc
-    AnnouncementTemplate.DARK -> Strings.announcementStyleDarkDesc
-    else -> ""
-}
-
 fun AnnouncementTemplateType.toUiTemplate(): AnnouncementTemplate = when (this) {
-    AnnouncementTemplateType.MINIMAL,
-    AnnouncementTemplateType.CUTE,
-    AnnouncementTemplateType.ELEGANT -> AnnouncementTemplate.MINIMAL
-
-    AnnouncementTemplateType.XIAOHONGSHU,
-    AnnouncementTemplateType.GRADIENT,
-    AnnouncementTemplateType.GLASSMORPHISM,
-    AnnouncementTemplateType.FESTIVE,
-    AnnouncementTemplateType.NATURE -> AnnouncementTemplate.GRADIENT
-
-    AnnouncementTemplateType.NEON,
-    AnnouncementTemplateType.DARK -> AnnouncementTemplate.DARK
+    AnnouncementTemplateType.DARK,
+    AnnouncementTemplateType.NEON -> AnnouncementTemplate.DARK
+    else -> AnnouncementTemplate.MINIMAL
 }
 
-fun AnnouncementTemplate.toStoredTemplate(): AnnouncementTemplateType = styleTemplate(this).type
+fun AnnouncementTemplate.toStoredTemplate(): AnnouncementTemplateType = type
 
-fun AnnouncementTemplate.getLocalizedDisplayName(): String = currentStyleName(styleTemplate(this))
+fun AnnouncementTemplate.getLocalizedDisplayName(): String = when (this) {
+    AnnouncementTemplate.MINIMAL -> Strings.announcementStyleClean
+    AnnouncementTemplate.DARK -> Strings.announcementStyleDark
+}
 
-fun AnnouncementTemplate.getLocalizedDescription(): String = currentStyleDesc(styleTemplate(this))
+fun AnnouncementTemplate.getLocalizedDescription(): String = when (this) {
+    AnnouncementTemplate.MINIMAL -> Strings.announcementStyleCleanDesc
+    AnnouncementTemplate.DARK -> Strings.announcementStyleDarkDesc
+}
 
-fun AnnouncementTemplate.isSelectableStyle(): Boolean = styleTemplate(this) in announcementStyleTemplates
+fun AnnouncementTemplate.isSelectableStyle(): Boolean = this in announcementStyleTemplates
 
-private fun styleAccentColor(template: AnnouncementTemplate): Color = when (styleTemplate(template)) {
+private fun styleAccentColor(template: AnnouncementTemplate): Color = when (template) {
     AnnouncementTemplate.MINIMAL -> Color(0xFF475569)
-    AnnouncementTemplate.GRADIENT -> Color(0xFF4F46E5)
     AnnouncementTemplate.DARK -> Color(0xFFCBD5E1)
-    else -> Color(0xFF4F46E5)
 }
 
-private fun styleSurfaceColor(template: AnnouncementTemplate): Color = when (styleTemplate(template)) {
+private fun styleSurfaceColor(template: AnnouncementTemplate): Color = when (template) {
     AnnouncementTemplate.MINIMAL -> Color(0xFFF8FAFC)
-    AnnouncementTemplate.GRADIENT -> Color(0xFFF7F7FF)
     AnnouncementTemplate.DARK -> Color(0xFF15161C)
-    else -> Color(0xFFF8FAFC)
 }
 
-private fun styleBodyColor(template: AnnouncementTemplate): Color = when (styleTemplate(template)) {
+private fun styleBodyColor(template: AnnouncementTemplate): Color = when (template) {
     AnnouncementTemplate.MINIMAL -> Color(0xFF1F2937)
-    AnnouncementTemplate.GRADIENT -> Color(0xFF27284A)
     AnnouncementTemplate.DARK -> Color(0xFFE5E7EB)
-    else -> Color(0xFF1F2937)
 }
 
-private fun styleBadgeColor(template: AnnouncementTemplate): Color = when (styleTemplate(template)) {
+private fun styleBadgeColor(template: AnnouncementTemplate): Color = when (template) {
     AnnouncementTemplate.MINIMAL -> Color(0xFFE2E8F0)
-    AnnouncementTemplate.GRADIENT -> Color(0xFFE0E7FF)
     AnnouncementTemplate.DARK -> Color(0xFF2A2D36)
-    else -> Color(0xFFE2E8F0)
-}
-
-private fun headerBrush(template: AnnouncementTemplate): Brush? = when (styleTemplate(template)) {
-    AnnouncementTemplate.MINIMAL -> null
-    AnnouncementTemplate.GRADIENT -> Brush.horizontalGradient(listOf(Color(0xFFEFF1FF), Color(0xFFF7F3FF)))
-    AnnouncementTemplate.DARK -> Brush.linearGradient(listOf(Color(0xFF23242C), Color(0xFF181A22)))
-    else -> null
 }
 
 private fun Announcement.linkUrlOrNull(): String? = linkUrl?.takeIf { it.isNotBlank() }
@@ -293,57 +189,21 @@ fun AnnouncementTemplateSelector(
     onTemplateSelected: (AnnouncementTemplate) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val selectedStyle = styleTemplate(selectedTemplate)
-
     Column(modifier = modifier) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(bottom = 12.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(30.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(
-                        Brush.linearGradient(
-                            listOf(
-                                MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-                                MaterialTheme.colorScheme.tertiary.copy(alpha = 0.12f)
-                            )
-                        )
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(Icons.Outlined.Campaign, null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
-            }
-            Spacer(modifier = Modifier.width(10.dp))
-            Text(
-                text = Strings.selectAnnouncementStyle,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            Surface(
-                shape = RoundedCornerShape(8.dp),
-                color = styleAccentColor(selectedStyle).copy(alpha = 0.10f)
-            ) {
-                Text(
-                    text = currentStyleName(selectedStyle),
-                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = styleAccentColor(selectedStyle),
-                    fontWeight = FontWeight.Medium
-                )
-            }
-        }
+        Text(
+            text = Strings.selectAnnouncementStyle,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = WtaSpacing.ContentGap)
+        )
 
-        LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            items(announcementStyleTemplates) { template ->
-                val isSelected = template == selectedStyle
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            announcementStyleTemplates.forEach { template ->
                 StyleCard(
                     template = template,
-                    isSelected = isSelected,
-                    onClick = { onTemplateSelected(template) }
+                    isSelected = template == selectedTemplate,
+                    onClick = { onTemplateSelected(template) },
+                    modifier = Modifier.weight(1f)
                 )
             }
         }
@@ -354,48 +214,42 @@ fun AnnouncementTemplateSelector(
 private fun StyleCard(
     template: AnnouncementTemplate,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    val style = styleTemplate(template)
-    val colors = when (style) {
+    val colors = when (template) {
         AnnouncementTemplate.MINIMAL -> listOf(Color(0xFFF8FAFC), Color(0xFFE2E8F0))
-        AnnouncementTemplate.GRADIENT -> listOf(Color(0xFFF3F4FF), Color(0xFFE9E5FF))
         AnnouncementTemplate.DARK -> listOf(Color(0xFF1C1D25), Color(0xFF101116))
-        else -> listOf(Color(0xFFF8FAFC), Color(0xFFE2E8F0))
     }
+    val accent = styleAccentColor(template)
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.width(116.dp)
+        modifier = modifier
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(92.dp)
-                .clip(RoundedCornerShape(18.dp))
+                .height(80.dp)
+                .clip(RoundedCornerShape(14.dp))
                 .border(
                     width = if (isSelected) 1.5.dp else 1.dp,
-                    color = if (isSelected) styleAccentColor(style) else Color.Transparent,
-                    shape = RoundedCornerShape(18.dp)
+                    color = if (isSelected) accent else Color.Transparent,
+                    shape = RoundedCornerShape(14.dp)
                 )
                 .background(Brush.linearGradient(colors))
                 .clickable(onClick = onClick)
-                .padding(10.dp)
+                .padding(10.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-                modifier = Modifier.fillMaxWidth()
-            ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    text = when (style) {
+                    text = when (template) {
                         AnnouncementTemplate.MINIMAL -> "◻"
-                        AnnouncementTemplate.GRADIENT -> "◈"
                         AnnouncementTemplate.DARK -> "◐"
-                        else -> "◻"
                     },
                     fontSize = 20.sp,
-                    color = styleAccentColor(style)
+                    color = accent
                 )
                 Spacer(modifier = Modifier.height(6.dp))
                 Box(
@@ -403,7 +257,7 @@ private fun StyleCard(
                         .width(46.dp)
                         .height(5.dp)
                         .clip(RoundedCornerShape(2.5.dp))
-                        .background(styleAccentColor(style).copy(alpha = 0.45f))
+                        .background(accent.copy(alpha = 0.45f))
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Box(
@@ -411,19 +265,50 @@ private fun StyleCard(
                         .width(58.dp)
                         .height(3.dp)
                         .clip(RoundedCornerShape(1.5.dp))
-                        .background(styleAccentColor(style).copy(alpha = 0.18f))
+                        .background(accent.copy(alpha = 0.18f))
                 )
             }
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(6.dp))
         Text(
-            text = currentStyleName(style),
+            text = template.getLocalizedDisplayName(),
             style = MaterialTheme.typography.labelMedium,
             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-            color = if (isSelected) styleAccentColor(style) else MaterialTheme.colorScheme.onSurface,
+            color = if (isSelected) accent else MaterialTheme.colorScheme.onSurface,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
+    }
+}
+
+@Composable
+private fun AnnouncementIconPlate(
+    config: AnnouncementConfig,
+    defaultIcon: ImageVector,
+    iconTint: Color,
+    plateBackground: Color
+) {
+    if (!config.announcement.showIcon) return
+    Box(
+        modifier = Modifier
+            .size(38.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(plateBackground),
+        contentAlignment = Alignment.Center
+    ) {
+        val bitmap = config.customIconBitmap
+        if (bitmap != null) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(38.dp)
+                    .clip(RoundedCornerShape(14.dp)),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Icon(defaultIcon, null, tint = iconTint, modifier = Modifier.size(18.dp))
+        }
     }
 }
 
@@ -434,7 +319,7 @@ fun AnnouncementDialog(
     onLinkClick: ((String) -> Unit)? = null,
     onNeverShowChecked: ((Boolean) -> Unit)? = null
 ) {
-    val style = styleTemplate(config.template)
+    val style = config.template
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
@@ -445,9 +330,7 @@ fun AnnouncementDialog(
     ) {
         when (style) {
             AnnouncementTemplate.MINIMAL -> SimpleDialog(config, style, onDismiss, onLinkClick, onNeverShowChecked)
-            AnnouncementTemplate.GRADIENT -> AccentDialog(config, style, onDismiss, onLinkClick, onNeverShowChecked)
             AnnouncementTemplate.DARK -> DarkDialog(config, style, onDismiss, onLinkClick, onNeverShowChecked)
-            else -> SimpleDialog(config, style, onDismiss, onLinkClick, onNeverShowChecked)
         }
     }
 }
@@ -489,15 +372,12 @@ private fun SimpleDialog(
     ) {
         Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(38.dp)
-                        .clip(RoundedCornerShape(14.dp))
-                        .background(styleBadgeColor(style)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(Icons.Outlined.CropSquare, null, tint = styleAccentColor(style), modifier = Modifier.size(18.dp))
-                }
+                AnnouncementIconPlate(
+                    config = config,
+                    defaultIcon = Icons.Outlined.CropSquare,
+                    iconTint = styleAccentColor(style),
+                    plateBackground = styleBadgeColor(style)
+                )
                 Spacer(modifier = Modifier.width(12.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
@@ -524,73 +404,6 @@ private fun SimpleDialog(
 }
 
 @Composable
-private fun AccentDialog(
-    config: AnnouncementConfig,
-    style: AnnouncementTemplate,
-    onDismiss: () -> Unit,
-    onLinkClick: ((String) -> Unit)?,
-    onNeverShowChecked: ((Boolean) -> Unit)?
-) {
-    val linkUrl = config.announcement.linkUrlOrNull()
-    Card(
-        modifier = Modifier.fillMaxWidth(0.90f),
-        shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.cardColors(containerColor = styleSurfaceColor(style)),
-        elevation = CardDefaults.cardElevation(defaultElevation = 10.dp)
-    ) {
-        Column {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(headerBrush(style) ?: Brush.linearGradient(listOf(Color(0xFFF3F4FF), Color(0xFFE9E5FF))))
-                    .padding(20.dp)
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(RoundedCornerShape(14.dp))
-                            .background(Color.White.copy(alpha = 0.9f)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(Icons.Outlined.Gradient, null, tint = styleAccentColor(style), modifier = Modifier.size(18.dp))
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = config.announcement.title.ifBlank { Strings.popupAnnouncement },
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = Color(0xFF1F2350)
-                        )
-                        if (!config.announcement.contentIsHtml) {
-                            Text(
-                                text = config.announcement.content,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color(0xFF3B3F68),
-                                lineHeight = 23.sp
-                            )
-                        }
-                    }
-                    IconButton(onClick = onDismiss) {
-                        Icon(Icons.Filled.Close, contentDescription = Strings.close, tint = Color(0xFF1F2350))
-                    }
-                }
-            }
-            Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
-                if (config.announcement.contentIsHtml) {
-                    AnnouncementContent(
-                        announcement = config.announcement,
-                        textColor = Color(0xFF3B3F68)
-                    )
-                }
-                DialogFooter(config.announcement.linkText, onLinkClick, linkUrl, onDismiss)
-            }
-        }
-    }
-}
-
-@Composable
 private fun DarkDialog(
     config: AnnouncementConfig,
     style: AnnouncementTemplate,
@@ -609,15 +422,12 @@ private fun DarkDialog(
     ) {
         Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(38.dp)
-                        .clip(RoundedCornerShape(14.dp))
-                        .background(Color.White.copy(alpha = 0.06f)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(Icons.Filled.DarkMode, null, tint = Color.White, modifier = Modifier.size(18.dp))
-                }
+                AnnouncementIconPlate(
+                    config = config,
+                    defaultIcon = Icons.Filled.DarkMode,
+                    iconTint = Color.White,
+                    plateBackground = Color.White.copy(alpha = 0.06f)
+                )
                 Spacer(modifier = Modifier.width(12.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppAnnouncementCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppAnnouncementCard.kt
@@ -3,7 +3,10 @@ package com.webtoapp.ui.screens
 import androidx.compose.animation.AnimatedVisibility
 import com.webtoapp.ui.animation.CardExpandTransition
 import com.webtoapp.ui.animation.CardCollapseTransition
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
@@ -12,15 +15,15 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import com.webtoapp.R
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.*
 import com.webtoapp.ui.components.*
 import com.webtoapp.ui.components.announcement.AnnouncementDialog
 import com.webtoapp.ui.components.announcement.AnnouncementConfig
-import com.webtoapp.ui.components.announcement.AnnouncementTemplate
 import com.webtoapp.ui.components.announcement.AnnouncementTemplateSelector
 import com.webtoapp.ui.components.announcement.toStoredTemplate
 import com.webtoapp.ui.components.announcement.toUiTemplate
@@ -51,12 +54,33 @@ fun AnnouncementCard(
     onAnnouncementChange: (Announcement) -> Unit
 ) {
     var showPreview by remember { mutableStateOf(false) }
+    val context = androidx.compose.ui.platform.LocalContext.current
+
+    val iconPickerLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.GetContent()
+    ) { uri: android.net.Uri? ->
+        uri?.let {
+            try {
+                val savedPath = com.webtoapp.util.IconStorage.saveIconFromUri(context, it)
+                if (savedPath != null) {
+                    onAnnouncementChange(announcement.copy(customIconPath = savedPath))
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    val previewBitmap = remember(announcement.customIconPath) {
+        announcement.customIconPath?.let { p ->
+            try { android.graphics.BitmapFactory.decodeFile(p) } catch (e: Exception) { null }
+        }
+    }
 
     if (showPreview && (announcement.title.isNotBlank() || announcement.content.isNotBlank())) {
         AnnouncementDialog(
             config = AnnouncementConfig(
                 announcement = announcement,
-                template = announcement.template.toUiTemplate()
+                template = announcement.template.toUiTemplate(),
+                customIconBitmap = previewBitmap
             ),
             onDismiss = { showPreview = false },
             onLinkClick = {  }
@@ -64,28 +88,26 @@ fun AnnouncementCard(
     }
 
     WtaSettingCard {
-        Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.ContentGap)) {
+        WtaToggleRow(
+            icon = Icons.Outlined.Campaign,
+            title = Strings.popupAnnouncement,
+            checked = enabled,
+            onCheckedChange = onEnabledChange
+        )
 
-            WtaToggleRow(
-                icon = Icons.Outlined.Campaign,
-                title = Strings.popupAnnouncement,
-                subtitle = null,
-                checked = enabled,
-                onCheckedChange = onEnabledChange
-            )
+        AnimatedVisibility(
+            visible = enabled,
+            enter = CardExpandTransition,
+            exit = CardCollapseTransition
+        ) {
+            Column {
+                WtaSectionDivider()
 
-            AnimatedVisibility(
-                visible = enabled,
-                enter = CardExpandTransition,
-                exit = CardCollapseTransition
-            ) {
                 Column(
-                    modifier = Modifier.padding(
-                        horizontal = WtaSpacing.RowHorizontal,
-                        vertical = WtaSpacing.ContentGap
-                    ),
+                    modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
+                    Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
 
                     AnnouncementTemplateSelector(
                         selectedTemplate = announcement.template.toUiTemplate(),
@@ -97,6 +119,87 @@ fun AnnouncementCard(
                             )
                         }
                     )
+                }
+
+                WtaToggleRow(
+                    icon = Icons.Outlined.Image,
+                    title = Strings.announcementShowIcon,
+                    subtitle = Strings.announcementShowIconHint,
+                    checked = announcement.showIcon,
+                    onCheckedChange = {
+                        onAnnouncementChange(announcement.copy(showIcon = it))
+                    }
+                )
+
+                AnimatedVisibility(visible = announcement.showIcon) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = WtaSpacing.RowHorizontal),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(MaterialTheme.colorScheme.surfaceVariant),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            val bitmap = previewBitmap
+                            if (bitmap != null) {
+                                androidx.compose.foundation.Image(
+                                    bitmap = bitmap.asImageBitmap(),
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .size(40.dp)
+                                        .clip(RoundedCornerShape(12.dp)),
+                                    contentScale = androidx.compose.ui.layout.ContentScale.Crop
+                                )
+                            } else {
+                                Icon(
+                                    Icons.Outlined.Campaign,
+                                    null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+
+                        if (announcement.customIconPath != null) {
+                            androidx.compose.material3.OutlinedButton(
+                                onClick = { iconPickerLauncher.launch("image/*") },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(Strings.announcementCustomIcon)
+                            }
+                            androidx.compose.material3.TextButton(
+                                onClick = {
+                                    onAnnouncementChange(announcement.copy(customIconPath = null))
+                                }
+                            ) {
+                                Text(
+                                    Strings.announcementRemoveCustomIcon,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        } else {
+                            androidx.compose.material3.OutlinedButton(
+                                onClick = { iconPickerLauncher.launch("image/*") },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Icon(Icons.Outlined.AddPhotoAlternate, null, Modifier.size(18.dp))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(Strings.announcementCustomIcon)
+                            }
+                        }
+                    }
+                }
+
+                Column(
+                    modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
 
                     PremiumTextField(
                         value = announcement.title,
@@ -129,17 +232,22 @@ fun AnnouncementCard(
                         maxLines = if (announcement.contentIsHtml) 10 else 5,
                         modifier = Modifier.fillMaxWidth()
                     )
+                }
 
-                    WtaToggleRow(
-                        icon = Icons.Outlined.Code,
-                        title = Strings.announcementContentHtml,
-                        subtitle = Strings.announcementContentHtmlDesc,
-                        checked = announcement.contentIsHtml,
-                        onCheckedChange = {
-                            onAnnouncementChange(announcement.copy(contentIsHtml = it))
-                        }
-                    )
+                WtaToggleRow(
+                    icon = Icons.Outlined.Code,
+                    title = Strings.announcementContentHtml,
+                    subtitle = Strings.announcementContentHtmlDesc,
+                    checked = announcement.contentIsHtml,
+                    onCheckedChange = {
+                        onAnnouncementChange(announcement.copy(contentIsHtml = it))
+                    }
+                )
 
+                Column(
+                    modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
                     PremiumTextField(
                         value = announcement.linkUrl ?: "",
                         onValueChange = {
@@ -176,20 +284,24 @@ fun AnnouncementCard(
                         Text(Strings.previewAnnouncementEffect)
                     }
 
-                    WtaSectionDivider(modifier = Modifier.padding(horizontal = 0.dp))
-
-                    AnnouncementTriggerSection(
-                        announcement = announcement,
-                        onAnnouncementChange = onAnnouncementChange
-                    )
-
-                    WtaSectionDivider(modifier = Modifier.padding(horizontal = 0.dp))
-
-                    AnnouncementAdvancedSection(
-                        announcement = announcement,
-                        onAnnouncementChange = onAnnouncementChange
-                    )
+                    Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
                 }
+
+                WtaSectionDivider()
+
+                AnnouncementTriggerSection(
+                    announcement = announcement,
+                    onAnnouncementChange = onAnnouncementChange
+                )
+
+                WtaSectionDivider()
+
+                AnnouncementAdvancedSection(
+                    announcement = announcement,
+                    onAnnouncementChange = onAnnouncementChange
+                )
+
+                Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
             }
         }
     }
@@ -201,15 +313,20 @@ private fun AnnouncementTriggerSection(
     announcement: Announcement,
     onAnnouncementChange: (Announcement) -> Unit
 ) {
-    var expanded by rememberSaveable { mutableStateOf(true) }
+    var expanded by rememberSaveable { mutableStateOf(false) }
 
-    WtaSection(
+    WtaChoiceRow(
         title = Strings.announcementTriggerSettings,
-        headerStyle = WtaSectionHeaderStyle.Quiet,
-        collapsible = true,
-        initiallyExpanded = true,
-        expanded = expanded,
-        onExpandedChange = { expanded = it }
+        icon = Icons.Outlined.AccessTime,
+        value = "",
+        isExpanded = expanded,
+        onClick = { expanded = !expanded }
+    )
+
+    AnimatedVisibility(
+        visible = expanded,
+        enter = CardExpandTransition,
+        exit = CardCollapseTransition
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             WtaToggleRow(
@@ -299,7 +416,6 @@ private fun AnnouncementTriggerSection(
             ) {
                 WtaToggleRow(
                     title = Strings.announcementTriggerIntervalIncludeLaunch,
-                    subtitle = Strings.announcementTriggerOnLaunchHint,
                     icon = Icons.Outlined.PlayCircle,
                     checked = announcement.triggerIntervalIncludeLaunch,
                     onCheckedChange = {
@@ -312,28 +428,30 @@ private fun AnnouncementTriggerSection(
 
             Text(
                 Strings.displayFrequency,
-                style = MaterialTheme.typography.labelLarge
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(
+                    start = WtaSpacing.RowHorizontal,
+                    top = WtaSpacing.ContentGap,
+                    bottom = WtaSpacing.ContentGap
+                )
             )
 
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = WtaSpacing.RowHorizontal),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 PremiumFilterChip(
                     selected = announcement.showOnce,
                     onClick = { onAnnouncementChange(announcement.copy(showOnce = true)) },
-                    label = { Text(Strings.showOnce) },
-                    leadingIcon = if (announcement.showOnce) {
-                        { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                    } else null
+                    label = { Text(Strings.showOnce) }
                 )
                 PremiumFilterChip(
                     selected = !announcement.showOnce,
                     onClick = { onAnnouncementChange(announcement.copy(showOnce = false)) },
-                    label = { Text(Strings.everyLaunch) },
-                    leadingIcon = if (!announcement.showOnce) {
-                        { Icon(Icons.Default.Check, null, Modifier.size(18.dp)) }
-                    } else null
+                    label = { Text(Strings.everyLaunch) }
                 )
             }
         }
@@ -347,13 +465,18 @@ private fun AnnouncementAdvancedSection(
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
 
-    WtaSection(
+    WtaChoiceRow(
         title = Strings.announcementAdvancedOptions,
-        headerStyle = WtaSectionHeaderStyle.Quiet,
-        collapsible = true,
-        initiallyExpanded = false,
-        expanded = expanded,
-        onExpandedChange = { expanded = it }
+        icon = Icons.Outlined.Tune,
+        value = "",
+        isExpanded = expanded,
+        onClick = { expanded = !expanded }
+    )
+
+    AnimatedVisibility(
+        visible = expanded,
+        enter = CardExpandTransition,
+        exit = CardCollapseTransition
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             WtaToggleRow(

--- a/app/src/main/java/com/webtoapp/ui/screens/DeviceDisguiseCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/DeviceDisguiseCard.kt
@@ -1,35 +1,25 @@
 package com.webtoapp.ui.screens
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.webtoapp.core.appearance.DeviceDisguiseConfig
 import com.webtoapp.core.appearance.DeviceType
-import com.webtoapp.core.appearance.DeviceOS
-import com.webtoapp.core.appearance.DeviceBrand
 import com.webtoapp.core.appearance.DevicePresets
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.animation.CardExpandTransition
 import com.webtoapp.ui.animation.CardCollapseTransition
-import com.webtoapp.ui.components.EnhancedElevatedCard
-import com.webtoapp.ui.design.WtaSwitch
+import com.webtoapp.ui.design.WtaSettingCard
+import com.webtoapp.ui.design.WtaToggleRow
+import com.webtoapp.ui.design.WtaSectionDivider
+import com.webtoapp.ui.design.WtaSpacing
+import com.webtoapp.ui.components.PremiumFilterChip
 import com.webtoapp.ui.components.PremiumTextField
 import com.webtoapp.ui.components.SettingsSwitch
 
@@ -39,7 +29,6 @@ fun DeviceDisguiseCard(
     config: DeviceDisguiseConfig,
     onConfigChange: (DeviceDisguiseConfig) -> Unit
 ) {
-    var expanded by remember { mutableStateOf(false) }
     var showCustomUA by remember { mutableStateOf(false) }
     var showCustomDevice by remember { mutableStateOf(false) }
 
@@ -50,536 +39,255 @@ fun DeviceDisguiseCard(
     var customDensity by remember { mutableStateOf("") }
 
     val isEnabled = config.enabled
-    val accentColor = if (isEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
 
-    EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
+    WtaSettingCard {
+        WtaToggleRow(
+            icon = Icons.Outlined.DevicesOther,
+            title = Strings.deviceDisguiseTitle,
+            checked = isEnabled,
+            onCheckedChange = { onConfigChange(config.copy(enabled = it)) }
+        )
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = !expanded },
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(
-                                if (isEnabled) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-                                else MaterialTheme.colorScheme.surfaceVariant
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            Icons.Outlined.DevicesOther,
-                            contentDescription = null,
-                            tint = accentColor,
-                            modifier = Modifier.size(22.dp)
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Column {
-                        Text(
-                            text = Strings.deviceDisguiseTitle,
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = if (isEnabled) Strings.enabled else Strings.notEnabled,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (isEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Icon(
-                    if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                    contentDescription = null
+        AnimatedVisibility(
+            visible = isEnabled,
+            enter = CardExpandTransition,
+            exit = CardCollapseTransition
+        ) {
+            Column {
+                WtaSectionDivider()
+
+                Text(
+                    text = Strings.deviceQuickSelect,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(
+                        start = WtaSpacing.RowHorizontal,
+                        top = WtaSpacing.ContentGap,
+                        bottom = WtaSpacing.ContentGap
+                    )
                 )
-            }
 
-            AnimatedVisibility(
-                visible = expanded,
-                enter = CardExpandTransition,
-                exit = CardCollapseTransition
-            ) {
-                Column(modifier = Modifier.padding(top = 16.dp)) {
+                val deviceTypes = listOf(
+                    DeviceType.PHONE to Strings.deviceTypePhone,
+                    DeviceType.TABLET to Strings.deviceTypeTablet,
+                    DeviceType.DESKTOP to Strings.deviceTypeDesktop,
+                    DeviceType.LAPTOP to Strings.deviceTypeLaptop,
+                    DeviceType.WATCH to Strings.deviceTypeWatch
+                )
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = Strings.deviceDisguiseTitle,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Medium
-                            )
-                            Text(
-                                text = if (isEnabled) Strings.deviceDisguiseActive else Strings.deviceDisguiseOff,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        WtaSwitch(
-                            checked = isEnabled,
-                            onCheckedChange = { onConfigChange(config.copy(enabled = it)) }
+                FlowRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = WtaSpacing.RowHorizontal),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    deviceTypes.forEach { (type, label) ->
+                        PremiumFilterChip(
+                            selected = config.deviceType == type,
+                            onClick = {
+                                val presets = DevicePresets.getPresetsForType(type)
+                                if (presets.isNotEmpty()) {
+                                    onConfigChange(presets.first().toConfig())
+                                } else {
+                                    onConfigChange(config.copy(deviceType = type))
+                                }
+                            },
+                            label = { Text(label) }
                         )
                     }
+                }
 
-                    AnimatedVisibility(
-                        visible = isEnabled,
-                        enter = CardExpandTransition,
-                        exit = CardCollapseTransition
-                    ) {
-                        Column {
-                            Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
+                WtaSectionDivider()
 
-                            Surface(
-                                color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.45f),
-                                shape = RoundedCornerShape(10.dp)
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(12.dp),
-                                    verticalAlignment = Alignment.Top
-                                ) {
-                                    Icon(
-                                        Icons.Outlined.Info,
-                                        null,
-                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                        modifier = Modifier.size(16.dp).padding(top = 2.dp)
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Text(
-                                        text = Strings.deviceDisguiseHint,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                        lineHeight = 18.sp
-                                    )
-                                }
-                            }
+                Text(
+                    text = Strings.devicePopularPresets,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.padding(
+                        start = WtaSpacing.RowHorizontal,
+                        top = WtaSpacing.ContentGap,
+                        bottom = WtaSpacing.ContentGap
+                    )
+                )
 
-                            Spacer(modifier = Modifier.height(16.dp))
+                val presets = DevicePresets.getPresetsForType(config.deviceType)
 
-                            Text(
-                                text = Strings.deviceQuickSelect,
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            val deviceTypes = listOf(
-                                DeviceType.PHONE to Strings.deviceTypePhone,
-                                DeviceType.TABLET to Strings.deviceTypeTablet,
-                                DeviceType.DESKTOP to Strings.deviceTypeDesktop,
-                                DeviceType.LAPTOP to Strings.deviceTypeLaptop,
-                                DeviceType.WATCH to Strings.deviceTypeWatch
-                            )
-
-                            FlowRow(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                deviceTypes.forEach { (type, label) ->
-                                    val isSelected = config.deviceType == type
-                                    val bgColor by animateColorAsState(
-                                        if (isSelected) MaterialTheme.colorScheme.primaryContainer
-                                        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                                        label = "typeBg"
-                                    )
-                                    val contentColor by animateColorAsState(
-                                        if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
-                                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                                        label = "typeContent"
-                                    )
-
-                                    Surface(
-                                        onClick = {
-
-                                            val presets = DevicePresets.getPresetsForType(type)
-                                            if (presets.isNotEmpty()) {
-                                                onConfigChange(presets.first().toConfig())
-                                            } else {
-                                                onConfigChange(config.copy(deviceType = type))
-                                            }
-                                        },
-                                        shape = RoundedCornerShape(12.dp),
-                                        color = bgColor,
-                                        border = if (isSelected) androidx.compose.foundation.BorderStroke(
-                                            1.5.dp, MaterialTheme.colorScheme.primary
-                                        ) else null
-                                    ) {
-                                        Column(
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)
-                                        ) {
-
-                                            Text(
-                                                text = type.emoji,
-                                                fontSize = 20.sp
-                                            )
-                                            Spacer(modifier = Modifier.height(2.dp))
-                                            Text(
-                                                text = label,
-                                                style = MaterialTheme.typography.labelSmall,
-                                                color = contentColor,
-                                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                                maxLines = 1
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                            Spacer(modifier = Modifier.height(12.dp))
-
-                            Text(
-                                text = Strings.devicePopularPresets,
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.tertiary
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            val presets = DevicePresets.getPresetsForType(config.deviceType)
-
-                            FlowRow(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                presets.forEach { preset ->
-
-                                    val isSelected = config.deviceModel == preset.model &&
-                                            config.deviceBrand == preset.brand
-                                    val chipBg by animateColorAsState(
-                                        if (isSelected) MaterialTheme.colorScheme.primaryContainer
-                                        else MaterialTheme.colorScheme.surface,
-                                        label = "presetBg"
-                                    )
-
-                                    Surface(
-                                        onClick = {
-
-                                            onConfigChange(preset.toConfig().copy(
-                                                deviceType = config.deviceType
-                                            ))
-                                        },
-                                        shape = RoundedCornerShape(12.dp),
-                                        color = chipBg,
-                                        tonalElevation = if (isSelected) 0.dp else 2.dp,
-                                        border = if (isSelected) androidx.compose.foundation.BorderStroke(
-                                            1.5.dp, MaterialTheme.colorScheme.primary
-                                        ) else androidx.compose.foundation.BorderStroke(
-                                            0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
-                                        )
-                                    ) {
-                                        Row(
-                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-
-                                            Column {
-                                                Text(
-                                                    text = preset.name,
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                                    maxLines = 1,
-                                                    overflow = TextOverflow.Ellipsis
-                                                )
-                                                Text(
-                                                    text = "${preset.os.displayName} · ${preset.screenWidth}×${preset.screenHeight}",
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                                                    maxLines = 1,
-                                                    fontSize = 10.sp
-                                                )
-                                            }
-                                            if (isSelected) {
-                                                Spacer(modifier = Modifier.width(6.dp))
-                                                Icon(
-                                                    Icons.Outlined.CheckCircle,
-                                                    null,
-                                                    tint = MaterialTheme.colorScheme.primary,
-                                                    modifier = Modifier.size(16.dp)
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                            Spacer(modifier = Modifier.height(12.dp))
-
-                            if (config.deviceModelName.isNotBlank()) {
-                                Text(
-                                    text = Strings.deviceCurrentDisguise,
-                                    style = MaterialTheme.typography.labelLarge,
-                                    color = MaterialTheme.colorScheme.primary
-                                )
-                                Spacer(modifier = Modifier.height(8.dp))
-
-                                Surface(
-                                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                                    shape = RoundedCornerShape(12.dp),
-                                    border = androidx.compose.foundation.BorderStroke(
-                                        1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
-                                    )
-                                ) {
-                                    Column(modifier = Modifier.padding(14.dp)) {
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-
-                                            Text(
-                                                text = config.deviceType.emoji,
-                                                fontSize = 24.sp
-                                            )
-                                            Spacer(modifier = Modifier.width(10.dp))
-                                            Column {
-                                                Text(
-                                                    text = config.deviceModelName,
-                                                    style = MaterialTheme.typography.titleSmall,
-                                                    fontWeight = FontWeight.SemiBold
-                                                )
-                                                Text(
-                                                    text = "${config.deviceBrand.displayName} · ${config.deviceOS.displayName}",
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                                )
-                                            }
-                                        }
-                                        Spacer(modifier = Modifier.height(10.dp))
-
-                                        val ua = config.generateUserAgent()
-                                        if (ua.isNotBlank()) {
-                                            Surface(
-                                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                                                shape = RoundedCornerShape(8.dp)
-                                            ) {
-                                                Column(modifier = Modifier.padding(10.dp)) {
-                                                    Text(
-                                                        text = Strings.deviceGeneratedUA,
-                                                        style = MaterialTheme.typography.labelSmall,
-                                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                                    )
-                                                    Spacer(modifier = Modifier.height(4.dp))
-                                                    Text(
-                                                        text = ua,
-                                                        style = MaterialTheme.typography.bodySmall,
-                                                        fontSize = 11.sp,
-                                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                                        lineHeight = 15.sp,
-                                                        maxLines = 4,
-                                                        overflow = TextOverflow.Ellipsis
-                                                    )
-                                                }
-                                            }
-                                        }
-
-                                        if (config.screenWidth > 0 && config.screenHeight > 0) {
-                                            Spacer(modifier = Modifier.height(8.dp))
-                                            Row(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                horizontalArrangement = Arrangement.spacedBy(16.dp)
-                                            ) {
-                                                InfoChip("${config.screenWidth}×${config.screenHeight}")
-                                                if (config.pixelDensity > 0) {
-                                                    InfoChip("${config.pixelDensity}x DPI")
-                                                }
-                                                if (config.requiresDesktopViewport()) {
-                                                    InfoChip("Desktop VP")
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                Spacer(modifier = Modifier.height(12.dp))
-                            }
-
-                            if (config.deviceType !in listOf(DeviceType.DESKTOP, DeviceType.LAPTOP)) {
-                                SettingsSwitch(
-                                    title = Strings.deviceDesktopViewport,
-                                    subtitle = Strings.deviceDesktopViewportHint,
-                                    checked = config.isDesktopViewport,
-                                    onCheckedChange = {
-                                        onConfigChange(config.copy(isDesktopViewport = it))
-                                    }
-                                )
-                                Spacer(modifier = Modifier.height(8.dp))
-                            }
-
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            SettingsSwitch(
-                                title = Strings.deviceCustomDevice,
-                                subtitle = Strings.deviceCustomDeviceHint,
-                                checked = showCustomDevice || config.isCustomDevice,
-                                onCheckedChange = {
-                                    showCustomDevice = it
-                                    if (it && config.deviceModelName.isNotBlank()) {
-
-                                        customModelName = config.deviceModelName
-                                        customModelId = config.deviceModel
-                                        customScreenW = if (config.screenWidth > 0) config.screenWidth.toString() else ""
-                                        customScreenH = if (config.screenHeight > 0) config.screenHeight.toString() else ""
-                                        customDensity = if (config.pixelDensity > 0) config.pixelDensity.toString() else ""
-                                    }
-                                }
-                            )
-
-                            AnimatedVisibility(
-                                visible = showCustomDevice || config.isCustomDevice,
-                                enter = CardExpandTransition,
-                                exit = CardCollapseTransition
-                            ) {
-                                Column(modifier = Modifier.padding(top = 8.dp)) {
-
-                                    PremiumTextField(
-                                        value = customModelName,
-                                        onValueChange = { customModelName = it },
-                                        label = { Text(Strings.deviceCustomName) },
-                                        placeholder = { Text("Galaxy S26 Ultra") },
-                                        modifier = Modifier.fillMaxWidth(),
-                                        singleLine = true
-                                    )
-                                    Spacer(modifier = Modifier.height(8.dp))
-
-                                    PremiumTextField(
-                                        value = customModelId,
-                                        onValueChange = { customModelId = it },
-                                        label = { Text(Strings.deviceCustomModelId) },
-                                        placeholder = { Text("SM-S938B") },
-                                        modifier = Modifier.fillMaxWidth(),
-                                        singleLine = true
-                                    )
-                                    Spacer(modifier = Modifier.height(8.dp))
-
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                    ) {
-                                        PremiumTextField(
-                                            value = customScreenW,
-                                            onValueChange = { customScreenW = it.filter { c -> c.isDigit() } },
-                                            label = { Text(Strings.deviceCustomWidth) },
-                                            placeholder = { Text("1920") },
-                                            modifier = Modifier.weight(1f),
-                                            singleLine = true
-                                        )
-                                        PremiumTextField(
-                                            value = customScreenH,
-                                            onValueChange = { customScreenH = it.filter { c -> c.isDigit() } },
-                                            label = { Text(Strings.deviceCustomHeight) },
-                                            placeholder = { Text("1080") },
-                                            modifier = Modifier.weight(1f),
-                                            singleLine = true
-                                        )
-                                    }
-                                    Spacer(modifier = Modifier.height(8.dp))
-
-                                    PremiumTextField(
-                                        value = customDensity,
-                                        onValueChange = { customDensity = it },
-                                        label = { Text(Strings.deviceCustomDensity) },
-                                        placeholder = { Text("2.0") },
-                                        modifier = Modifier.fillMaxWidth(),
-                                        singleLine = true
-                                    )
-                                    Spacer(modifier = Modifier.height(12.dp))
-
-                                    FilledTonalButton(
-                                        onClick = {
-                                            onConfigChange(config.copy(
-                                                deviceModelName = customModelName.ifBlank { "Custom Device" },
-                                                deviceModel = customModelId.ifBlank { "CUSTOM-${System.currentTimeMillis()}" },
-                                                screenWidth = customScreenW.toIntOrNull() ?: 0,
-                                                screenHeight = customScreenH.toIntOrNull() ?: 0,
-                                                pixelDensity = customDensity.toFloatOrNull() ?: 0f,
-                                                isCustomDevice = true
-                                            ))
-                                        },
-                                        modifier = Modifier.fillMaxWidth(),
-                                        shape = RoundedCornerShape(12.dp),
-                                        enabled = customModelName.isNotBlank()
-                                    ) {
-                                        Icon(
-                                            Icons.Outlined.Save,
-                                            null,
-                                            modifier = Modifier.size(18.dp)
-                                        )
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        Text(Strings.deviceCustomApply)
-                                    }
-                                }
-                            }
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            SettingsSwitch(
-                                title = Strings.deviceCustomUA,
-                                subtitle = Strings.deviceCustomUAHint,
-                                checked = showCustomUA || !config.customUserAgent.isNullOrBlank(),
-                                onCheckedChange = {
-                                    showCustomUA = it
-                                    if (!it) onConfigChange(config.copy(customUserAgent = null))
-                                }
-                            )
-
-                            AnimatedVisibility(
-                                visible = showCustomUA || !config.customUserAgent.isNullOrBlank(),
-                                enter = CardExpandTransition,
-                                exit = CardCollapseTransition
-                            ) {
-                                PremiumTextField(
-                                    value = config.customUserAgent ?: "",
-                                    onValueChange = {
-                                        onConfigChange(config.copy(customUserAgent = it.ifBlank { null }))
-                                    },
-                                    label = { Text("User-Agent") },
-                                    placeholder = { Text("Mozilla/5.0 ...") },
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 8.dp),
-                                    singleLine = false,
-                                    minLines = 2,
-                                    maxLines = 4
-                                )
-                            }
-                        }
+                FlowRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = WtaSpacing.RowHorizontal),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    presets.forEach { preset ->
+                        PremiumFilterChip(
+                            selected = config.deviceModel == preset.model &&
+                                    config.deviceBrand == preset.brand,
+                            onClick = {
+                                onConfigChange(preset.toConfig().copy(
+                                    deviceType = config.deviceType
+                                ))
+                            },
+                            label = { Text(preset.name) }
+                        )
                     }
                 }
+
+                Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
+                WtaSectionDivider()
+
+                if (config.deviceType !in listOf(DeviceType.DESKTOP, DeviceType.LAPTOP)) {
+                    SettingsSwitch(
+                        title = Strings.deviceDesktopViewport,
+                        subtitle = Strings.deviceDesktopViewportHint,
+                        checked = config.isDesktopViewport,
+                        onCheckedChange = {
+                            onConfigChange(config.copy(isDesktopViewport = it))
+                        }
+                    )
+                }
+
+                SettingsSwitch(
+                    title = Strings.deviceCustomDevice,
+                    subtitle = Strings.deviceCustomDeviceHint,
+                    checked = showCustomDevice || config.isCustomDevice,
+                    onCheckedChange = {
+                        showCustomDevice = it
+                        if (it && config.deviceModelName.isNotBlank()) {
+                            customModelName = config.deviceModelName
+                            customModelId = config.deviceModel
+                            customScreenW = if (config.screenWidth > 0) config.screenWidth.toString() else ""
+                            customScreenH = if (config.screenHeight > 0) config.screenHeight.toString() else ""
+                            customDensity = if (config.pixelDensity > 0) config.pixelDensity.toString() else ""
+                        }
+                    }
+                )
+
+                AnimatedVisibility(
+                    visible = showCustomDevice || config.isCustomDevice,
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    Column(modifier = Modifier.padding(horizontal = WtaSpacing.RowHorizontal)) {
+                        Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
+
+                        PremiumTextField(
+                            value = customModelName,
+                            onValueChange = { customModelName = it },
+                            label = { Text(Strings.deviceCustomName) },
+                            placeholder = { Text("Galaxy S26 Ultra") },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        PremiumTextField(
+                            value = customModelId,
+                            onValueChange = { customModelId = it },
+                            label = { Text(Strings.deviceCustomModelId) },
+                            placeholder = { Text("SM-S938B") },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            PremiumTextField(
+                                value = customScreenW,
+                                onValueChange = { customScreenW = it.filter { c -> c.isDigit() } },
+                                label = { Text(Strings.deviceCustomWidth) },
+                                placeholder = { Text("1920") },
+                                modifier = Modifier.weight(1f),
+                                singleLine = true
+                            )
+                            PremiumTextField(
+                                value = customScreenH,
+                                onValueChange = { customScreenH = it.filter { c -> c.isDigit() } },
+                                label = { Text(Strings.deviceCustomHeight) },
+                                placeholder = { Text("1080") },
+                                modifier = Modifier.weight(1f),
+                                singleLine = true
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        PremiumTextField(
+                            value = customDensity,
+                            onValueChange = { customDensity = it },
+                            label = { Text(Strings.deviceCustomDensity) },
+                            placeholder = { Text("2.0") },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        FilledTonalButton(
+                            onClick = {
+                                onConfigChange(config.copy(
+                                    deviceModelName = customModelName.ifBlank { "Custom Device" },
+                                    deviceModel = customModelId.ifBlank { "CUSTOM-${System.currentTimeMillis()}" },
+                                    screenWidth = customScreenW.toIntOrNull() ?: 0,
+                                    screenHeight = customScreenH.toIntOrNull() ?: 0,
+                                    pixelDensity = customDensity.toFloatOrNull() ?: 0f,
+                                    isCustomDevice = true
+                                ))
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(12.dp),
+                            enabled = customModelName.isNotBlank()
+                        ) {
+                            Icon(
+                                Icons.Outlined.Save,
+                                null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(Strings.deviceCustomApply)
+                        }
+
+                        Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
+                    }
+                }
+
+                SettingsSwitch(
+                    title = Strings.deviceCustomUA,
+                    subtitle = Strings.deviceCustomUAHint,
+                    checked = showCustomUA || !config.customUserAgent.isNullOrBlank(),
+                    onCheckedChange = {
+                        showCustomUA = it
+                        if (!it) onConfigChange(config.copy(customUserAgent = null))
+                    }
+                )
+
+                AnimatedVisibility(
+                    visible = showCustomUA || !config.customUserAgent.isNullOrBlank(),
+                    enter = CardExpandTransition,
+                    exit = CardCollapseTransition
+                ) {
+                    PremiumTextField(
+                        value = config.customUserAgent ?: "",
+                        onValueChange = {
+                            onConfigChange(config.copy(customUserAgent = it.ifBlank { null }))
+                        },
+                        label = { Text("User-Agent") },
+                        placeholder = { Text("Mozilla/5.0 ...") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = WtaSpacing.RowHorizontal)
+                            .padding(top = WtaSpacing.ContentGap),
+                        singleLine = false,
+                        minLines = 2,
+                        maxLines = 4
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(WtaSpacing.ContentGap))
             }
         }
-    }
-}
-
-@Composable
-private fun InfoChip(text: String) {
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-        shape = RoundedCornerShape(6.dp)
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
     }
 }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -109,13 +109,22 @@ fun ShellAnnouncementDialog(
             com.webtoapp.data.model.AnnouncementTemplateType.MINIMAL
         },
         requireConfirmation = config.announcementRequireConfirmation,
-        allowNeverShow = config.announcementAllowNeverShow
+        allowNeverShow = config.announcementAllowNeverShow,
+        showIcon = config.announcementShowIcon
     )
+
+    val customIconBitmap = if (config.announcementHasCustomIcon) {
+        try {
+            val bytes = com.webtoapp.core.crypto.AssetDecryptor(context).loadAsset("announcement_icon.png")
+            android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        } catch (e: Exception) { null }
+    } else null
 
     com.webtoapp.ui.components.announcement.AnnouncementDialog(
         config = com.webtoapp.ui.components.announcement.AnnouncementConfig(
             announcement = shellAnnouncement,
-            template = shellAnnouncement.template.toUiTemplate()
+            template = shellAnnouncement.template.toUiTemplate(),
+            customIconBitmap = customIconBitmap
         ),
         onDismiss = {
             onDismiss()

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -407,7 +407,10 @@ fun AnnouncementDialog(
     com.webtoapp.ui.components.announcement.AnnouncementDialog(
         config = com.webtoapp.ui.components.announcement.AnnouncementConfig(
             announcement = announcement,
-            template = announcement.template.toUiTemplate()
+            template = announcement.template.toUiTemplate(),
+            customIconBitmap = announcement.customIconPath?.let { p ->
+                try { android.graphics.BitmapFactory.decodeFile(p) } catch (e: Exception) { null }
+            }
         ),
         onDismiss = onDismiss,
         onLinkClick = { url -> onLinkClick(url) }

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -3367,7 +3367,10 @@ fun WebViewScreen(
 com.webtoapp.ui.components.announcement.AnnouncementDialog(
             config = com.webtoapp.ui.components.announcement.AnnouncementConfig(
                 announcement = ann,
-                template = ann.template.toUiTemplate()
+                template = ann.template.toUiTemplate(),
+                customIconBitmap = ann.customIconPath?.let { p ->
+                    try { android.graphics.BitmapFactory.decodeFile(p) } catch (e: Exception) { null }
+                }
             ),
             onDismiss = {
                 showAnnouncementDialog = false


### PR DESCRIPTION
## Summary

Overhaul the editor configuration cards (Device Disguise, Auto Start, Announcement) for visual consistency and reduced verbosity, simplify the announcement template system, and add announcement icon customization.

Fixes #418

## Changes

### 1. Card style: collapsible → button-style
- **DeviceDisguiseCard** and **AutoStartCard** converted from expand/collapse arrow pattern to `WtaSettingCard` + `WtaToggleRow` (switch in header), matching KeepScreenOnCard, LongPressMenuCard, etc.

### 2. UI optimization (3 cards)
- **DeviceDisguiseCard** (~480 → ~240 lines): removed hint box, emoji chips → `PremiumFilterChip`, single-line presets, removed redundant "Current Disguise" recap, unified `WtaSectionDivider`.
- **AutoStartCard**: removed restated subtitles, bottom info note, "all ready" block; simplified next-trigger to inline text; compacted permission prompts.
- **AnnouncementCard**: fixed double-padding structure, replaced `WtaSection(Quiet)` headers with `WtaChoiceRow` (visible icon + title + arrow), removed redundant chip check icons.

### 3. Announcement templates simplified
- Removed Accent/Gradient style and `AccentDialog`; renamed Clean → **Light** (10 languages); kept only **Light** and **Dark**.
- UI enum reduced from 10 values to 2; selector uses `Row` + `weight(1f)` instead of `LazyRow`.
- Old stored templates gracefully remap via `toUiTemplate()`.

### 4. Announcement trigger section
- Defaults to collapsed (`expanded = false`, `initiallyExpanded = false`).

### 5. New feature: announcement icon toggle + custom upload
Full export chain:
```
Announcement model (+showIcon, +customIconPath)
  → Editor UI (WtaToggleRow + image picker via IconStorage)
  → AnnouncementBlock (+showIcon, +hasCustomIcon)
  → ApkConfigJsonFactory (+announcementShowIcon, +announcementHasCustomIcon)
  → ApkBuilder (embed as assets/announcement_icon.png, encryption-aware)
  → ShellConfig (+2 @SerializedName fields)
  → ShellDialogs (AssetDecryptor.loadAsset → BitmapFactory)
  → AnnouncementIconPlate composable (conditional render, custom bitmap)
  → Host preview (WebViewActivity, SplashLauncherActivity)
```

### 6. i18n
- 4 new strings × 10 languages (announcementShowIcon, announcementShowIconHint, announcementCustomIcon, announcementRemoveCustomIcon).
- `announcementStyleClean` values updated to Light/浅色 in all 10 languages.

## Stats
- 13 files changed, **+729 / −1033** (net −304 lines)

## Test plan
- [x] `./gradlew :app:compileDebugKotlin -x syncCloneHostDex` — BUILD SUCCESSFUL, no new errors
- [x] `python3 scripts/check_config_field_drift.py` — OK (payload=432, shell=462)
- [x] No Agent tool references to announcement (verified: zero hits in `core/agent/`)
- [ ] Manual: verify Device Disguise / Auto Start / Announcement cards render correctly in editor
- [ ] Manual: verify announcement popup with icon toggle and custom icon in preview
- [ ] Manual: export an APK with custom announcement icon and verify in generated app