### PR TITLE
fix(agent): use model context length as output ceiling instead of 32k hard cap

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -40,7 +40,7 @@ class AgentEngine(
         val registry: ToolRegistry,
         val temperature: Float = 0.7f,
         val maxTurns: Int = 24,
-        val maxTokens: Int = 16384
+        val maxTokens: Int = 65536
     )
 
     fun run(input: Input): Flow<AgentEvent> = channelFlow {

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -276,11 +276,15 @@ class AgentService : Service() {
     }
 
     private fun resolveMaxOutputTokens(model: com.webtoapp.data.model.AiModel): Int {
+        // Use the model's context length as the effective ceiling — this is the closest
+        // thing to "unlimited" output: the model can produce tokens until it fills its
+        // context window. For models without a registry entry the context length acts as
+        // a generous fallback, and for very large contexts (1M+) the API will clip it.
         val fromRegistry = runCatching {
             com.webtoapp.core.ai.ModelsDevRepository.getInstance(this).getMaxOutputTokens(model.id, model.provider)
         }.getOrNull()
-        return fromRegistry?.takeIf { it > 0 }?.coerceAtMost(MAX_OUTPUT_TOKENS_CEILING)
-            ?: DEFAULT_MAX_OUTPUT_TOKENS
+        val ceiling = model.contextLength.coerceIn(8192, 2_000_000)
+        return fromRegistry?.takeIf { it > 0 }?.coerceAtMost(ceiling) ?: ceiling
     }
 
     fun cancel() {
@@ -371,8 +375,6 @@ class AgentService : Service() {
         private const val CHANNEL_ID = "aicoding_agent_v3"
         private const val NOTIFICATION_ID = 1201
         private const val WAKE_LOCK_TIMEOUT_MS = 20L * 60 * 1000
-        private const val DEFAULT_MAX_OUTPUT_TOKENS = 8192
-        private const val MAX_OUTPUT_TOKENS_CEILING = 32768
     }
 }
 


### PR DESCRIPTION
## Summary

The agent's output was being truncated mid-sentence because `resolveMaxOutputTokens` capped output at a hard-coded 32,768 tokens. For reasoning models (DeepSeek-R1, etc.), reasoning + output share the token budget, so a long thinking phase (35–60s of reasoning) would exhaust the budget before the model finished its actual text output — leaving an incomplete sentence ending in a dangling colon.

## Fix

`resolveMaxOutputTokens` now uses the model's own `contextLength` as the ceiling (clamped to 8k–2M), instead of the old 32k hard cap. This is the closest practical equivalent of "unlimited" output: the model can produce tokens until it fills its context window. The API will clip it server-side if it exceeds what the model actually supports.

- Old: registry value capped at 32k, else fallback 8k
- New: registry value capped at model's contextLength, else fallback to contextLength
- Engine default raised 16k → 64k for direct callers

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: long reasoning turn completes with full output instead of truncating mid-sentence.

Fixes #429