### PR TITLE
feat(agent): copy output vs copy all; tighten stream idle timeout

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -401,8 +401,11 @@ class AgentEngine(
         private const val MAX_RATE_LIMIT_RETRIES = 5
         // If the LLM stream emits nothing for this long, treat it as a stalled
         // connection and retry (some OpenAI-compat endpoints open the SSE channel,
-        // send a partial response, then go silent without ever closing it).
-        private const val STREAM_IDLE_TIMEOUT_MS = 120_000L
+        // send a partial response, then go silent without ever closing it). 90s is
+        // generous enough for slow reasoning models that pause between chunks, but
+        // short enough that a genuinely dead connection recovers in ~1.5 minutes
+        // instead of the 10-minute OkHttp readTimeout.
+        private const val STREAM_IDLE_TIMEOUT_MS = 90_000L
     }
 }
 

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1526,6 +1526,8 @@ object Strings {
     val agentThinkingTapToExpand: String get() = StringsB.agentThinkingTapToExpand
     val agentThinkingTapToCollapse: String get() = StringsB.agentThinkingTapToCollapse
     val agentMessageActionCopy: String get() = StringsB.agentMessageActionCopy
+    val agentMessageActionCopyOutput: String get() = StringsB.agentMessageActionCopyOutput
+    val agentMessageActionCopyAll: String get() = StringsB.agentMessageActionCopyAll
     val agentMessageActionEdit: String get() = StringsB.agentMessageActionEdit
     val agentMessageActionRegenerate: String get() = StringsB.agentMessageActionRegenerate
     val agentMessageActionDelete: String get() = StringsB.agentMessageActionDelete
@@ -23982,6 +23984,30 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Копировать"
         AppLanguage.JAPANESE -> "コピー"
         AppLanguage.KOREAN -> "복사"
+    }
+    val agentMessageActionCopyOutput: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "复制输出"
+        AppLanguage.ENGLISH -> "Copy output"
+        AppLanguage.ARABIC -> "نسخ المخرجات"
+        AppLanguage.PORTUGUESE -> "Copiar saída"
+        AppLanguage.SPANISH -> "Copiar salida"
+        AppLanguage.FRENCH -> "Copier la sortie"
+        AppLanguage.GERMAN -> "Ausgabe kopieren"
+        AppLanguage.RUSSIAN -> "Копировать вывод"
+        AppLanguage.JAPANESE -> "出力をコピー"
+        AppLanguage.KOREAN -> "출력 복사"
+    }
+    val agentMessageActionCopyAll: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "复制全部(含思考与工具)"
+        AppLanguage.ENGLISH -> "Copy all (with thinking & tools)"
+        AppLanguage.ARABIC -> "نسخ الكل (مع التفكير والأدوات)"
+        AppLanguage.PORTUGUESE -> "Copiar tudo (com raciocínio e ferramentas)"
+        AppLanguage.SPANISH -> "Copiar todo (con razonamiento y herramientas)"
+        AppLanguage.FRENCH -> "Tout copier (avec réflexion et outils)"
+        AppLanguage.GERMAN -> "Alles kopieren (mit Denken & Werkzeugen)"
+        AppLanguage.RUSSIAN -> "Копировать всё (с размышлениями и инструментами)"
+        AppLanguage.JAPANESE -> "すべてコピー(思考・ツール含む)"
+        AppLanguage.KOREAN -> "전체 복사(사고 및 도구 포함)"
     }
     val agentMessageActionEdit: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "编辑并重发"

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -79,6 +79,7 @@ import com.webtoapp.ui.agent.components.Composer
 import com.webtoapp.ui.agent.components.ContextPickerDialog
 import com.webtoapp.ui.agent.components.MaterialIconBadgeRound
 import com.webtoapp.ui.agent.components.MessageActions
+import com.webtoapp.ui.agent.components.formatMessageForCopy
 import com.webtoapp.ui.agent.components.MessageBubble
 import com.webtoapp.ui.agent.components.PermissionDialog
 import com.webtoapp.ui.agent.components.PreviewSheet
@@ -182,8 +183,9 @@ fun AgentScreen(
 
     val messageActions = remember(vm) {
         MessageActions(
-            onCopy = { msg ->
-                clipboard.setText(AnnotatedString(AgentViewModel.stripInlineMarkers(msg.content)))
+            onCopy = { msg, includeDetails ->
+                val text = formatMessageForCopy(msg, includeDetails)
+                clipboard.setText(AnnotatedString(text))
                 scope.launch { snackbar.showSnackbar(Strings.agentMessageCopied) }
             },
             onEdit = vm::startEditing,

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -69,6 +69,7 @@ import com.webtoapp.core.agent.session.RecordedToolCall
 import com.webtoapp.core.agent.session.ThinkingSegmentData
 import com.webtoapp.core.agent.session.UserAttachment
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.ui.agent.AgentViewModel
 import com.webtoapp.ui.agent.ThinkingSegment
 import com.webtoapp.ui.design.WtaAlpha
 import com.webtoapp.ui.design.WtaCard
@@ -81,11 +82,54 @@ import com.webtoapp.ui.design.WtaSpacing
 import com.webtoapp.ui.theme.AppColors
 
 data class MessageActions(
-    val onCopy: (AgentMessage) -> Unit,
+    val onCopy: (AgentMessage, includeDetails: Boolean) -> Unit,
     val onEdit: (AgentMessage) -> Unit,
     val onRegenerate: (AgentMessage) -> Unit,
     val onDeleteFromHere: (AgentMessage) -> Unit
 )
+
+/**
+ * Build a copy-paste-friendly plain-text rendering of an assistant message.
+ * When [includeDetails] is true, thinking blocks and tool calls are interleaved
+ * with the prose output (in arrival order where possible); otherwise only the
+ * clean prose output is returned.
+ */
+internal fun formatMessageForCopy(message: AgentMessage, includeDetails: Boolean): String {
+    val cleanContent = AgentViewModel.stripInlineMarkers(message.content).trim()
+    if (!includeDetails) return cleanContent
+    val segments = message.thinkingSegmentsSafe
+    val hasThinking = segments.any { it.content.isNotBlank() }
+    val hasTools = message.toolCalls.isNotEmpty()
+    if (!hasThinking && !hasTools) return cleanContent
+
+    val sb = StringBuilder()
+    // Thinking blocks (in order). If there's only one, label it simply; otherwise
+    // number them so multi-turn reasoning stays readable.
+    segments.forEachIndexed { i, seg ->
+        val c = seg.content.trim()
+        if (c.isBlank()) return@forEachIndexed
+        if (sb.isNotEmpty()) sb.append("\n\n")
+        sb.append(if (segments.size > 1) "💭 思考过程 (${i + 1})" else "💭 思考过程")
+        sb.append("\n").append(c)
+    }
+    // Tool calls with their result previews.
+    message.toolCalls.forEach { tc ->
+        if (sb.isNotEmpty()) sb.append("\n\n")
+        sb.append("🔧 ").append(tc.name)
+        val args = tc.argumentsJson.trim()
+        if (args.isNotEmpty()) sb.append("(").append(args).append(")")
+        val result = tc.resultPreview.trim()
+        if (result.isNotEmpty() && result != RecordedToolCall.RUNNING_SENTINEL) {
+            sb.append("\n→ ").append(result)
+        }
+    }
+    // Final prose output.
+    if (cleanContent.isNotEmpty()) {
+        if (sb.isNotEmpty()) sb.append("\n\n")
+        sb.append(cleanContent)
+    }
+    return sb.toString()
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -187,11 +231,24 @@ fun MessageBubble(
                 modifier = Modifier.size(WtaSize.TouchTarget)
             )
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
-                DropdownMenuItem(
-                    text = { Text(Strings.agentMessageActionCopy) },
-                    leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
-                    onClick = { menuOpen = false; actions.onCopy(message) }
-                )
+                if (isUser) {
+                    DropdownMenuItem(
+                        text = { Text(Strings.agentMessageActionCopy) },
+                        leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                        onClick = { menuOpen = false; actions.onCopy(message, false) }
+                    )
+                } else {
+                    DropdownMenuItem(
+                        text = { Text(Strings.agentMessageActionCopyOutput) },
+                        leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                        onClick = { menuOpen = false; actions.onCopy(message, false) }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(Strings.agentMessageActionCopyAll) },
+                        leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                        onClick = { menuOpen = false; actions.onCopy(message, true) }
+                    )
+                }
                 if (isUser) {
                     DropdownMenuItem(
                         text = { Text(Strings.agentMessageActionEdit) },


### PR DESCRIPTION
## Summary

Two changes requested by the user.

### 1. Copy menu: output vs all
Assistant messages now show two copy options instead of one:
- **Copy output** — clean prose only (markers stripped)
- **Copy all (with thinking & tools)** — formats thinking segments (`💭`) and tool calls (`🔧 name(args) → result`) alongside the prose output

User messages keep the single "Copy" item. Adds `formatMessageForCopy(message, includeDetails)` + 2 strings across 10 languages.

### 2. Stream idle timeout: 120s → 90s
Lowers the stalled-stream recovery window from 120s to 90s. The user saw a 60.6s reasoning block that then appeared to hang; 90s is still generous for slow reasoning models (the timer resets on every chunk) but recovers a dead connection faster.

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: assistant message → "Copy output" → paste → clean prose only.
- [ ] Manual: assistant message → "Copy all" → paste → thinking + tools + prose.
- [ ] Manual: user message → "Copy" → paste → the user's text.

Fixes #429