### PR TITLE
fix(agent): crash on legacy sessions — thinkingSegments null from Gson

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/session/SessionModels.kt
@@ -52,6 +52,14 @@ data class AgentMessage(
     val timestamp: Long = System.currentTimeMillis()
 ) {
     enum class Role { USER, ASSISTANT, SYSTEM }
+
+    /**
+     * Null-safe accessor: Gson bypasses the constructor when deserialising, so
+     * [thinkingSegments] can be null for messages loaded from older session JSON that
+     * predates this field. Treat that the same as an empty list.
+     */
+    val thinkingSegmentsSafe: List<ThinkingSegmentData>
+        get() = @Suppress("USELESS_CAST") (thinkingSegments as? List<ThinkingSegmentData>) ?: emptyList()
 }
 
 /**

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -1357,9 +1357,10 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         streamThinkingSegments.clear()
         // Rebuild per-turn segments from the persisted structured field so the live
         // timeline can keep interleaving them with text/tools after a UI recreation.
-        if (draft.thinkingSegments.isNotEmpty()) {
+        val draftSegments = draft.thinkingSegmentsSafe
+        if (draftSegments.isNotEmpty()) {
             val now = System.currentTimeMillis()
-            draft.thinkingSegments.forEach { seg ->
+            draftSegments.forEach { seg ->
                 streamThinkingSegments += ThinkingSegment(
                     id = seg.id,
                     content = seg.content,

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.unit.sp
 import com.google.gson.JsonParser
 import com.webtoapp.core.agent.session.AgentMessage
 import com.webtoapp.core.agent.session.RecordedToolCall
+import com.webtoapp.core.agent.session.ThinkingSegmentData
 import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.ui.agent.ThinkingSegment
@@ -113,7 +114,11 @@ fun MessageBubble(
         // For assistant messages, thinking blocks are interleaved with prose/tools via
         // the timeline when structured segments exist; otherwise fall back to a single
         // top-of-bubble ThinkingBlock for legacy messages (pre-structured-thinking).
-        val hasStructuredThinking = !isUser && message.thinkingSegments.isNotEmpty()
+        // NOTE: thinkingSegments can be null for messages deserialised from older
+        // session JSON — Gson bypasses the constructor so the emptyList() default is
+        // lost. Treat null as empty.
+        val segments: List<ThinkingSegmentData> = message.thinkingSegmentsSafe
+        val hasStructuredThinking = !isUser && segments.isNotEmpty()
         if (!isUser && !hasStructuredThinking && !message.thinking.isNullOrBlank()) {
             ThinkingBlock(
                 content = message.thinking,
@@ -151,7 +156,7 @@ fun MessageBubble(
                 }
             } else {
                 val uiThinkingSegments = if (hasStructuredThinking) {
-                    message.thinkingSegments.map { seg ->
+                    segments.map { seg ->
                         ThinkingSegment(
                             id = seg.id,
                             content = seg.content,


### PR DESCRIPTION
## Summary

Hotfix for a production crash introduced by #435.

`AgentMessage.thinkingSegments` is a new field. When Gson deserialises messages from **older session JSON** (saved before this field existed), it bypasses the constructor (the class has no no-arg constructor), so the `emptyList()` default is ignored and the field is `null` at runtime. Accessing `.isNotEmpty()` on it throws:

```
java.lang.NullPointerException: Attempt to invoke interface method
'boolean java.util.Collection.isEmpty()' on a null object reference
  at ...MessageBubblesKt.MessageBubble(MessageBubbles.kt:116)
```

## Fix

Add a `thinkingSegmentsSafe` accessor on `AgentMessage` that treats `null` as `emptyList()`, and route all read sites through it:
- `MessageBubble` (the crash site)
- `AgentViewModel.resumeFromActiveTurn`

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: open the Agent screen with an existing session from before #435 — no crash, legacy thinking renders as a single block via the fallback path.

Fixes #429