### PR TITLE
refactor(ui): trim redundant metric chips from usage stats rank cards

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/screens/StatsScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/StatsScreen.kt
@@ -524,41 +524,6 @@ private fun UsageRankCard(
                     trackColor = MaterialTheme.colorScheme.surfaceVariant
                 )
             }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                MetaChip(
-                    label = Strings.statsLastSession,
-                    value = stats.formattedLastSession
-                )
-                MetaChip(
-                    label = Strings.statsTotalUsage,
-                    value = stats.formattedTotalUsage
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MetaChip(label: String, value: String) {
-    Surface(
-        shape = RoundedCornerShape(10.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
-            Text(
-                label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                value,
-                style = MaterialTheme.typography.labelLarge,
-                fontWeight = FontWeight.SemiBold
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Slim down the usage-stats ranking cards by removing a redundant bottom metric row.

Fixes #427

## Why

Every `UsageRankCard` rendered a bottom row of two `MetaChip`s ("Last session" + "Total usage"):
- **"Total usage" duplicated the primary metric** shown on the right when sorted by Time or Recent.
- The row added ~50dp of height to every card in the list.

## Changes

- **Removed** the bottom `MetaChip` row from `UsageRankCard`.
- **Deleted** the now-unused `MetaChip` composable.

Rank cards now keep their core layout: **rank badge → app icon → name → last-used → primary sort metric → comparison progress bar**. The "last used" timestamp under the name and the overall stats card are untouched.

## Stats
- 1 file changed, **+0 / −35**

## Test plan
- [x] `./gradlew :app:compileDebugKotlin -x syncCloneHostDex` — BUILD SUCCESSFUL, no new errors
- [ ] Manual: verify rank cards render compactly across all three sort modes with no duplicate total-usage display