### PR TITLE
fix(agent): duplicate rendering — sync activeTurn draftMessage on flush

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -175,37 +175,50 @@ class AgentService : Service() {
         acc: TurnAccumulator,
         ev: AgentEvent
     ) {
+        // Flush helper: writes the draft AND syncs _activeTurn so the UI can hide the
+        // draft from the history list (otherwise it renders twice: once as a saved
+        // bubble, once in the live StreamingBubble).
+        suspend fun flush(force: Boolean = false) {
+            val draft = acc.maybeFlushDraft(store, force)
+            if (draft != null) {
+                _activeTurn.value = TurnSnapshot(
+                    sessionId = sessionId,
+                    isRunning = true,
+                    draftMessage = draft
+                )
+            }
+        }
         when (ev) {
             is AgentEvent.TextDelta -> {
                 acc.applyTextDelta(ev.accumulated)
-                acc.maybeFlushDraft(store)
+                flush()
             }
             is AgentEvent.ThinkingDelta -> {
                 acc.applyThinkingDelta(ev.segmentId, ev.delta)
-                acc.maybeFlushDraft(store)
+                flush()
             }
             AgentEvent.ThinkingTurnEnded -> {
                 acc.freezeCurrentThinkingSegment()
-                acc.maybeFlushDraft(store)
+                flush()
             }
             is AgentEvent.ToolCallStarted -> {
                 acc.startTool(ev.toolCallId, ev.name)
-                acc.maybeFlushDraft(store)
+                flush()
             }
             is AgentEvent.ToolCallArgsDelta -> {
                 acc.appendToolArgs(ev.toolCallId, ev.delta)
             }
             is AgentEvent.ToolProgress -> {
                 acc.updateToolProgress(ev.toolCallId, ev.accumulated)
-                acc.maybeFlushDraft(store)
+                flush()
             }
             is AgentEvent.ToolExecuting -> {
                 acc.updateToolActivity(ev.toolCallId, ev.activity ?: ev.name)
-                acc.maybeFlushDraft(store)
+                flush()
             }
             is AgentEvent.ToolFinished -> {
                 acc.finishTool(ev.toolCallId, ev.name, ev.argumentsJson, ev.result)
-                acc.maybeFlushDraft(store, force = true)
+                flush(force = true)
             }
             is AgentEvent.FileChanged -> {
                 acc.recordProducedFile(ev.change.path)
@@ -466,12 +479,13 @@ private class TurnAccumulator(private val sessionId: String) {
      * Throttled draft upsert. Writes at most once per [FLUSH_INTERVAL_MS], unless
      * [force] is set (used for tool-finish boundaries and other durable events).
      */
-    suspend fun maybeFlushDraft(store: SessionStore, force: Boolean = false) {
+    suspend fun maybeFlushDraft(store: SessionStore, force: Boolean = false): AgentMessage? {
         val now = System.currentTimeMillis()
-        if (!force && now - lastFlushAt < FLUSH_INTERVAL_MS) return
+        if (!force && now - lastFlushAt < FLUSH_INTERVAL_MS) return null
         lastFlushAt = now
-        val draft = buildDraftMessage() ?: return
+        val draft = buildDraftMessage() ?: return null
         store.upsertAssistantDraft(sessionId, draft)
+        return draft
     }
 
     private fun buildDraftMessage(): AgentMessage? {


### PR DESCRIPTION
## Summary

The user reported that during streaming, the same output renders **twice** — identical content in two bubbles, not two separate requests.

## Root cause

The service flushes a draft to `SessionStore` every ~200ms during streaming (`maybeFlushDraft`). That draft appears in the session's message list (via `sessionsFlow` → `observeStreams` → `currentSession.messages`). The UI hides it via `streamingDraftMessageId`, which comes from `activeTurn.draftMessage.id`.

**But `_activeTurn.draftMessage` was never updated during flushing** — it was only set at turn start (`draftMessage = null`) and at completion (the final message). So while the draft was already in the message list, `streamingDraftMessageId` stayed `null`, and the filter didn't hide it → the draft bubble and the live `StreamingBubble` both showed the same content.

## Fix

`maybeFlushDraft` now returns the flushed `AgentMessage`. `persistEvent` uses it to update `_activeTurn` synchronously after every flush, so `activeTurn.draftMessage.id` is always current → `streamingDraftMessageId` correctly hides the draft from the history list while streaming.

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: streaming output renders once (not twice).

Fixes #429