### PR TITLE
fix(agent): per-turn reasoning + service-side persistence

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -167,6 +167,11 @@ class AgentEngine(
 
                 if (hardError != null) { send(AgentEvent.Failed(hardError!!)); return@channelFlow }
 
+                // This turn's reasoning stream is done (text/tools come next, or the
+                // turn ends). Freeze it so the UI can start a fresh live block on the
+                // next turn instead of piling into one shared buffer.
+                if (turnThinking.isNotEmpty()) send(AgentEvent.ThinkingTurnEnded)
+
                 if (finishReason == FinishReason.LENGTH && continuationCount >= maxContinuations) {
                     send(AgentEvent.Notice(Strings.agentOutputTruncated))
                 }

--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
@@ -10,6 +10,14 @@ sealed class AgentEvent {
 
     data class ThinkingDelta(val delta: String, val accumulated: String) : AgentEvent()
 
+    /**
+     * Emitted once the current turn's reasoning stream has finished and the model is
+     * about to move on to text / tool calls. Lets the UI freeze that turn's thinking
+     * block so the next turn can open a fresh live one, instead of every turn piling
+     * into a single buffer with one shared timestamp.
+     */
+    object ThinkingTurnEnded : AgentEvent()
+
     data class ToolCallStarted(val toolCallId: String, val name: String) : AgentEvent()
 
     data class ToolCallArgsDelta(val toolCallId: String, val delta: String) : AgentEvent()

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -21,9 +21,15 @@ import com.webtoapp.core.agent.engine.AgentEvent
 import com.webtoapp.core.agent.permission.PermissionChecker
 import com.webtoapp.core.agent.permission.PermissionMode
 import com.webtoapp.core.agent.permission.PermissionPrompter
+import com.webtoapp.core.agent.session.AgentMessage
+import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.core.agent.session.SessionStore
+import com.webtoapp.core.agent.tool.FileChange
 import com.webtoapp.core.agent.tool.ToolContext
 import com.webtoapp.core.agent.tool.ToolRegistry
+import com.webtoapp.core.agent.tool.ToolResult
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.ui.MainActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -65,6 +71,14 @@ class AgentService : Service() {
     private val _isRunning = MutableStateFlow(false)
     val isRunning: StateFlow<Boolean> = _isRunning.asStateFlow()
 
+    /**
+     * Snapshot of the currently running (or just-finished) turn, so the UI can resume
+     * an in-flight turn after being destroyed and recreated (e.g. user left the Agent
+     * screen, Activity got reclaimed, then came back). Null when no turn is active.
+     */
+    private val _activeTurn = MutableStateFlow<TurnSnapshot?>(null)
+    val activeTurn: StateFlow<TurnSnapshot?> = _activeTurn.asStateFlow()
+
     inner class LocalBinder : Binder() {
         fun service(): AgentService = this@AgentService
     }
@@ -89,12 +103,21 @@ class AgentService : Service() {
 
         val abort = AbortController().also { abortController = it }
         val engine = AgentEngine(gateway, permissionChecker, abort)
+        val store = request.sessionStore
+        val sessionId = request.sessionId
+        val accumulator = TurnAccumulator(sessionId)
+
+        _activeTurn.value = TurnSnapshot(
+            sessionId = sessionId,
+            isRunning = true,
+            draftMessage = null
+        )
 
         turnJob = scope.launch {
             try {
                 val ctx = ToolContext(
                     androidContext = this@AgentService,
-                    sessionId = request.sessionId,
+                    sessionId = sessionId,
                     fileManager = request.toolContext.fileManager,
                     textModel = request.toolContext.textModel,
                     textApiKey = request.toolContext.textApiKey,
@@ -106,6 +129,8 @@ class AgentService : Service() {
                     readFiles = request.toolContext.readFiles,
                     activePlanFile = request.toolContext.activePlanFile
                 )
+                // Single collection source: broadcast to UI AND persist in the same
+                // collector so persistence no longer depends on any UI scope.
                 engine.run(
                     AgentEngine.Input(
                         systemPrompt = request.systemPrompt,
@@ -117,13 +142,134 @@ class AgentService : Service() {
                         maxTurns = request.maxTurns,
                         maxTokens = resolveMaxOutputTokens(ctx.textModel.model)
                     )
-                ).collect { _events.emit(it) }
+                ).collect { ev ->
+                    // Broadcast to UI first so live streaming stays responsive.
+                    _events.emit(ev)
+                    // Then persist (best-effort; never let a storage failure kill the turn).
+                    if (store != null) {
+                        runCatching { persistEvent(store, sessionId, accumulator, ev) }
+                            .onFailure { AppLogger.w(TAG, "persist failed: ${it.message}") }
+                    }
+                }
             } catch (t: Throwable) {
-                _events.emit(AgentEvent.Failed(t.message ?: "service crashed"))
+                val ev = AgentEvent.Failed(t.message ?: "service crashed")
+                _events.emit(ev)
+                if (store != null) {
+                    runCatching { persistEvent(store, sessionId, accumulator, ev) }
+                }
             } finally {
                 _isRunning.value = false
                 releaseWakeLock()
                 abortController = null
+                // Keep the final snapshot briefly so a UI that rebinds right at the
+                // boundary can still observe the finished draft; clear the running flag.
+                _activeTurn.value = _activeTurn.value?.copy(isRunning = false)
+            }
+        }
+    }
+
+    private suspend fun persistEvent(
+        store: SessionStore,
+        sessionId: String,
+        acc: TurnAccumulator,
+        ev: AgentEvent
+    ) {
+        when (ev) {
+            is AgentEvent.TextDelta -> {
+                acc.applyTextDelta(ev.accumulated)
+                acc.maybeFlushDraft(store)
+            }
+            is AgentEvent.ThinkingDelta -> {
+                acc.applyThinkingDelta(ev.delta)
+                acc.maybeFlushDraft(store)
+            }
+            AgentEvent.ThinkingTurnEnded -> {
+                acc.freezeCurrentThinkingSegment()
+                acc.maybeFlushDraft(store)
+            }
+            is AgentEvent.ToolCallStarted -> {
+                acc.startTool(ev.toolCallId, ev.name)
+                acc.maybeFlushDraft(store)
+            }
+            is AgentEvent.ToolCallArgsDelta -> {
+                acc.appendToolArgs(ev.toolCallId, ev.delta)
+            }
+            is AgentEvent.ToolProgress -> {
+                acc.updateToolProgress(ev.toolCallId, ev.accumulated)
+                acc.maybeFlushDraft(store)
+            }
+            is AgentEvent.ToolExecuting -> {
+                acc.updateToolActivity(ev.toolCallId, ev.activity ?: ev.name)
+                acc.maybeFlushDraft(store)
+            }
+            is AgentEvent.ToolFinished -> {
+                acc.finishTool(ev.toolCallId, ev.name, ev.argumentsJson, ev.result)
+                acc.maybeFlushDraft(store, force = true)
+            }
+            is AgentEvent.FileChanged -> {
+                acc.recordProducedFile(ev.change.path)
+            }
+            is AgentEvent.Completed -> {
+                val msg = acc.buildFinalMessage(
+                    summaryFallback = ev.summary,
+                    isError = false
+                )
+                if (msg != null) {
+                    store.finalizeDraft(sessionId, msg)
+                    _activeTurn.value = TurnSnapshot(
+                        sessionId = sessionId,
+                        isRunning = false,
+                        draftMessage = msg
+                    )
+                } else {
+                    // Degenerate turn produced nothing durable; drop the draft so we
+                    // don't leave an empty stub message in the session.
+                    acc.draftId?.let { store.dropDraft(sessionId, it) }
+                    _activeTurn.value = null
+                }
+            }
+            is AgentEvent.Failed -> {
+                val msg = acc.buildFinalMessage(
+                    summaryFallback = null,
+                    isError = true,
+                    errorSuffix = ev.message
+                )
+                if (msg != null) {
+                    store.finalizeDraft(sessionId, msg)
+                }
+                _activeTurn.value = null
+            }
+            is AgentEvent.PlanReviewRequired -> {
+                val msg = acc.buildFinalMessage(
+                    summaryFallback = null,
+                    isError = false
+                )
+                if (msg != null) {
+                    store.finalizeDraft(sessionId, msg)
+                    _activeTurn.value = TurnSnapshot(
+                        sessionId = sessionId,
+                        isRunning = false,
+                        draftMessage = msg
+                    )
+                }
+            }
+            AgentEvent.Aborted -> {
+                val msg = acc.buildFinalMessage(
+                    summaryFallback = null,
+                    isError = true,
+                    errorSuffix = null,
+                    aborted = true
+                )
+                if (msg != null) {
+                    store.finalizeDraft(sessionId, msg)
+                } else {
+                    acc.draftId?.let { store.dropDraft(sessionId, it) }
+                }
+                _activeTurn.value = null
+            }
+            is AgentEvent.PermissionDenied, is AgentEvent.Usage, is AgentEvent.Notice,
+            AgentEvent.Started -> {
+                // No persistence impact.
             }
         }
     }
@@ -147,6 +293,7 @@ class AgentService : Service() {
         turnJob?.cancel()
         scope.cancel()
         releaseWakeLock()
+        _activeTurn.value = null
     }
 
     private fun ensureChannel() {
@@ -184,7 +331,7 @@ class AgentService : Service() {
 
     private fun acquireWakeLock() {
         if (wakeLock?.isHeld == true) return
-        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        val pm = getSystemService(POWER_SERVICE) as PowerManager
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "WebToApp:AgentTurn").apply {
             setReferenceCounted(false)
             acquire(WAKE_LOCK_TIMEOUT_MS)
@@ -203,15 +350,209 @@ class AgentService : Service() {
         val userMessage: String,
         val toolContext: ToolContext,
         val registry: ToolRegistry,
+        val sessionStore: SessionStore? = null,
         val temperature: Float = 0.7f,
         val maxTurns: Int = 24
     )
 
+    /**
+     * Live snapshot of a turn, exposed to the UI so it can resume display of an
+     * in-flight turn after recreation.
+     */
+    data class TurnSnapshot(
+        val sessionId: String,
+        val isRunning: Boolean,
+        val draftMessage: AgentMessage?
+    )
+
     companion object {
+        private const val TAG = "AgentService"
         private const val CHANNEL_ID = "aicoding_agent_v3"
         private const val NOTIFICATION_ID = 1201
         private const val WAKE_LOCK_TIMEOUT_MS = 20L * 60 * 1000
         private const val DEFAULT_MAX_OUTPUT_TOKENS = 8192
         private const val MAX_OUTPUT_TOKENS_CEILING = 32768
+    }
+}
+
+/**
+ * Accumulates a single turn's streaming output on the service side so it can be
+ * persisted as a draft (and finalized) independently of any UI scope. Mirrors the
+ * ViewModel's in-memory buffers but is purely data-oriented and persistence-driven.
+ */
+private class TurnAccumulator(private val sessionId: String) {
+    private val text = StringBuilder()
+    private val thinkingSegments = mutableListOf<ThinkingSegment>()
+    private val tools = LinkedHashMap<String, RecordedToolCall>()
+    private val toolArgs = LinkedHashMap<String, StringBuilder>()
+    private val producedFiles = mutableListOf<String>()
+
+    internal var draftId: String? = null
+        private set
+
+    private var lastFlushAt = 0L
+    private val startedAt: Long = System.currentTimeMillis()
+
+    private val toolMarkerRegex = Regex("\u2063TC:([^\u2063]+)\u2063")
+
+    private data class ThinkingSegment(
+        var content: String,
+        val startedAt: Long,
+        var frozenDurationMs: Long? = null
+    )
+
+    fun applyTextDelta(accumulated: String) {
+        text.setLength(0)
+        text.append(accumulated)
+    }
+
+    fun applyThinkingDelta(delta: String) {
+        val now = System.currentTimeMillis()
+        val tail = thinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null }
+        if (tail == null) {
+            thinkingSegments += ThinkingSegment(delta, now)
+        } else {
+            tail.content = tail.content + delta
+        }
+    }
+
+    fun freezeCurrentThinkingSegment() {
+        val tail = thinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null } ?: return
+        tail.frozenDurationMs = System.currentTimeMillis() - tail.startedAt
+    }
+
+    fun startTool(id: String, name: String) {
+        tools[id] = RecordedToolCall(
+            toolCallId = id,
+            name = name,
+            argumentsJson = "",
+            resultPreview = RecordedToolCall.RUNNING_SENTINEL,
+            ok = true
+        )
+        toolArgs.remove(id)
+    }
+
+    fun appendToolArgs(id: String, delta: String) {
+        toolArgs.getOrPut(id) { StringBuilder() }.append(delta)
+        tools[id]?.let { tools[id] = it.copy(argumentsJson = toolArgs[id].toString()) }
+    }
+
+    fun updateToolProgress(id: String, accumulated: String) {
+        val prev = tools[id] ?: return
+        val capped = if (accumulated.length <= PREVIEW_CAP) accumulated
+                     else accumulated.takeLast(PREVIEW_CAP)
+        tools[id] = prev.copy(resultPreview = capped)
+    }
+
+    fun updateToolActivity(id: String, activity: String) {
+        val prev = tools[id] ?: return
+        tools[id] = prev.copy(activity = activity)
+    }
+
+    fun finishTool(id: String, name: String, argumentsJson: String, result: ToolResult) {
+        val prev = tools[id]
+        tools[id] = RecordedToolCall(
+            toolCallId = id,
+            name = name,
+            argumentsJson = argumentsJson,
+            resultPreview = result.text.take(2000),
+            ok = !result.isError,
+            activity = prev?.activity
+        )
+        toolArgs.remove(id)
+    }
+
+    fun recordProducedFile(path: String) {
+        if (path !in producedFiles) producedFiles += path
+    }
+
+    /**
+     * Throttled draft upsert. Writes at most once per [FLUSH_INTERVAL_MS], unless
+     * [force] is set (used for tool-finish boundaries and other durable events).
+     */
+    suspend fun maybeFlushDraft(store: SessionStore, force: Boolean = false) {
+        val now = System.currentTimeMillis()
+        if (!force && now - lastFlushAt < FLUSH_INTERVAL_MS) return
+        lastFlushAt = now
+        val draft = buildDraftMessage() ?: return
+        store.upsertAssistantDraft(sessionId, draft)
+    }
+
+    private fun buildDraftMessage(): AgentMessage? {
+        val cleanText = stripToolMarkers(text.toString()).trim()
+        val joined = joinedThinking()
+        if (cleanText.isBlank() && joined.isNullOrBlank() && tools.isEmpty()) return null
+        val id = draftId ?: java.util.UUID.randomUUID().toString().also { draftId = it }
+        return AgentMessage(
+            id = id,
+            role = AgentMessage.Role.ASSISTANT,
+            content = cleanText.ifBlank { "" },
+            thinking = joined,
+            thinkingDurationMs = totalThinkingDurationMs(),
+            toolCalls = tools.values.toList(),
+            producedFiles = producedFiles.toList()
+        )
+    }
+
+    fun buildFinalMessage(
+        summaryFallback: String?,
+        isError: Boolean,
+        errorSuffix: String? = null,
+        aborted: Boolean = false
+    ): AgentMessage? {
+        val rawText = text.toString()
+        var cleanText = stripToolMarkers(rawText).trim()
+        if (cleanText.isBlank()) cleanText = stripToolMarkers(summaryFallback.orEmpty()).trim()
+        val joined = joinedThinking()
+        val anyTools = tools.isNotEmpty()
+        if (cleanText.isBlank() && joined.isNullOrBlank() && tools.isEmpty()) return null
+
+        val content = buildString {
+            append(cleanText)
+            if (aborted && cleanText.isNotBlank()) {
+                append("\n\n")
+                append(Strings.agentAbortedHint)
+            }
+            if (errorSuffix != null) {
+                if (isNotEmpty()) append("\n\n")
+                append(Strings.agentErrorPrefix.format(errorSuffix))
+            }
+        }.ifBlank { Strings.agentNoOutput }
+
+        val id = draftId ?: java.util.UUID.randomUUID().toString().also { draftId = it }
+        return AgentMessage(
+            id = id,
+            role = AgentMessage.Role.ASSISTANT,
+            content = content,
+            thinking = joined,
+            thinkingDurationMs = totalThinkingDurationMs(),
+            toolCalls = tools.values.toList(),
+            producedFiles = producedFiles.toList(),
+            isError = isError || aborted
+        )
+    }
+
+    private fun stripToolMarkers(s: String): String =
+        if (s.isEmpty() || '\u2063' !in s) s else toolMarkerRegex.replace(s, "")
+
+    private fun joinedThinking(): String? {
+        val joined = thinkingSegments.joinToString("\n\n") { it.content.trim() }
+            .replace(Regex("\n{3,}"), "\n\n")
+            .trim()
+        return joined.takeIf { it.isNotBlank() }
+    }
+
+    private fun totalThinkingDurationMs(): Long? {
+        if (thinkingSegments.isEmpty()) return null
+        val now = System.currentTimeMillis()
+        val total = thinkingSegments.sumOf { seg ->
+            seg.frozenDurationMs ?: (now - seg.startedAt).coerceAtLeast(0L)
+        }
+        return total.takeIf { it > 0 }
+    }
+
+    companion object {
+        private const val FLUSH_INTERVAL_MS = 200L
+        private const val PREVIEW_CAP = 2000
     }
 }

--- a/app/src/main/java/com/webtoapp/core/agent/session/SessionStore.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/session/SessionStore.kt
@@ -91,6 +91,53 @@ class SessionStore(
         it.copy(messages = messages)
     }
 
+    /**
+     * Insert or replace the trailing assistant [message] for a session, keyed by
+     * [message.id]. Used by [com.webtoapp.core.agent.runtime.AgentService] to keep a
+     * live "draft" of the in-flight turn so the output survives even if the UI is
+     * destroyed mid-turn. If the trailing message already has this id it is replaced
+     * in place (so the list does not grow on every throttled snapshot); otherwise the
+     * message is appended.
+     */
+    suspend fun upsertAssistantDraft(id: String, message: AgentMessage): AgentSession? = mutate(id) { s ->
+        val msgs = s.messages.toMutableList()
+        val draftIdx = msgs.indexOfLast { it.id == message.id }
+        if (draftIdx >= 0) {
+            msgs[draftIdx] = message
+        } else {
+            msgs += message
+        }
+        s.copy(messages = msgs)
+    }
+
+    /**
+     * Finalize a draft: replace the trailing message whose id == [final.id] with
+     * [final] (used when the turn ends), or append [final] if no draft with that id
+     * exists. Returns the updated session.
+     */
+    suspend fun finalizeDraft(id: String, final: AgentMessage): AgentSession? = mutate(id) { s ->
+        val msgs = s.messages.toMutableList()
+        val draftIdx = msgs.indexOfLast { it.id == final.id }
+        if (draftIdx >= 0) {
+            msgs[draftIdx] = final
+        } else {
+            msgs += final
+        }
+        s.copy(messages = msgs)
+    }
+
+    /**
+     * Remove the trailing draft message with [draftMessageId] if it is still present
+     * and was never finalized. Used to clean up an aborted draft that produced no
+     * usable output.
+     */
+    suspend fun dropDraft(sessionId: String, draftMessageId: String): AgentSession? = mutate(sessionId) { s ->
+        val msgs = s.messages.toMutableList()
+        val idx = msgs.indexOfLast { it.id == draftMessageId }
+        if (idx >= 0) msgs.removeAt(idx)
+        s.copy(messages = msgs)
+    }
+
     suspend fun truncateAt(id: String, messageId: String, keep: Boolean): AgentSession? = mutate(id) { s ->
         val idx = s.messages.indexOfFirst { it.id == messageId }
         if (idx < 0) return@mutate s

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -499,7 +499,11 @@ private fun Conversation(
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
-    val messages = state.currentSession?.messages.orEmpty()
+    // Hide the in-flight assistant draft from history while streaming: it is shown
+    // live via StreamingBubble, so including it here would render the same output twice.
+    val messages = state.currentSession?.messages.orEmpty().filterNot {
+        it.id == state.streamingDraftMessageId
+    }
 
     var followBottom by remember { mutableStateOf(true) }
     val atBottom by remember {
@@ -532,7 +536,7 @@ private fun Conversation(
     }
 
     val streamingTextLen = state.streamingText.length
-    val streamingThinkingLen = state.streamingThinking.length
+    val streamingThinkingLen = state.streamingThinkingSegments.sumOf { it.content.length }
     LaunchedEffect(
         followBottom,
         messages.size,
@@ -595,9 +599,7 @@ private fun Conversation(
                 item(key = "streaming") {
                     StreamingBubble(
                         text = state.streamingText,
-                        thinking = state.streamingThinking,
-                        thinkingStartedAt = state.streamingThinkingStartedAt,
-                        thinkingFrozenDurationMs = state.streamingThinkingDurationMs,
+                        thinkingSegments = state.streamingThinkingSegments,
                         pendingTools = state.pendingToolCalls,
                         activity = state.currentActivity
                     )

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -15,11 +15,15 @@ data class AgentUiState(
     val currentSession: AgentSession? = null,
 
     val streamingText: String = "",
-    val streamingThinking: String = "",
+    val streamingThinkingSegments: List<ThinkingSegment> = emptyList(),
 
-    val streamingThinkingStartedAt: Long? = null,
+    /**
+     * Message id of the assistant draft the service is currently writing, if any.
+     * The UI hides this message from the history list while streaming (to avoid it
+     * showing twice: once as a saved bubble and once in the live StreamingBubble).
+     */
+    val streamingDraftMessageId: String? = null,
 
-    val streamingThinkingDurationMs: Long? = null,
     val pendingToolCalls: List<RecordedToolCall> = emptyList(),
     val currentActivity: String? = null,
 
@@ -105,6 +109,18 @@ data class ContextAppItem(
     val name: String,
     val appType: String,
     val categoryId: Long? = null
+)
+
+/**
+ * One turn's worth of streaming reasoning. [frozenDurationMs] is null while the
+ * reasoning for this turn is still arriving (live); once the turn's thinking stream
+ * ends it is frozen so the UI renders a static, collapsed block and the next turn
+ * can open its own live block.
+ */
+data class ThinkingSegment(
+    val content: String,
+    val startedAt: Long,
+    val frozenDurationMs: Long? = null
 )
 
 data class ContextModuleItem(

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.google.gson.JsonParser
 import com.webtoapp.core.ai.AiConfigManager
 import com.webtoapp.core.agent.llm.LlmMessage
 import com.webtoapp.core.agent.engine.AgentEvent
@@ -117,9 +116,10 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     private var eventCollectionJob: Job? = null
     private var permissionCollectionJob: Job? = null
     private var choiceCollectionJob: Job? = null
+    private var activeTurnJob: Job? = null
     private var streamingSessionId: String? = null
     private val streamText = StringBuilder()
-    private val streamThinking = StringBuilder()
+    private val streamThinkingSegments = mutableListOf<ThinkingSegment>()
     private val streamTools = LinkedHashMap<String, RecordedToolCall>()
     private val streamToolArgs = HashMap<String, StringBuilder>()
     private val readFilesThisTurn = mutableSetOf<String>()
@@ -635,43 +635,20 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun cancelTurn() {
-        val sid = streamingSessionId
-        if (sid != null) {
-            viewModelScope.launch { savePartialMessage(sid) }
-        }
+        // Aborted-turn persistence is handled by AgentService. Here we just cancel the
+        // engine job and reset UI buffers immediately for responsiveness.
         service?.cancel()
         _ui.update {
             it.copy(
                 phase = AgentUiState.Phase.Idle,
                 currentActivity = null,
                 streamingText = "",
-                streamingThinking = "",
-                streamingThinkingStartedAt = null,
-                streamingThinkingDurationMs = null,
+                streamingThinkingSegments = emptyList(),
                 pendingToolCalls = emptyList()
             )
         }
         streamingSessionId = null
-        streamText.clear(); streamThinking.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
-    }
-
-    private suspend fun savePartialMessage(sid: String) {
-        val text = streamText.toString().trim()
-        val thinking = streamThinking.toString().takeIf { it.isNotBlank() }
-        val tools = streamTools.values.toList()
-        if (text.isBlank() && thinking.isNullOrBlank() && tools.isEmpty()) return
-        sessionStore.appendMessage(
-            sid,
-            AgentMessage(
-                role = AgentMessage.Role.ASSISTANT,
-                content = text.ifBlank { Strings.agentNoOutput } + "\n\n" + Strings.agentAbortedHint,
-                isError = true,
-                thinking = thinking,
-                thinkingDurationMs = _ui.value.streamingThinkingDurationMs
-                    ?: _ui.value.streamingThinkingStartedAt?.let { start -> System.currentTimeMillis() - start },
-                toolCalls = tools
-            )
-        )
+        streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
     }
 
     fun dismissBanner() {
@@ -1050,16 +1027,14 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         } else session
 
         streamingSessionId = workingSession.id
-        streamText.clear(); streamThinking.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
+        streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
         val compactSvc2 = compactService ?: CompactService(service!!.gateway).also { compactService = it }
         val estTokens = compactSvc2.estimateTokens(workingSession.messages)
         _ui.update {
             it.copy(
                 phase = AgentUiState.Phase.Connecting,
                 streamingText = "",
-                streamingThinking = "",
-                streamingThinkingStartedAt = null,
-                streamingThinkingDurationMs = null,
+                streamingThinkingSegments = emptyList(),
                 pendingToolCalls = emptyList(),
                 currentActivity = null,
                 error = null,
@@ -1195,6 +1170,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 userMessage = if (tailHasMentions) "" else prompt,
                 toolContext = toolCtx,
                 registry = registry,
+                sessionStore = sessionStore,
                 temperature = session.config.temperature,
                 maxTurns = session.config.maxTurns
             )
@@ -1326,6 +1302,11 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private fun attachToService() {
+        // If the service is still running a turn (e.g. the UI was destroyed and is now
+        // reconnecting), resume the streaming buffers from its latest draft so the user
+        // sees the in-flight output instead of a blank screen.
+        resumeFromActiveTurn()
+
         eventCollectionJob?.cancel()
         eventCollectionJob = viewModelScope.launch {
             service?.events?.collect { handleAgentEvent(it) }
@@ -1344,8 +1325,60 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 _ui.update { it.copy(pendingChoice = req) }
             }
         }
+        // Track the service's active-turn draft id so the UI can hide the in-flight
+        // draft from the history list (it is shown live via StreamingBubble instead).
+        activeTurnJob?.cancel()
+        activeTurnJob = viewModelScope.launch {
+            service?.activeTurn?.collect { snap ->
+                val draftId = snap?.takeIf { it.isRunning }?.draftMessage?.id
+                _ui.update { it.copy(streamingDraftMessageId = draftId) }
+            }
+        }
 
         applyAutoApproveToService(_ui.value.autoApprove)
+    }
+
+    /**
+     * Pull the service's current [AgentService.activeTurn] snapshot into the streaming
+     * UI buffers. This lets a freshly created ViewModel (after the previous one was
+     * cleared) pick up an in-flight turn and keep showing its progress live.
+     */
+    private fun resumeFromActiveTurn() {
+        val svc = service ?: return
+        val snapshot = svc.activeTurn.value ?: return
+        if (!snapshot.isRunning) return
+        val draft = snapshot.draftMessage ?: return
+        // Only resume if this turn belongs to the session the user is currently viewing.
+        if (_ui.value.currentSession?.id != snapshot.sessionId) return
+
+        streamingSessionId = snapshot.sessionId
+        streamText.setLength(0)
+        streamText.append(draft.content)
+        streamThinkingSegments.clear()
+        // The draft's thinking is a single joined string (per-turn boundaries are not
+        // preserved across drafts); restore it as one segment. New live deltas will open
+        // a fresh segment after the current one is frozen.
+        draft.thinking?.takeIf { it.isNotBlank() }?.let {
+            streamThinkingSegments += ThinkingSegment(
+                content = it,
+                startedAt = System.currentTimeMillis(),
+                frozenDurationMs = draft.thinkingDurationMs
+            )
+        }
+        streamTools.clear()
+        streamToolArgs.clear()
+        draft.toolCalls.forEach { tc ->
+            streamTools[tc.toolCallId] = tc
+        }
+        _ui.update {
+            it.copy(
+                phase = AgentUiState.Phase.Streaming,
+                streamingText = draft.content,
+                streamingThinkingSegments = streamThinkingSegments.toList(),
+                pendingToolCalls = streamTools.values.toList(),
+                currentActivity = streamTools.values.lastOrNull()?.activity
+            )
+        }
     }
 
     private suspend fun handleAgentEvent(ev: AgentEvent) {
@@ -1355,23 +1388,32 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
             is AgentEvent.TextDelta -> {
                 streamText.setLength(0); streamText.append(ev.accumulated)
                 _ui.update {
-
-                    val frozen = it.streamingThinkingDurationMs ?: it.streamingThinkingStartedAt
-                        ?.let { start -> System.currentTimeMillis() - start }
-                    it.copy(
-                        streamingText = ev.accumulated,
-                        streamingThinkingDurationMs = frozen
-                    )
+                    it.copy(streamingText = ev.accumulated)
                 }
             }
             is AgentEvent.ThinkingDelta -> {
-                streamThinking.append(ev.delta)
+                // Append to the current live segment, or open a new one for a fresh turn.
+                val now = System.currentTimeMillis()
+                val tail = streamThinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null }
+                if (tail == null) {
+                    streamThinkingSegments += ThinkingSegment(content = ev.delta, startedAt = now)
+                } else {
+                    streamThinkingSegments[streamThinkingSegments.lastIndex] =
+                        tail.copy(content = tail.content + ev.delta)
+                }
                 _ui.update {
-                    val started = it.streamingThinkingStartedAt ?: System.currentTimeMillis()
-                    it.copy(
-                        streamingThinking = streamThinking.toString(),
-                        streamingThinkingStartedAt = started
-                    )
+                    it.copy(streamingThinkingSegments = streamThinkingSegments.toList())
+                }
+            }
+            AgentEvent.ThinkingTurnEnded -> {
+                // Freeze the live segment so the next turn opens its own live block.
+                val tail = streamThinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null }
+                if (tail != null) {
+                    streamThinkingSegments[streamThinkingSegments.lastIndex] =
+                        tail.copy(frozenDurationMs = System.currentTimeMillis() - tail.startedAt)
+                    _ui.update {
+                        it.copy(streamingThinkingSegments = streamThinkingSegments.toList())
+                    }
                 }
             }
             is AgentEvent.ToolCallStarted -> {
@@ -1479,59 +1521,16 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 _ui.update { it.copy(info = ev.message) }
             }
             is AgentEvent.Completed -> {
-                val rawText = streamText.toString()
-                val text = stripToolMarkers(rawText).trim().ifEmpty {
-                    stripToolMarkers(ev.summary).trim()
-                }
-                val contentForTimeline = rawText.ifBlank { text }
-                val producedFiles = streamTools.values
-                    .filter { it.ok && it.name in setOf("Write", "Edit", "Delete", "GenerateImage") }
-                    .mapNotNull { tc ->
-                        runCatching {
-                            JsonParser.parseString(tc.argumentsJson).asJsonObject.get("path")?.asString
-                        }.getOrNull()
-                    }
-                    .distinct()
-                val attachments = streamTools.values
-                    .filter { it.ok && it.name == "GenerateImage" }
-                    .mapNotNull { tc ->
-                        runCatching {
-                            JsonParser.parseString(tc.argumentsJson).asJsonObject.get("path")?.asString
-                        }.getOrNull()
-                    }
-
-                val isDegenerate = text.isBlank() &&
-                    streamThinking.toString().isBlank() &&
-                    streamTools.isEmpty()
-                val finalContent = if (isDegenerate) {
-                    Strings.agentEmptyResponseHint
-                } else {
-                    text
-                }
-                val saved = sessionStore.appendMessage(
-                    sid,
-                    AgentMessage(
-                        role = AgentMessage.Role.ASSISTANT,
-                        content = if (isDegenerate) finalContent else contentForTimeline.ifBlank { finalContent },
-                        thinking = streamThinking.toString().takeIf { it.isNotBlank() },
-                        thinkingDurationMs = _ui.value.streamingThinkingDurationMs
-                            ?: _ui.value.streamingThinkingStartedAt?.let { start -> System.currentTimeMillis() - start },
-                        toolCalls = streamTools.values.toList(),
-                        producedFiles = producedFiles,
-                        attachments = attachments,
-                        isError = isDegenerate
-                    )
-                )
+                // Persistence is handled by AgentService (outlives the UI scope).
+                // Here we only reset the streaming UI buffers and surface a notice.
                 streamingSessionId = null
-                streamText.clear(); streamThinking.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
+                streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
                 lastToolUiPushAt = 0L
                 _ui.update {
                     it.copy(
                         phase = AgentUiState.Phase.Idle,
                         streamingText = "",
-                        streamingThinking = "",
-                        streamingThinkingStartedAt = null,
-                        streamingThinkingDurationMs = null,
+                        streamingThinkingSegments = emptyList(),
                         pendingToolCalls = emptyList(),
                         currentActivity = null,
                         info = if (ev.toolCallCount > 0)
@@ -1539,31 +1538,18 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                         else null
                     )
                 }
-
-                saved?.let { maybeAutoTitle(it) }
+                // The service finalized the message; refresh title from the persisted session.
+                viewModelScope.launch { maybeAutoTitle(sid) }
             }
             is AgentEvent.PlanReviewRequired -> {
                 val planContent = files.readText(sid, ev.planPath) ?: ""
-                val text = streamText.toString().trim().ifEmpty { Strings.agentPlanAwaitingReview }
-                sessionStore.appendMessage(
-                    sid,
-                    AgentMessage(
-                        role = AgentMessage.Role.ASSISTANT,
-                        content = text,
-                        thinking = streamThinking.toString().takeIf { it.isNotBlank() },
-                        thinkingDurationMs = _ui.value.streamingThinkingDurationMs
-                            ?: _ui.value.streamingThinkingStartedAt?.let { start -> System.currentTimeMillis() - start },
-                        toolCalls = streamTools.values.toList()
-                    )
-                )
                 streamingSessionId = null
+                streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
                 _ui.update {
                     it.copy(
                         phase = AgentUiState.Phase.Idle,
                         streamingText = "",
-                        streamingThinking = "",
-                        streamingThinkingStartedAt = null,
-                        streamingThinkingDurationMs = null,
+                        streamingThinkingSegments = emptyList(),
                         pendingToolCalls = emptyList(),
                         currentActivity = null,
                         pendingPlanReview = PlanReview(planPath = ev.planPath, content = planContent)
@@ -1571,41 +1557,28 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 }
             }
             AgentEvent.Aborted -> {
-                savePartialMessage(sid)
+                // Partial output is persisted by AgentService; just reset UI state.
                 streamingSessionId = null
+                streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
                 _ui.update {
                     it.copy(
                         phase = AgentUiState.Phase.Idle,
                         streamingText = "",
-                        streamingThinking = "",
-                        streamingThinkingStartedAt = null,
-                        streamingThinkingDurationMs = null,
+                        streamingThinkingSegments = emptyList(),
                         pendingToolCalls = emptyList(),
                         currentActivity = null
                     )
                 }
             }
             is AgentEvent.Failed -> {
-                sessionStore.appendMessage(
-                    sid,
-                    AgentMessage(
-                        role = AgentMessage.Role.ASSISTANT,
-                        content = streamText.toString().ifBlank { Strings.agentNoOutput } + "\n\n" + Strings.agentErrorPrefix.format(ev.message),
-                        isError = true,
-                        thinking = streamThinking.toString().takeIf { it.isNotBlank() },
-                        thinkingDurationMs = _ui.value.streamingThinkingDurationMs
-                            ?: _ui.value.streamingThinkingStartedAt?.let { start -> System.currentTimeMillis() - start },
-                        toolCalls = streamTools.values.toList()
-                    )
-                )
+                // Error message is persisted by AgentService; just reset UI state.
                 streamingSessionId = null
+                streamText.clear(); streamThinkingSegments.clear(); streamTools.clear(); streamToolArgs.clear(); readFilesThisTurn.clear()
                 _ui.update {
                     it.copy(
                         phase = AgentUiState.Phase.Idle,
                         streamingText = "",
-                        streamingThinking = "",
-                        streamingThinkingStartedAt = null,
-                        streamingThinkingDurationMs = null,
+                        streamingThinkingSegments = emptyList(),
                         pendingToolCalls = emptyList(),
                         currentActivity = null
                     )
@@ -1614,7 +1587,10 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    private fun maybeAutoTitle(session: AgentSession) {
+    private suspend fun maybeAutoTitle(sessionId: String) {
+        // Re-read from the store: the service finalized the assistant message, so the
+        // persisted session is the source of truth here.
+        val session = sessionStore.get(sessionId) ?: return
         if (!session.titleAutoGenerated) return
 
         val userMsgs = session.messages.count { it.role == AgentMessage.Role.USER }
@@ -1622,70 +1598,68 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         if (userMsgs != 1 || assistantMsgs != 1) return
 
         val gateway = service?.gateway ?: return
-        viewModelScope.launch {
-            val models = configManager.savedModelsFlow.first()
-            val keys = configManager.apiKeysFlow.first()
-            val textModel = resolveTextModel(models) ?: return@launch
-            val textKey = keys.firstOrNull { it.id == textModel.apiKeyId } ?: return@launch
+        val models = configManager.savedModelsFlow.first()
+        val keys = configManager.apiKeysFlow.first()
+        val textModel = resolveTextModel(models) ?: return
+        val textKey = keys.firstOrNull { it.id == textModel.apiKeyId } ?: return
 
-            val firstUser = session.messages.first { it.role == AgentMessage.Role.USER }.content
-            val firstAssistant = session.messages.first { it.role == AgentMessage.Role.ASSISTANT }.content
+        val firstUser = session.messages.first { it.role == AgentMessage.Role.USER }.content
+        val firstAssistant = session.messages.first { it.role == AgentMessage.Role.ASSISTANT }.content
 
-            val sysPrompt = """
-                Summarise the following conversation as a short title.
-                Constraints:
-                - 4 to 7 words; no leading verbs like "How to" or "Helping with".
-                - Match the user's language (Chinese stays Chinese, English stays English, etc.).
-                - Plain text only — no quotes, no trailing punctuation, no markdown.
-                - Respond with the title only. Do not preface, do not explain.
-            """.trimIndent()
-            val convo = buildString {
-                append("User: ")
-                append(firstUser.take(800))
-                append("\n\nAssistant: ")
-                append(firstAssistant.take(400))
-            }
-
-            val req = com.webtoapp.core.agent.llm.ChatRequest(
-                apiKey = textKey,
-                model = textModel.model,
-                messages = listOf(
-                    LlmMessage(LlmMessage.Role.SYSTEM, sysPrompt),
-                    LlmMessage(LlmMessage.Role.USER, convo)
-                ),
-                tools = emptyList(),
-                temperature = 0.3f,
-                useTools = false
-            )
-
-            val sb = StringBuilder()
-            try {
-                gateway.chatStream(req).collect { ev ->
-                    when (ev) {
-                        is com.webtoapp.core.agent.llm.LlmEvent.TextDelta -> sb.append(ev.delta)
-                        is com.webtoapp.core.agent.llm.LlmEvent.Error ->
-                            if (!ev.recoverable) return@collect
-                        else -> Unit
-                    }
-                }
-            } catch (_: Throwable) {
-                return@launch
-            }
-
-            val title = sb.toString()
-                .lineSequence()
-                .map { it.trim() }
-                .firstOrNull { it.isNotEmpty() }
-                ?.trim('"', '\'', '“', '”', '「', '」', '《', '》')
-                ?.trimEnd('.', '。', '!', '！', '?', '？', ':', '：', ';', '；', ',', '，')
-                ?.trim()
-                ?.takeIf { it.isNotEmpty() }
-                ?.take(40)
-                ?: return@launch
-
-            if (title == session.title.trim()) return@launch
-            sessionStore.setAutoTitle(session.id, title)
+        val sysPrompt = """
+            Summarise the following conversation as a short title.
+            Constraints:
+            - 4 to 7 words; no leading verbs like "How to" or "Helping with".
+            - Match the user's language (Chinese stays Chinese, English stays English, etc.).
+            - Plain text only — no quotes, no trailing punctuation, no markdown.
+            - Respond with the title only. Do not preface, do not explain.
+        """.trimIndent()
+        val convo = buildString {
+            append("User: ")
+            append(firstUser.take(800))
+            append("\n\nAssistant: ")
+            append(firstAssistant.take(400))
         }
+
+        val req = com.webtoapp.core.agent.llm.ChatRequest(
+            apiKey = textKey,
+            model = textModel.model,
+            messages = listOf(
+                LlmMessage(LlmMessage.Role.SYSTEM, sysPrompt),
+                LlmMessage(LlmMessage.Role.USER, convo)
+            ),
+            tools = emptyList(),
+            temperature = 0.3f,
+            useTools = false
+        )
+
+        val sb = StringBuilder()
+        try {
+            gateway.chatStream(req).collect { ev ->
+                when (ev) {
+                    is com.webtoapp.core.agent.llm.LlmEvent.TextDelta -> sb.append(ev.delta)
+                    is com.webtoapp.core.agent.llm.LlmEvent.Error ->
+                        if (!ev.recoverable) return@collect
+                    else -> Unit
+                }
+            }
+        } catch (_: Throwable) {
+            return
+        }
+
+        val title = sb.toString()
+            .lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.isNotEmpty() }
+            ?.trim('"', '\'', '“', '”', '「', '」', '《', '》')
+            ?.trimEnd('.', '。', '!', '！', '?', '？', ':', '：', ';', '；', ',', '，')
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.take(40)
+            ?: return
+
+        if (title == session.title.trim()) return
+        sessionStore.setAutoTitle(session.id, title)
     }
 
     private fun synthesiseReadCallsFor(m: AgentMessage, sessionId: String): List<LlmMessage> {
@@ -1778,6 +1752,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         eventCollectionJob?.cancel()
         permissionCollectionJob?.cancel()
         choiceCollectionJob?.cancel()
+        activeTurnJob?.cancel()
         if (bound) runCatching { ctx.unbindService(connection) }
     }
 

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -68,6 +68,7 @@ import com.webtoapp.core.agent.session.AgentMessage
 import com.webtoapp.core.agent.session.RecordedToolCall
 import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.ui.agent.ThinkingSegment
 import com.webtoapp.ui.design.WtaAlpha
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
@@ -304,34 +305,33 @@ fun ThinkingBlock(
 @Composable
 fun StreamingBubble(
     text: String,
-    thinking: String,
-    thinkingStartedAt: Long?,
-    thinkingFrozenDurationMs: Long?,
+    thinkingSegments: List<ThinkingSegment>,
     pendingTools: List<RecordedToolCall>,
     activity: String?
 ) {
-    val isThinkingLive = thinkingFrozenDurationMs == null && text.isBlank() && thinking.isNotBlank()
+    val hasLiveSegment = thinkingSegments.any { it.frozenDurationMs == null }
     var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
-    LaunchedEffect(isThinkingLive) {
-        while (isThinkingLive) {
+    LaunchedEffect(hasLiveSegment) {
+        while (hasLiveSegment) {
             nowMs = System.currentTimeMillis()
             kotlinx.coroutines.delay(100)
         }
     }
 
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.Start) {
-        if (thinking.isNotBlank()) {
-            val liveDurationMs = thinkingStartedAt?.let { nowMs - it }
+        thinkingSegments.forEach { seg ->
+            val isLive = seg.frozenDurationMs == null
+            val durationMs = seg.frozenDurationMs ?: (nowMs - seg.startedAt)
             ThinkingBlock(
-                content = thinking,
-                durationMs = thinkingFrozenDurationMs ?: liveDurationMs,
-                isLive = isThinkingLive,
-                initiallyExpanded = isThinkingLive,
+                content = seg.content,
+                durationMs = durationMs,
+                isLive = isLive,
+                initiallyExpanded = isLive,
                 modifier = Modifier.widthIn(max = 560.dp)
             )
             Spacer(Modifier.height(WtaSpacing.Tiny))
         }
-        if (text.isNotBlank() || pendingTools.isNotEmpty() || thinking.isBlank()) {
+        if (text.isNotBlank() || pendingTools.isNotEmpty() || thinkingSegments.isEmpty()) {
             WtaCard(
                 tone = WtaCardTone.Surface,
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(


### PR DESCRIPTION
## Summary

Fixes two related Agent output-loss bugs from #429.

### 1. Only turn 1's reasoning was shown
A single user request often runs multiple engine turns (reasoning → text → tool call → next reasoning). The streaming state machine shared **one accumulated thinking buffer and a single start timestamp** across all turns, so after turn 1 the UI's "is thinking live" guard (`frozenDurationMs == null && text.isBlank() && thinking.isNotBlank()`) was always false — subsequent turns' reasoning was force-collapsed and stamped with turn 1's duration.

**Fix:** each turn now gets its own live `ThinkingSegment` (own timer). A new `ThinkingTurnEnded` event freezes the current segment when a turn's reasoning stream ends, so the next turn opens a fresh live block.

### 2. In-flight output was lost when the UI left or the app was killed
Message persistence ran only in the UI layer (`viewModelScope`). When the Activity was destroyed (background reclaim / swipe-kill) or the process force-killed, `viewModelScope` was cancelled mid-turn → the `Completed` event was never handled → all streaming buffers that lived only in ViewModel memory were lost.

**Fix:** persistence moved into `AgentService`. The engine's event flow is collected by a single collector in the service's own scope that both **broadcasts events to the UI** and **persists a throttled draft** to `SessionStore` (every ~200ms + on tool boundaries), so the turn outlives any UI scope. The service exposes an `activeTurn: StateFlow<TurnSnapshot?>`; a recreated UI reads it to **resume live progress**. The persisted draft is hidden from the history list while streaming to avoid duplicate bubbles.

### Why this is safe
- `AgentMessage` / `SessionStore` data model is unchanged — drafts reuse `AgentMessage`; Gson handles it transparently.
- `sessionStore.sessionsFlow` was already observed by the UI, so Service writes refresh the message list automatically.
- Service is `started + bound`; unbinding on `onCleared` does not destroy it, so the turn keeps running in the background.
- Write split: user messages are still written by the ViewModel; assistant messages are written only by the Service — no concurrent DataStore writes to the same message.
- User-only tool surface; nothing here is shell-synced, so export/preview paths are unaffected.

Fixes #429

## Test plan
- [x] `:app:compileDebugKotlin` green
- [x] `:app:checkConfigFieldDrift` green
- [ ] Manual: multi-turn tool-calling request with a reasoning model → each turn's thinking block shows independently, live, then collapses with its own duration.
- [ ] Manual: start a multi-turn request → leave the Agent screen → wait for completion → return → assistant output persisted and visible.
- [ ] Manual: start a request → swipe-kill the app (Activity destroyed, service survives) → reopen → live progress resumed from the service snapshot.
- [ ] Manual: start a request → force-kill the process → reopen → recovered up to the last throttled draft snapshot.