### PR TITLE
fix(build): HTML project scan must skip .changes/ tracking files

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/BuildInputPreflight.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/BuildInputPreflight.kt
@@ -217,9 +217,14 @@ object BuildInputPreflight {
         }
 
         htmlFiles.forEachIndexed { index, file ->
+            // Skip internal change-tracking markers (Agent's ".changes/" dir) — they
+            // are not real project files and would spuriously fail the empty-file check.
+            val name = file.name
+            if (name.startsWith(".changes/") || name.contains("/.changes/") ||
+                name.endsWith(".__deleted__")) return@forEachIndexed
             requireReadableFile(
                 key = "htmlFiles[$index]",
-                label = "HTML project file '${file.name.ifBlank { "(unnamed)" }}'",
+                label = "HTML project file '${name.ifBlank { "(unnamed)" }}'",
                 path = file.path,
                 requireNonEmpty = true
             )

--- a/app/src/main/java/com/webtoapp/util/HtmlProjectHelper.kt
+++ b/app/src/main/java/com/webtoapp/util/HtmlProjectHelper.kt
@@ -179,8 +179,12 @@ object HtmlProjectHelper {
 
         val files = mutableListOf<HtmlFile>()
         outputDir.walkTopDown().forEach { file ->
+            // Skip internal change-tracking directories (e.g. Agent's ".changes/"
+            // which contains ".__deleted__" markers). These are not real project
+            // files and a 0-byte marker would fail the build preflight.
+            val relativePath = file.relativeTo(outputDir).path
+            if (relativePath.startsWith(".changes/") || relativePath == ".changes") return@forEach
             if (file.isFile) {
-                val relativePath = file.relativeTo(outputDir).path
                 val savedPath = HtmlStorage.saveFromTempFile(context, file.absolutePath, relativePath, projectId)
                 if (savedPath != null) {
                     files.add(HtmlFile(name = relativePath, path = savedPath, type = detectFileType(file.name)))


### PR DESCRIPTION
## Summary

When the Agent creates an HTML app (`CreateApp` → `SaveSessionAsAppUseCase`), it scans the session sandbox via `HtmlProjectHelper.copyBuildOutputToStorage`. That walker did **not** skip the Agent's internal `.changes/` directory, so change-tracking markers like `.changes/index.html.__deleted__` (a **0-byte file**) were included in `htmlConfig.files`.

The build preflight then failed:
```
BuildApk failed: Build input preflight failed: 1 issue(s)
```
The "1 issue(s)" message gives **no detail** about what failed, so the Agent couldn't diagnose it and kept retrying fruitlessly.

## Root cause
`.changes/index.html.__deleted__` is a 0-byte internal marker. `requireHtmlFiles` checks every file with `requireNonEmpty = true`, so the 0-byte marker trips the "is empty" check.

## Fix
1. **`HtmlProjectHelper.copyBuildOutputToStorage`** — skip the `.changes/` directory entirely when scanning, so new apps never get tracking markers in their file list.
2. **`BuildInputPreflight.requireHtmlFiles`** — defensively skip any file under `.changes/` or ending in `.__deleted__`, so **existing apps** (where the marker is already persisted in `htmlConfig.files`) can still build.

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: Agent creates HTML app from sandbox → BuildApk succeeds (no preflight failure).
- [ ] Manual: existing app with `.changes/` marker in files → BuildApk succeeds.

Fixes #429