### PR TITLE
refactor(ui): deduplicate policy status chips in Play Store screen

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/screens/PlayStoreScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/PlayStoreScreen.kt
@@ -738,29 +738,6 @@ private fun ReportSummaryCard(report: PlayPolicyChecker.Report) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            if (!report.isClean) {
-                Spacer(modifier = Modifier.height(10.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    if (report.blockerCount > 0) {
-                        StatusChip(
-                            label = "${Strings.playStoreSeverityBlocker} ${report.blockerCount}",
-                            color = MaterialTheme.colorScheme.error
-                        )
-                    }
-                    if (report.warningCount > 0) {
-                        StatusChip(
-                            label = "${Strings.playStoreSeverityWarning} ${report.warningCount}",
-                            color = Color(0xFFED6C02)
-                        )
-                    }
-                    if (report.infoCount > 0) {
-                        StatusChip(
-                            label = "${Strings.playStoreSeverityInfo} ${report.infoCount}",
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                }
-            }
         }
     }
 }
@@ -832,7 +809,7 @@ private fun ViolationCard(violation: PlayPolicyChecker.Violation) {
                 )
             }
             Spacer(modifier = Modifier.height(12.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
             Spacer(modifier = Modifier.height(12.dp))
             Text(
                 text = Strings.playStoreFixHintLabel,


### PR DESCRIPTION
## Summary

Remove the duplicated policy severity chips from the Google Play export screen's report summary, and soften a heavy divider.

Fixes #425

## Why

The Blocker/Warning/Info counts were rendered twice:
- `ExportActionCard` (always visible, beside the export button) — the actionable chips.
- `ReportSummaryCard` (inside the collapsible `PolicyAdviceCard`) — its headline already says "N blockers"/"N warnings", then it rendered the same chips again.

## Changes

- **Removed** the redundant `StatusChip` row from `ReportSummaryCard`. The colored headline + description remain; the always-visible `ExportActionCard` chips are now the single source for the counts.
- **Softened** the `ViolationCard` divider from opaque `outlineVariant` to `outlineVariant.copy(alpha = 0.5f)`, matching the subtle dividers used elsewhere.

`StatusChip` itself is kept (still used by `ExportActionCard`).

## Stats
- 1 file changed, **+1 / −24**

## Test plan
- [x] `./gradlew :app:compileDebugKotlin -x syncCloneHostDex` — BUILD SUCCESSFUL, no new errors
- [ ] Manual: verify policy counts appear once (in the export card) and the report summary shows headline + description without duplicate chips