### PR TITLE
fix(agent): prevent inline-marker leaks and wedged prompts

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/permission/PermissionPrompter.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/permission/PermissionPrompter.kt
@@ -1,10 +1,12 @@
 package com.webtoapp.core.agent.permission
 
+import com.webtoapp.core.logging.AppLogger
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 class PermissionPrompter {
 
@@ -27,11 +29,20 @@ class PermissionPrompter {
     suspend fun request(req: PermissionRequest): PermissionResponse = singleFlight.withLock {
         requestChannel.send(req)
 
-        while (true) {
-            val (id, resp) = responseChannel.receive()
-            if (id == req.toolCallId) return resp
+        // Guard against the UI never responding (e.g. it was destroyed mid-prompt and the
+        // pending request was lost). Without this the engine would hang forever waiting on
+        // the response channel. On timeout we deny the tool so the turn can continue/end.
+        val resp = withTimeoutOrNull(PROMPT_TIMEOUT_MS) {
+            while (true) {
+                val (id, r) = responseChannel.receive()
+                if (id == req.toolCallId) return@withTimeoutOrNull r
+            }
+            @Suppress("UNREACHABLE_CODE") PermissionResponse.Deny
         }
-        @Suppress("UNREACHABLE_CODE") PermissionResponse.Deny
+        resp ?: run {
+            AppLogger.w(TAG, "permission request '${req.toolCallId}' timed out after ${PROMPT_TIMEOUT_MS}ms — denying")
+            PermissionResponse.Deny
+        }
     }
 
     fun respond(toolCallId: String, response: PermissionResponse) {
@@ -40,15 +51,30 @@ class PermissionPrompter {
 
     suspend fun askChoice(req: ChoiceRequest): ChoiceResponse = singleFlight.withLock {
         choiceChannel.send(req)
-        while (true) {
-            val (id, resp) = choiceResponseChannel.receive()
-            if (id == req.id) return resp
+        // Same rationale as request(): if the choice sheet is never shown or answered,
+        // cancel after a grace period so the agent loop doesn't hang indefinitely.
+        val resp = withTimeoutOrNull(PROMPT_TIMEOUT_MS) {
+            while (true) {
+                val (id, r) = choiceResponseChannel.receive()
+                if (id == req.id) return@withTimeoutOrNull r
+            }
+            @Suppress("UNREACHABLE_CODE") ChoiceResponse.Cancelled
         }
-        @Suppress("UNREACHABLE_CODE") ChoiceResponse.Cancelled
+        resp ?: run {
+            AppLogger.w(TAG, "choice request '${req.id}' timed out after ${PROMPT_TIMEOUT_MS}ms — cancelling")
+            ChoiceResponse.Cancelled
+        }
     }
 
     fun respondChoice(requestId: String, response: ChoiceResponse) {
         choiceResponseChannel.trySend(requestId to response)
+    }
+
+    companion object {
+        private const val TAG = "PermissionPrompter"
+        // 10 minutes — generous enough for a user who steps away, but finite so a lost
+        // UI prompt can never wedge the agent loop forever.
+        private const val PROMPT_TIMEOUT_MS = 10L * 60 * 1000
     }
 }
 

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -183,7 +183,7 @@ fun AgentScreen(
     val messageActions = remember(vm) {
         MessageActions(
             onCopy = { msg ->
-                clipboard.setText(AnnotatedString(msg.content))
+                clipboard.setText(AnnotatedString(AgentViewModel.stripInlineMarkers(msg.content)))
                 scope.launch { snackbar.showSnackbar(Strings.agentMessageCopied) }
             },
             onEdit = vm::startEditing,

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -1626,7 +1626,9 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         val textKey = keys.firstOrNull { it.id == textModel.apiKeyId } ?: return
 
         val firstUser = session.messages.first { it.role == AgentMessage.Role.USER }.content
-        val firstAssistant = session.messages.first { it.role == AgentMessage.Role.ASSISTANT }.content
+        val firstAssistant = stripInlineMarkers(
+            session.messages.first { it.role == AgentMessage.Role.ASSISTANT }.content
+        )
 
         val sysPrompt = """
             Summarise the following conversation as a short title.

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -377,7 +377,9 @@ fun StreamingBubble(
 
 private val INLINE_TOOL_MARKER = Regex("\u2063TC:([^\u2063]+)\u2063")
 private val INLINE_THINKING_MARKER = Regex("\u2063TH:([^\u2063]+)\u2063")
-private val ANY_INLINE_MARKER = Regex("\u2063(?:TC|TH):[^\u2063]+\u2063")
+// Match ANY \u2063…\u2063 pair (not just TC/TH) so an unrecognized marker type is still
+// consumed rather than leaking into a Prose segment as visible text.
+private val ANY_INLINE_MARKER = Regex("\u2063[^\u2063]*\u2063")
 
 @Composable
 fun RichAssistantTimeline(
@@ -493,7 +495,7 @@ private fun buildSegments(
     var cursor = 0
     ANY_INLINE_MARKER.findAll(text).forEach { match ->
         val before = text.substring(cursor, match.range.first)
-        if (before.isNotBlank()) out += TimelineSegment.Prose(before.trimEnd())
+        if (before.isNotBlank()) out += TimelineSegment.Prose(scrubInline(before).trimEnd())
         val raw = match.value
         when {
             raw.startsWith("\u2063TC:") -> {
@@ -515,14 +517,20 @@ private fun buildSegments(
                 }
             }
         }
+        // Unrecognized marker types fall through here — they are consumed (cursor
+        // advances past them) so they never reach a Prose segment.
         cursor = match.range.last + 1
     }
     if (cursor < text.length) {
         val tail = text.substring(cursor)
-        if (tail.isNotBlank()) out += TimelineSegment.Prose(tail.trimEnd())
+        if (tail.isNotBlank()) out += TimelineSegment.Prose(scrubInline(tail).trimEnd())
     }
     return out
 }
+
+/** Strip any stray \u2063 characters (e.g. an unpaired marker) so they never render. */
+private fun scrubInline(s: String): String =
+    if ('\u2063' !in s) s else s.replace("\u2063", "")
 
 @Composable
 fun ToolCallCard(tc: RecordedToolCall, live: Boolean) {


### PR DESCRIPTION
## Summary

Four related Agent fixes addressing user-reported issues with inline markers leaking and the agent appearing to "stop".

### 1. Clipboard copy leaked markers
`onCopy` copied `msg.content` verbatim, which contains inline `\u2063TC/\u2063TH` markers. Now runs through `stripInlineMarkers` first.

### 2. Auto-title fed markers to the LLM
`maybeAutoTitle` sent the raw assistant content (with markers) into the titling prompt, which could pollute the generated session title. Now stripped first.

### 3. PermissionPrompter could hang forever
`request()` and `askChoice()` waited on a response channel with `while(true) { receive() }` — no timeout. If the UI never surfaced or answered a prompt (Activity destroyed mid-prompt, `pendingChoice` lost), the agent loop hung indefinitely. Added a 10-minute `withTimeoutOrNull` guard that denies/cancels so the turn can continue or end.

> **Note on "agent stops outputting":** the agent calling `AskUserQuestion` (e.g. "确认两个点") **suspends** waiting for the user to answer a choice sheet — this is by design, not a bug. The timeout here is a safety net for when that sheet is lost.

### 4. buildSegments could leak unrecognized markers
The matcher only recognized `TC`/`TH` prefixes. Any other `\u2063…\u2063` pair (or a stray unpaired `\u2063`) would pass through into a Prose segment as visible text. Broadened the matcher to consume **any** `\u2063…\u2063` pair, and added a defensive scrub of stray `\u2063` from prose segments.

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: copy an assistant message → paste → no marker text.
- [ ] Manual: multi-turn session → session title has no marker pollution.
- [ ] Manual: agent calls AskUser → choice sheet appears → answering resumes the turn.
- [ ] Manual: agent calls AskUser → dismiss/navigate away → turn eventually ends (no permanent hang).

Fixes #429