### PR TITLE
fix(agent): interleave thinking with output; preserve per-turn thinking segments

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -115,8 +115,18 @@ class AgentEngine(
                                 send(AgentEvent.TextDelta(ev.delta, accText.toString()))
                             }
                             is LlmEvent.ThinkingDelta -> {
+                                // On the first delta of a turn's reasoning stream, anchor a
+                                // thinking marker in the accumulated text (mirrors the tool
+                                // marker) so the timeline can interleave this block with
+                                // prose/tools in the order they actually occurred.
+                                if (turnThinking.isEmpty()) {
+                                    val segmentId = "th-turn-$turn"
+                                    val marker = "\u2063TH:$segmentId\u2063"
+                                    accText.append(marker)
+                                    send(AgentEvent.TextDelta(marker, accText.toString()))
+                                }
                                 turnThinking.append(ev.delta)
-                                send(AgentEvent.ThinkingDelta(ev.delta, turnThinking.toString()))
+                                send(AgentEvent.ThinkingDelta("th-turn-$turn", ev.delta, turnThinking.toString()))
                             }
                             is LlmEvent.ToolCallBegin -> {
                                 pending[ev.id] = ev.name to StringBuilder()

--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
@@ -8,7 +8,7 @@ sealed class AgentEvent {
 
     data class TextDelta(val delta: String, val accumulated: String) : AgentEvent()
 
-    data class ThinkingDelta(val delta: String, val accumulated: String) : AgentEvent()
+    data class ThinkingDelta(val segmentId: String, val delta: String, val accumulated: String) : AgentEvent()
 
     /**
      * Emitted once the current turn's reasoning stream has finished and the model is

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -24,6 +24,7 @@ import com.webtoapp.core.agent.permission.PermissionPrompter
 import com.webtoapp.core.agent.session.AgentMessage
 import com.webtoapp.core.agent.session.RecordedToolCall
 import com.webtoapp.core.agent.session.SessionStore
+import com.webtoapp.core.agent.session.ThinkingSegmentData
 import com.webtoapp.core.agent.tool.FileChange
 import com.webtoapp.core.agent.tool.ToolContext
 import com.webtoapp.core.agent.tool.ToolRegistry
@@ -180,7 +181,7 @@ class AgentService : Service() {
                 acc.maybeFlushDraft(store)
             }
             is AgentEvent.ThinkingDelta -> {
-                acc.applyThinkingDelta(ev.delta)
+                acc.applyThinkingDelta(ev.segmentId, ev.delta)
                 acc.maybeFlushDraft(store)
             }
             AgentEvent.ThinkingTurnEnded -> {
@@ -393,9 +394,10 @@ private class TurnAccumulator(private val sessionId: String) {
     private var lastFlushAt = 0L
     private val startedAt: Long = System.currentTimeMillis()
 
-    private val toolMarkerRegex = Regex("\u2063TC:([^\u2063]+)\u2063")
+    private val inlineMarkerRegex = Regex("\u2063(?:TC|TH):[^\u2063]+\u2063")
 
     private data class ThinkingSegment(
+        val id: String,
         var content: String,
         val startedAt: Long,
         var frozenDurationMs: Long? = null
@@ -406,19 +408,23 @@ private class TurnAccumulator(private val sessionId: String) {
         text.append(accumulated)
     }
 
-    fun applyThinkingDelta(delta: String) {
+    fun applyThinkingDelta(segmentId: String, delta: String) {
         val now = System.currentTimeMillis()
-        val tail = thinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null }
-        if (tail == null) {
-            thinkingSegments += ThinkingSegment(delta, now)
+        val idx = thinkingSegments.indexOfFirst { it.id == segmentId }
+        if (idx < 0) {
+            thinkingSegments += ThinkingSegment(segmentId, delta, now)
         } else {
-            tail.content = tail.content + delta
+            thinkingSegments[idx].content = thinkingSegments[idx].content + delta
         }
     }
 
     fun freezeCurrentThinkingSegment() {
-        val tail = thinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null } ?: return
-        tail.frozenDurationMs = System.currentTimeMillis() - tail.startedAt
+        val now = System.currentTimeMillis()
+        thinkingSegments.forEach { seg ->
+            if (seg.frozenDurationMs == null) {
+                seg.frozenDurationMs = now - seg.startedAt
+            }
+        }
     }
 
     fun startTool(id: String, name: String) {
@@ -479,15 +485,21 @@ private class TurnAccumulator(private val sessionId: String) {
     }
 
     private fun buildDraftMessage(): AgentMessage? {
-        val cleanText = stripToolMarkers(text.toString()).trim()
+        // Keep inline markers (both tool and thinking) in content: the timeline renderer
+        // turns them into interleaved Tool/Thinking segments. Strip only to judge whether
+        // there is any substantive content.
+        val raw = text.toString().trim()
         val joined = joinedThinking()
-        if (cleanText.isBlank() && joined.isNullOrBlank() && tools.isEmpty()) return null
+        val segs = buildThinkingSegmentData()
+        val hasSubstance = stripAllMarkers(raw).isNotBlank() || !joined.isNullOrBlank() || tools.isNotEmpty()
+        if (!hasSubstance) return null
         val id = draftId ?: java.util.UUID.randomUUID().toString().also { draftId = it }
         return AgentMessage(
             id = id,
             role = AgentMessage.Role.ASSISTANT,
-            content = cleanText.ifBlank { "" },
+            content = raw,
             thinking = joined,
+            thinkingSegments = segs,
             thinkingDurationMs = totalThinkingDurationMs(),
             toolCalls = tools.values.toList(),
             producedFiles = producedFiles.toList()
@@ -500,16 +512,18 @@ private class TurnAccumulator(private val sessionId: String) {
         errorSuffix: String? = null,
         aborted: Boolean = false
     ): AgentMessage? {
-        val rawText = text.toString()
-        var cleanText = stripToolMarkers(rawText).trim()
-        if (cleanText.isBlank()) cleanText = stripToolMarkers(summaryFallback.orEmpty()).trim()
+        val raw = text.toString().trim()
         val joined = joinedThinking()
-        val anyTools = tools.isNotEmpty()
-        if (cleanText.isBlank() && joined.isNullOrBlank() && tools.isEmpty()) return null
+        val segs = buildThinkingSegmentData()
+        val hasSubstance = stripAllMarkers(raw).isNotBlank() || !joined.isNullOrBlank() || tools.isNotEmpty()
+        if (!hasSubstance) return null
+
+        val baseText = if (stripAllMarkers(raw).isNotBlank()) raw
+                       else stripAllMarkers(summaryFallback.orEmpty()).trim()
 
         val content = buildString {
-            append(cleanText)
-            if (aborted && cleanText.isNotBlank()) {
+            append(baseText)
+            if (aborted && baseText.isNotBlank()) {
                 append("\n\n")
                 append(Strings.agentAbortedHint)
             }
@@ -525,6 +539,7 @@ private class TurnAccumulator(private val sessionId: String) {
             role = AgentMessage.Role.ASSISTANT,
             content = content,
             thinking = joined,
+            thinkingSegments = segs,
             thinkingDurationMs = totalThinkingDurationMs(),
             toolCalls = tools.values.toList(),
             producedFiles = producedFiles.toList(),
@@ -532,8 +547,20 @@ private class TurnAccumulator(private val sessionId: String) {
         )
     }
 
-    private fun stripToolMarkers(s: String): String =
-        if (s.isEmpty() || '\u2063' !in s) s else toolMarkerRegex.replace(s, "")
+    private fun buildThinkingSegmentData(): List<ThinkingSegmentData> {
+        if (thinkingSegments.isEmpty()) return emptyList()
+        val now = System.currentTimeMillis()
+        return thinkingSegments.map { seg ->
+            ThinkingSegmentData(
+                id = seg.id,
+                content = seg.content.trim(),
+                durationMs = seg.frozenDurationMs ?: (now - seg.startedAt).coerceAtLeast(0L)
+            )
+        }
+    }
+
+    private fun stripAllMarkers(s: String): String =
+        if (s.isEmpty() || '\u2063' !in s) s else inlineMarkerRegex.replace(s, "")
 
     private fun joinedThinking(): String? {
         val joined = thinkingSegments.joinToString("\n\n") { it.content.trim() }

--- a/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
@@ -36,6 +36,8 @@ data class AgentMessage(
     val content: String,
     val thinking: String? = null,
 
+    val thinkingSegments: List<ThinkingSegmentData> = emptyList(),
+
     val thinkingDurationMs: Long? = null,
     val toolCalls: List<RecordedToolCall> = emptyList(),
 
@@ -79,3 +81,15 @@ data class RecordedToolCall(
         const val RUNNING_SENTINEL = "__running__"
     }
 }
+
+/**
+ * One turn's worth of reasoning, persisted so the boundaries survive across drafts
+ * and reloads. [id] matches the inline marker (`\u2063TH:id\u2063`) embedded in
+ * [AgentMessage.content], letting the timeline renderer interleave thinking blocks
+ * with prose and tool calls in the order they actually occurred.
+ */
+data class ThinkingSegmentData(
+    val id: String,
+    val content: String,
+    val durationMs: Long? = null
+)

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -115,9 +115,11 @@ data class ContextAppItem(
  * One turn's worth of streaming reasoning. [frozenDurationMs] is null while the
  * reasoning for this turn is still arriving (live); once the turn's thinking stream
  * ends it is frozen so the UI renders a static, collapsed block and the next turn
- * can open its own live block.
+ * can open its own live block. [id] matches the inline marker in the streamed text
+ * so the timeline can interleave this block with prose/tools.
  */
 data class ThinkingSegment(
+    val id: String,
     val content: String,
     val startedAt: Long,
     val frozenDurationMs: Long? = null

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -1116,7 +1116,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                     out += LlmMessage(
                         role = LlmMessage.Role.ASSISTANT,
 
-                        content = stripToolMarkers(m.content),
+                        content = stripInlineMarkers(m.content),
                         toolCalls = m.toolCalls.map {
                             com.webtoapp.core.agent.llm.LlmToolCall(
                                 it.toolCallId, it.name, it.argumentsJson
@@ -1355,12 +1355,23 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         streamText.setLength(0)
         streamText.append(draft.content)
         streamThinkingSegments.clear()
-        // The draft's thinking is a single joined string (per-turn boundaries are not
-        // preserved across drafts); restore it as one segment. New live deltas will open
-        // a fresh segment after the current one is frozen.
-        draft.thinking?.takeIf { it.isNotBlank() }?.let {
+        // Rebuild per-turn segments from the persisted structured field so the live
+        // timeline can keep interleaving them with text/tools after a UI recreation.
+        if (draft.thinkingSegments.isNotEmpty()) {
+            val now = System.currentTimeMillis()
+            draft.thinkingSegments.forEach { seg ->
+                streamThinkingSegments += ThinkingSegment(
+                    id = seg.id,
+                    content = seg.content,
+                    startedAt = now,
+                    frozenDurationMs = seg.durationMs ?: 0L
+                )
+            }
+        } else if (!draft.thinking.isNullOrBlank()) {
+            // Legacy draft (no structured segments) — restore as a single frozen segment.
             streamThinkingSegments += ThinkingSegment(
-                content = it,
+                id = "th-restored",
+                content = draft.thinking,
                 startedAt = System.currentTimeMillis(),
                 frozenDurationMs = draft.thinkingDurationMs
             )
@@ -1392,25 +1403,35 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 }
             }
             is AgentEvent.ThinkingDelta -> {
-                // Append to the current live segment, or open a new one for a fresh turn.
+                // Associate by segmentId (stable per turn, mirrors the inline marker).
                 val now = System.currentTimeMillis()
-                val tail = streamThinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null }
-                if (tail == null) {
-                    streamThinkingSegments += ThinkingSegment(content = ev.delta, startedAt = now)
+                val idx = streamThinkingSegments.indexOfFirst { it.id == ev.segmentId }
+                if (idx < 0) {
+                    streamThinkingSegments += ThinkingSegment(
+                        id = ev.segmentId,
+                        content = ev.delta,
+                        startedAt = now
+                    )
                 } else {
-                    streamThinkingSegments[streamThinkingSegments.lastIndex] =
-                        tail.copy(content = tail.content + ev.delta)
+                    streamThinkingSegments[idx] =
+                        streamThinkingSegments[idx].copy(content = streamThinkingSegments[idx].content + ev.delta)
                 }
                 _ui.update {
                     it.copy(streamingThinkingSegments = streamThinkingSegments.toList())
                 }
             }
             AgentEvent.ThinkingTurnEnded -> {
-                // Freeze the live segment so the next turn opens its own live block.
-                val tail = streamThinkingSegments.lastOrNull()?.takeIf { it.frozenDurationMs == null }
-                if (tail != null) {
-                    streamThinkingSegments[streamThinkingSegments.lastIndex] =
-                        tail.copy(frozenDurationMs = System.currentTimeMillis() - tail.startedAt)
+                // Freeze any still-live segment so the next turn opens its own live block.
+                var changed = false
+                for (i in streamThinkingSegments.indices) {
+                    val seg = streamThinkingSegments[i]
+                    if (seg.frozenDurationMs == null) {
+                        streamThinkingSegments[i] =
+                            seg.copy(frozenDurationMs = System.currentTimeMillis() - seg.startedAt)
+                        changed = true
+                    }
+                }
+                if (changed) {
                     _ui.update {
                         it.copy(streamingThinkingSegments = streamThinkingSegments.toList())
                     }
@@ -1758,12 +1779,12 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
 
     companion object {
 
-        private val TOOL_MARKER_REGEX =
-            Regex("\u2063TC:([^\u2063]+)\u2063")
+        private val INLINE_MARKER_REGEX =
+            Regex("\u2063(?:TC|TH):[^\u2063]+\u2063")
 
-        fun stripToolMarkers(text: String): String =
+        fun stripInlineMarkers(text: String): String =
             if (text.isEmpty() || '\u2063' !in text) text
-            else TOOL_MARKER_REGEX.replace(text, "")
+            else INLINE_MARKER_REGEX.replace(text, "")
 
         private const val MENTION_LINE_LIMIT = 1500
 

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -110,7 +110,11 @@ fun MessageBubble(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = if (isUser) Alignment.End else Alignment.Start
     ) {
-        if (!message.thinking.isNullOrBlank()) {
+        // For assistant messages, thinking blocks are interleaved with prose/tools via
+        // the timeline when structured segments exist; otherwise fall back to a single
+        // top-of-bubble ThinkingBlock for legacy messages (pre-structured-thinking).
+        val hasStructuredThinking = !isUser && message.thinkingSegments.isNotEmpty()
+        if (!isUser && !hasStructuredThinking && !message.thinking.isNullOrBlank()) {
             ThinkingBlock(
                 content = message.thinking,
                 durationMs = message.thinkingDurationMs,
@@ -146,9 +150,20 @@ fun MessageBubble(
                     MentionList(message.mentionedFiles)
                 }
             } else {
+                val uiThinkingSegments = if (hasStructuredThinking) {
+                    message.thinkingSegments.map { seg ->
+                        ThinkingSegment(
+                            id = seg.id,
+                            content = seg.content,
+                            startedAt = 0L,
+                            frozenDurationMs = seg.durationMs
+                        )
+                    }
+                } else emptyList()
                 RichAssistantTimeline(
                     text = message.content,
                     toolCalls = message.toolCalls,
+                    thinkingSegments = uiThinkingSegments,
                     onSurface = onContainer,
                     liveTrailing = false
                 )
@@ -319,50 +334,36 @@ fun StreamingBubble(
     }
 
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.Start) {
-        thinkingSegments.forEach { seg ->
-            val isLive = seg.frozenDurationMs == null
-            val durationMs = seg.frozenDurationMs ?: (nowMs - seg.startedAt)
-            ThinkingBlock(
-                content = seg.content,
-                durationMs = durationMs,
-                isLive = isLive,
-                initiallyExpanded = isLive,
-                modifier = Modifier.widthIn(max = 560.dp)
-            )
-            Spacer(Modifier.height(WtaSpacing.Tiny))
-        }
-        if (text.isNotBlank() || pendingTools.isNotEmpty() || thinkingSegments.isEmpty()) {
-            WtaCard(
-                tone = WtaCardTone.Surface,
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                    horizontal = WtaSpacing.Medium + 2.dp,
-                    vertical = WtaSpacing.Medium - 2.dp
-                ),
-                modifier = Modifier.widthIn(max = 560.dp)
-            ) {
-                if (text.isNotEmpty() || pendingTools.isNotEmpty()) {
-
-                    RichAssistantTimeline(
-                        text = text,
-                        toolCalls = pendingTools,
-                        onSurface = MaterialTheme.colorScheme.onSurface,
-                        liveTrailing = true
+        WtaCard(
+            tone = WtaCardTone.Surface,
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                horizontal = WtaSpacing.Medium + 2.dp,
+                vertical = WtaSpacing.Medium - 2.dp
+            ),
+            modifier = Modifier.widthIn(max = 560.dp)
+        ) {
+            if (text.isNotEmpty() || pendingTools.isNotEmpty() || thinkingSegments.isNotEmpty()) {
+                RichAssistantTimeline(
+                    text = text,
+                    toolCalls = pendingTools,
+                    thinkingSegments = thinkingSegments,
+                    onSurface = MaterialTheme.colorScheme.onSurface,
+                    liveTrailing = true
+                )
+            }
+            if (text.isBlank() && pendingTools.isEmpty() && thinkingSegments.isEmpty()) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        strokeWidth = 1.5.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                }
-                if (text.isBlank() && pendingTools.isEmpty()) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(12.dp),
-                            strokeWidth = 1.5.dp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(Modifier.width(WtaSpacing.Small))
-                        Text(
-                            text = activity ?: Strings.agentPhaseThinking,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                    Spacer(Modifier.width(WtaSpacing.Small))
+                    Text(
+                        text = activity ?: Strings.agentPhaseThinking,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
         }
@@ -370,31 +371,39 @@ fun StreamingBubble(
 }
 
 private val INLINE_TOOL_MARKER = Regex("\u2063TC:([^\u2063]+)\u2063")
+private val INLINE_THINKING_MARKER = Regex("\u2063TH:([^\u2063]+)\u2063")
+private val ANY_INLINE_MARKER = Regex("\u2063(?:TC|TH):[^\u2063]+\u2063")
 
 @Composable
 fun RichAssistantTimeline(
     text: String,
     toolCalls: List<RecordedToolCall>,
     onSurface: Color,
+    thinkingSegments: List<ThinkingSegment> = emptyList(),
     liveTrailing: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     val emptyHint = Strings.agentNoOutput
     val toolsById = remember(toolCalls) { toolCalls.associateBy { it.toolCallId } }
-    val seenIds = remember(text, toolCalls) { mutableSetOf<String>() }
+    val thinkingById = remember(thinkingSegments) { thinkingSegments.associateBy { it.id } }
+    val seenToolIds = remember(text, toolCalls, thinkingSegments) { mutableSetOf<String>() }
+    val seenThinkingIds = remember(text, toolCalls, thinkingSegments) { mutableSetOf<String>() }
 
-    val segments = remember(text, toolCalls) {
-        buildSegments(text, toolsById, seenIds)
+    val segments = remember(text, toolCalls, thinkingSegments) {
+        buildSegments(text, toolsById, thinkingById, seenToolIds, seenThinkingIds)
     }
 
-    val leftovers = remember(toolCalls, segments) {
-        toolCalls.filter { it.toolCallId !in seenIds }
+    val leftoverTools = remember(toolCalls, segments) {
+        toolCalls.filter { it.toolCallId !in seenToolIds }
+    }
+    val leftoverThinking = remember(thinkingSegments, segments) {
+        thinkingSegments.filter { it.id !in seenThinkingIds }
     }
 
     val proseLastIdx = segments.indexOfLast { it is TimelineSegment.Prose }
 
     Column(modifier = modifier.fillMaxWidth()) {
-        if (segments.isEmpty() && leftovers.isEmpty()) {
+        if (segments.isEmpty() && leftoverTools.isEmpty() && leftoverThinking.isEmpty()) {
 
             SelectionContainer {
                 Text(
@@ -409,15 +418,28 @@ fun RichAssistantTimeline(
             when (seg) {
                 is TimelineSegment.Prose -> {
                     val isLastProse = i == proseLastIdx
-                    val proseText = if (liveTrailing && isLastProse && leftovers.isEmpty())
+                    val proseText = if (liveTrailing && isLastProse && leftoverTools.isEmpty())
                         seg.text
                     else seg.text
                     if (proseText.isNotEmpty()) {
                         RichAssistantText(
                             text = proseText,
                             onSurface = onSurface,
-                            streamingCaret = liveTrailing && isLastProse && leftovers.isEmpty()
+                            streamingCaret = liveTrailing && isLastProse && leftoverTools.isEmpty()
                         )
+                    }
+                }
+                is TimelineSegment.Thinking -> {
+                    val isLive = liveTrailing && seg.seg.frozenDurationMs == null
+                    if (i > 0) Spacer(Modifier.height(WtaSpacing.Tiny))
+                    ThinkingBlock(
+                        content = seg.seg.content,
+                        durationMs = seg.seg.frozenDurationMs,
+                        isLive = isLive,
+                        initiallyExpanded = isLive
+                    )
+                    if (i < segments.lastIndex || leftoverTools.isNotEmpty()) {
+                        Spacer(Modifier.height(WtaSpacing.Tiny))
                     }
                 }
                 is TimelineSegment.Tool -> {
@@ -428,7 +450,19 @@ fun RichAssistantTimeline(
                 }
             }
         }
-        leftovers.forEach { tc ->
+        // Thinking segments whose marker wasn't in the text yet (e.g. a brand-new live
+        // turn whose marker just arrived but text hasn't followed) render as trailing.
+        leftoverThinking.forEach { seg ->
+            val isLive = liveTrailing && seg.frozenDurationMs == null
+            ThinkingBlock(
+                content = seg.content,
+                durationMs = seg.frozenDurationMs,
+                isLive = isLive,
+                initiallyExpanded = isLive
+            )
+            Spacer(Modifier.height(WtaSpacing.Tiny))
+        }
+        leftoverTools.forEach { tc ->
             Spacer(Modifier.height(WtaSpacing.Tiny))
             ToolCallCard(tc, live = liveTrailing &&
                 tc.resultPreview == RecordedToolCall.RUNNING_SENTINEL)
@@ -438,25 +472,43 @@ fun RichAssistantTimeline(
 
 private sealed class TimelineSegment {
     data class Prose(val text: String) : TimelineSegment()
+    data class Thinking(val seg: ThinkingSegment) : TimelineSegment()
     data class Tool(val tc: RecordedToolCall) : TimelineSegment()
 }
 
 private fun buildSegments(
     text: String,
     toolsById: Map<String, RecordedToolCall>,
-    seenIds: MutableSet<String>
+    thinkingById: Map<String, ThinkingSegment>,
+    seenToolIds: MutableSet<String>,
+    seenThinkingIds: MutableSet<String>
 ): List<TimelineSegment> {
     if (text.isEmpty()) return emptyList()
     val out = mutableListOf<TimelineSegment>()
     var cursor = 0
-    INLINE_TOOL_MARKER.findAll(text).forEach { match ->
+    ANY_INLINE_MARKER.findAll(text).forEach { match ->
         val before = text.substring(cursor, match.range.first)
         if (before.isNotBlank()) out += TimelineSegment.Prose(before.trimEnd())
-        val id = match.groupValues[1]
-        val tc = toolsById[id]
-        if (tc != null) {
-            out += TimelineSegment.Tool(tc)
-            seenIds += id
+        val raw = match.value
+        when {
+            raw.startsWith("\u2063TC:") -> {
+                val id = INLINE_TOOL_MARKER.find(raw)?.groupValues?.get(1)
+                if (id != null) {
+                    toolsById[id]?.let {
+                        out += TimelineSegment.Tool(it)
+                        seenToolIds += id
+                    }
+                }
+            }
+            raw.startsWith("\u2063TH:") -> {
+                val id = INLINE_THINKING_MARKER.find(raw)?.groupValues?.get(1)
+                if (id != null) {
+                    thinkingById[id]?.let {
+                        out += TimelineSegment.Thinking(it)
+                        seenThinkingIds += id
+                    }
+                }
+            }
         }
         cursor = match.range.last + 1
     }


### PR DESCRIPTION
## Summary

Follow-up to #430 addressing two rendering problems with reasoning blocks.

### 1. Thinking and output were split into separate regions
`StreamingBubble` stacked all thinking blocks on top, then rendered prose/tools below — not interleaved. The real event order is `think1 → text1 → tool1 → think2 → text2`, so thinking appeared detached from the output it preceded.

### 2. Completed turns merged their thinking into one block
`AgentMessage.thinking` was a single joined string; once persisted, `MessageBubble` rendered it as one `ThinkingBlock`, losing per-turn boundaries.

## Fix

Thinking now uses the **same inline-marker mechanism** as tool calls: when a turn's reasoning stream starts, the engine anchors a `\u2063TH:<id>\u2063` marker in the accumulated text (mirroring `\u2063TC:<id>\u2063` for tools). `buildSegments` then emits a single interleaved timeline of `Prose | Thinking | Tool`, so both `StreamingBubble` and `MessageBubble` render everything in the order it actually occurred.

Per-turn segments are persisted as `AgentMessage.thinkingSegments` (structured list), so boundaries survive reloads. The legacy joined `thinking: String?` is kept for:
- Backward compat with existing sessions (Gson deserializes missing field → `emptyList` → falls back to single-block rendering)
- Provider round-trip (`reasoningContent` still reads the joined string)

### Files (7)
- `AgentEvent.kt` — `ThinkingDelta` gains `segmentId`
- `AgentEngine.kt` — inserts thinking marker in accText on first delta of a turn
- `SessionModels.kt` — new `ThinkingSegmentData`; `AgentMessage.thinkingSegments`
- `AgentUiState.kt` — UI `ThinkingSegment` gains `id`
- `AgentViewModel.kt` — associates segments by id; `stripToolMarkers` → `stripInlineMarkers` (TC + TH); resume rebuilds segments from structured field
- `MessageBubbles.kt` — unified `RichAssistantTimeline` (Prose/Thinking/Tool interleaved); `StreamingBubble` and `MessageBubble` both use it; legacy fallback for old messages
- `AgentService.kt` — `TurnAccumulator` keeps structured segments + sets both `thinking` and `thinkingSegments`; content keeps thinking markers

## Test plan
- [x] `:app:compileDebugKotlin` green (no warnings)
- [x] `:app:testDebugUnitTest` green
- [ ] Manual: multi-turn tool-calling with a reasoning model → thinking interleaved with text/tools in real order, each block independent.
- [ ] Manual: after turn completes → per-turn thinking blocks stay separate in history (not merged).
- [ ] Manual: leave and re-enter → persisted message shows interleaved independent blocks.
- [ ] Manual: old session (no `thinkingSegments`) → falls back to single top block, no crash.

Fixes #429