### PR TITLE
fix(agent): recover from stalled LLM streams instead of hanging forever

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -22,6 +22,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicLong
 
 class AgentEngine(
     private val gateway: LlmGateway,
@@ -106,7 +109,10 @@ class AgentEngine(
                             maxTokens = input.maxTokens,
                             useTools = !isContinuation
                         )
-                    ).collect { ev ->
+                    ).collectWithIdleTimeout(
+                        idleTimeoutMs = STREAM_IDLE_TIMEOUT_MS,
+                        onTimeout = { retryableError = "LLM stream went idle for ${STREAM_IDLE_TIMEOUT_MS / 1000}s"; retryAfterMs = null }
+                    ) { ev ->
                         when (ev) {
                             is LlmEvent.Started -> Unit
                             is LlmEvent.TextDelta -> {
@@ -393,5 +399,54 @@ class AgentEngine(
         private const val TAG = "AgentEngine"
         private const val MAX_TOOL_RESULT_CHARS = 32_000
         private const val MAX_RATE_LIMIT_RETRIES = 5
+        // If the LLM stream emits nothing for this long, treat it as a stalled
+        // connection and retry (some OpenAI-compat endpoints open the SSE channel,
+        // send a partial response, then go silent without ever closing it).
+        private const val STREAM_IDLE_TIMEOUT_MS = 120_000L
     }
+}
+
+/**
+ * Collect [flow] but abort if it goes [idleTimeoutMs] without emitting any event.
+ * Some OpenAI-compatible SSE endpoints open the channel, send a partial response
+ * (e.g. the first reasoning chunk), then go silent without ever closing the
+ * connection — which would otherwise hang the agent loop for the full OkHttp
+ * read timeout (10 minutes). On idle timeout, [onTimeout] is invoked (typically
+ * to set a retryable error) and the flow collection is cancelled.
+ */
+private suspend fun <T> Flow<T>.collectWithIdleTimeout(
+    idleTimeoutMs: Long,
+    onTimeout: () -> Unit,
+    action: suspend (T) -> Unit
+) {
+    val lastEventAt = AtomicLong(System.currentTimeMillis())
+    coroutineScope {
+        // Watchdog: poll every second; if no event for idleTimeoutMs, cancel this scope
+        // (which cancels the collector below).
+        val watchdog = launch {
+            while (true) {
+                delay(1000)
+                val idle = System.currentTimeMillis() - lastEventAt.get()
+                if (idle >= idleTimeoutMs) {
+                    onTimeout()
+                    throw IdleStreamTimeout
+                }
+            }
+        }
+        try {
+            collect {
+                lastEventAt.set(System.currentTimeMillis())
+                action(it)
+            }
+        } catch (e: IdleStreamTimeout) {
+            // Expected — onTimeout already set the retryable error.
+        } finally {
+            watchdog.cancel()
+        }
+    }
+}
+
+/** Marker exception used to break out of a stalled stream collector. */
+private object IdleStreamTimeout : RuntimeException() {
+    override fun fillInStackTrace(): Throwable = this
 }

--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -115,6 +115,14 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
                         true
                     }
                     if (!done) emitFinish(toolNames, toolArgsAccum, finishReason)
+                } catch (e: Exception) {
+                    // A SocketTimeoutException (OkHttp read timeout) or a premature connection
+                    // close lands here. Previously this was silently swallowed (only finally {
+                    // close() } ran), so the engine's collector saw the flow complete with no
+                    // Done/Error event and the turn hung. Surface it as a recoverable error so
+                    // the engine's retry path can kick in.
+                    AppLogger.w("OpenAiCompatProvider", "stream interrupted: ${e.message}")
+                    trySend(LlmEvent.Error("Stream interrupted: ${e.message}", recoverable = true))
                 } finally { runCatching { response.body?.close() }; close() }
             }
         })


### PR DESCRIPTION
## Summary

When an OpenAI-compatible SSE endpoint sends a partial response (e.g. the first reasoning chunk) then goes silent without closing the connection, the agent **hangs for 10 minutes** (OkHttp readTimeout = 600s) with no feedback — the UI shows "thinking…" indefinitely. This matches the user report: a `TH:th-turn-N` thinking marker appears, then nothing.

## Root cause

1. **No idle timeout on the stream.** `AgentEngine` collected `gateway.chatStream()` with no timeout between events. A stalled SSE connection blocked in `SseParser.consume()` → `source.readUtf8Line()` for the full 600s read timeout.
2. **SSE exceptions were swallowed.** `OpenAiCompatProvider` had no `catch` around `sse.consume()` — a `SocketTimeoutException` or premature close was silently absorbed by `finally { close() }`, so the flow completed with **no** `Done`/`Error` event and the engine treated it as a clean finish.

## Fix

**1. Idle-timeout watchdog (`AgentEngine`)**
Each `gateway.chatStream().collect{}` is now wrapped in `collectWithIdleTimeout(120_000ms, ...)`. A watchdog coroutine polls every second; if no event arrives for 120s, collection is cancelled and the turn retries via the existing 429/5xx retry path (up to `MAX_RATE_LIMIT_RETRIES`). A legitimately slow model that takes time between chunks is unaffected — the timer resets on **every** event.

**2. SSE exception → recoverable error (`OpenAiCompatProvider`)**
Added a `catch (e: Exception)` around `sse.consume()` that emits `LlmEvent.Error("Stream interrupted…", recoverable = true)` so the retry path engages instead of silently closing.

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: point the agent at an endpoint that stalls mid-stream → after 120s it retries (up to 5×) instead of hanging for 10 minutes.
- [ ] Manual: normal multi-turn session with a fast model → no spurious timeouts.

Fixes #429