### PR TITLE
fix(agent): use effectiveContextLength for max_tokens; fallback 65k for unconfigured models

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -141,7 +141,7 @@ class AgentService : Service() {
                         registry = request.registry,
                         temperature = request.temperature,
                         maxTurns = request.maxTurns,
-                        maxTokens = resolveMaxOutputTokens(ctx.textModel.model)
+                            maxTokens = resolveMaxOutputTokens(ctx.textModel)
                     )
                 ).collect { ev ->
                     // Broadcast to UI first so live streaming stays responsive.
@@ -275,15 +275,21 @@ class AgentService : Service() {
         }
     }
 
-    private fun resolveMaxOutputTokens(model: com.webtoapp.data.model.AiModel): Int {
-        // Use the model's context length as the effective ceiling — this is the closest
-        // thing to "unlimited" output: the model can produce tokens until it fills its
-        // context window. For models without a registry entry the context length acts as
-        // a generous fallback, and for very large contexts (1M+) the API will clip it.
+    private fun resolveMaxOutputTokens(savedModel: com.webtoapp.data.model.SavedModel): Int {
+        // Use the model's effective context length (which honours the user's
+        // per-model override) as the output ceiling. This is the closest practical
+        // equivalent of "unlimited" output: the model can produce tokens until it
+        // fills its context window. The API clips server-side if it exceeds what the
+        // model actually supports.
+        val model = savedModel.model
         val fromRegistry = runCatching {
             com.webtoapp.core.ai.ModelsDevRepository.getInstance(this).getMaxOutputTokens(model.id, model.provider)
         }.getOrNull()
-        val ceiling = model.contextLength.coerceIn(8192, 2_000_000)
+        // Many custom models report the default contextLength (4096) because the user
+        // didn't configure it — treat that as "unknown" and fall back to a generous
+        // value rather than capping output at 4k tokens (which truncated reasoning).
+        val rawContext = savedModel.effectiveContextLength
+        val ceiling = if (rawContext in 1..8192) 65536 else rawContext.coerceIn(8192, 2_000_000)
         return fromRegistry?.takeIf { it > 0 }?.coerceAtMost(ceiling) ?: ceiling
     }
 


### PR DESCRIPTION
## Summary

Follow-up fix to #440. The previous PR used `AiModel.contextLength` as the max_tokens ceiling, but that field **defaults to 4096** for custom models — which is *lower* than the old 32k hard cap, making truncation worse for reasoning models.

## Fix

1. Use `SavedModel.effectiveContextLength` instead of `AiModel.contextLength` — this respects the user's per-model context-length override in AI Settings.
2. When the configured context length is the 4096 default (likely unconfigured for custom models), fall back to **65536** instead of capping output at 4k tokens.

| Scenario | Before (#440) | After |
|---|---|---|
| Custom model, contextLength=4096 (unconfigured) | max_tokens=4096 ❌ worse than original | max_tokens=65536 ✅ |
| Model with user-set contextLength=128000 | max_tokens=4096 ❌ (wrong field) | max_tokens=128000 ✅ |
| Registry-known model with maxOutput | capped at contextLength | capped at effectiveContextLength ✅ |

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: long reasoning turn with a custom model completes fully instead of truncating mid-sentence.

Fixes #429