### PR TITLE
feat(agent): show built APK in Files sidebar with install/share info card

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -283,6 +283,7 @@ class AgentEngine(
     ) {
         out.send(AgentEvent.ToolFinished(call.id, call.name, call.argumentsJson, result))
         result.fileChange?.let { out.send(AgentEvent.FileChanged(it)) }
+        result.builtApk?.let { out.send(AgentEvent.ApkBuilt(it)) }
     }
 
     private suspend fun runSequential(

--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEvent.kt
@@ -1,5 +1,6 @@
 package com.webtoapp.core.agent.engine
 
+import com.webtoapp.core.agent.tool.BuiltApkInfo
 import com.webtoapp.core.agent.tool.FileChange
 import com.webtoapp.core.agent.tool.ToolResult
 
@@ -39,6 +40,9 @@ sealed class AgentEvent {
     ) : AgentEvent()
 
     data class FileChanged(val change: FileChange) : AgentEvent()
+
+    /** An APK was built by a tool; surfaced as a virtual file in the Files sidebar. */
+    data class ApkBuilt(val info: BuiltApkInfo) : AgentEvent()
 
     data class PermissionDenied(val toolCallId: String, val name: String) : AgentEvent()
 

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -282,6 +282,7 @@ class AgentService : Service() {
                 _activeTurn.value = null
             }
             is AgentEvent.PermissionDenied, is AgentEvent.Usage, is AgentEvent.Notice,
+            is AgentEvent.ApkBuilt,
             AgentEvent.Started -> {
                 // No persistence impact.
             }

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolResult.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolResult.kt
@@ -5,7 +5,8 @@ data class ToolResult(
     val isError: Boolean = false,
     val images: List<ImageAttachment> = emptyList(),
     val fileChange: FileChange? = null,
-    val planReviewPath: String? = null
+    val planReviewPath: String? = null,
+    val builtApk: BuiltApkInfo? = null
 ) {
     val isMultimodal: Boolean get() = images.isNotEmpty()
 
@@ -29,6 +30,28 @@ data class ToolResult(
             images = images,
             fileChange = fileChange
         )
+    }
+}
+
+/**
+ * Metadata about an APK produced by [com.webtoapp.core.agent.tool.builtin.BuildApkTool].
+ * Surfaced as a virtual entry in the Files sidebar and previewed via an info card
+ * (install / share) rather than a WebView, since the APK lives in the external
+ * `built_apks/` directory and is a binary artifact.
+ */
+data class BuiltApkInfo(
+    val appId: Long,
+    val apkName: String,
+    val apkPath: String,
+    val sizeBytes: Long,
+    val buildMode: String,
+    val packageName: String?,
+    val versionName: String?
+) {
+    fun formatSize(): String = when {
+        sizeBytes < 1024 -> "${sizeBytes}B"
+        sizeBytes < 1024 * 1024 -> "${sizeBytes / 1024}KB"
+        else -> String.format("%.1fMB", sizeBytes / (1024.0 * 1024.0))
     }
 }
 

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/AppLifecycleTools.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/AppLifecycleTools.kt
@@ -2,6 +2,7 @@ package com.webtoapp.core.agent.tool.builtin
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.webtoapp.core.agent.tool.BuiltApkInfo
 import com.webtoapp.core.agent.tool.Tool
 import com.webtoapp.core.agent.tool.ToolContext
 import com.webtoapp.core.agent.tool.ToolResult
@@ -34,10 +35,33 @@ class BuildApkTool : Tool {
         return when (val result = builder.buildApk(app, force)) {
             is BuildResult.Success -> {
                 val sizeKb = result.apkFile.length() / 1024
-                ToolResult.ok("APK built successfully: ${result.apkFile.absolutePath} (${sizeKb}KB, ${result.buildMode}).")
+                val versionName = extractVersionFromName(result.apkFile.name) ?: "1.0.0"
+                val info = BuiltApkInfo(
+                    appId = appId,
+                    apkName = result.apkFile.name,
+                    apkPath = result.apkFile.absolutePath,
+                    sizeBytes = result.apkFile.length(),
+                    buildMode = result.buildMode,
+                    packageName = app.packageName,
+                    versionName = versionName
+                )
+                ToolResult(
+                    text = "APK built successfully: ${result.apkFile.absolutePath} (${sizeKb}KB, ${result.buildMode}).",
+                    isError = false,
+                    builtApk = info
+                )
             }
             is BuildResult.Error -> ToolResult.error("BuildApk failed: ${result.message}")
         }
+    }
+
+    private fun extractVersionFromName(fileName: String): String? {
+        // APK file name format: "{AppName}_v{version}.APK"
+        val idx = fileName.lastIndexOf("_v")
+        if (idx < 0) return null
+        val afterV = fileName.substring(idx + 2)
+        val dot = afterV.lastIndexOf('.')
+        return if (dot > 0) afterV.substring(0, dot) else afterV.takeIf { it.isNotEmpty() }
     }
 }
 

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1583,6 +1583,13 @@ object Strings {
     val agentEmptySessionsHint: String get() = StringsB.agentEmptySessionsHint
     val agentEmptyFiles: String get() = StringsB.agentEmptyFiles
     val agentEmptyFilesHint: String get() = StringsB.agentEmptyFilesHint
+    val agentBuiltApks: String get() = StringsB.agentBuiltApks
+    val agentApkInstall: String get() = StringsB.agentApkInstall
+    val agentApkShare: String get() = StringsB.agentApkShare
+    val agentApkPackage: String get() = StringsB.agentApkPackage
+    val agentApkVersion: String get() = StringsB.agentApkVersion
+    val agentApkBuildMode: String get() = StringsB.agentApkBuildMode
+    val agentApkSize: String get() = StringsB.agentApkSize
     val agentNotifIdle: String get() = StringsB.agentNotifIdle
     val agentNotifRunning: String get() = StringsB.agentNotifRunning
     val agentOutputTruncated: String get() = StringsB.agentOutputTruncated
@@ -24672,6 +24679,90 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Файлы появятся после общения с ИИ"
         AppLanguage.JAPANESE -> "AIと会話するとファイルが表示されます"
         AppLanguage.KOREAN -> "AI와 대화하면 파일이 나타납니다"
+    }
+    val agentBuiltApks: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "构建产物"
+        AppLanguage.ENGLISH -> "Build Artifacts"
+        AppLanguage.ARABIC -> "مخرجات البناء"
+        AppLanguage.PORTUGUESE -> "Artefatos de Build"
+        AppLanguage.SPANISH -> "Artefactos de compilación"
+        AppLanguage.FRENCH -> "Artefacts de build"
+        AppLanguage.GERMAN -> "Build-Artefakte"
+        AppLanguage.RUSSIAN -> "Артефакты сборки"
+        AppLanguage.JAPANESE -> "ビルド成果物"
+        AppLanguage.KOREAN -> "빌드 산출물"
+    }
+    val agentApkInstall: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "安装"
+        AppLanguage.ENGLISH -> "Install"
+        AppLanguage.ARABIC -> "تثبيت"
+        AppLanguage.PORTUGUESE -> "Instalar"
+        AppLanguage.SPANISH -> "Instalar"
+        AppLanguage.FRENCH -> "Installer"
+        AppLanguage.GERMAN -> "Installieren"
+        AppLanguage.RUSSIAN -> "Установить"
+        AppLanguage.JAPANESE -> "インストール"
+        AppLanguage.KOREAN -> "설치"
+    }
+    val agentApkShare: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "分享"
+        AppLanguage.ENGLISH -> "Share"
+        AppLanguage.ARABIC -> "مشاركة"
+        AppLanguage.PORTUGUESE -> "Compartilhar"
+        AppLanguage.SPANISH -> "Compartir"
+        AppLanguage.FRENCH -> "Partager"
+        AppLanguage.GERMAN -> "Teilen"
+        AppLanguage.RUSSIAN -> "Поделиться"
+        AppLanguage.JAPANESE -> "共有"
+        AppLanguage.KOREAN -> "공유"
+    }
+    val agentApkPackage: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "包名"
+        AppLanguage.ENGLISH -> "Package"
+        AppLanguage.ARABIC -> "الحزمة"
+        AppLanguage.PORTUGUESE -> "Pacote"
+        AppLanguage.SPANISH -> "Paquete"
+        AppLanguage.FRENCH -> "Package"
+        AppLanguage.GERMAN -> "Paket"
+        AppLanguage.RUSSIAN -> "Пакет"
+        AppLanguage.JAPANESE -> "パッケージ"
+        AppLanguage.KOREAN -> "패키지"
+    }
+    val agentApkVersion: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "版本"
+        AppLanguage.ENGLISH -> "Version"
+        AppLanguage.ARABIC -> "الإصدار"
+        AppLanguage.PORTUGUESE -> "Versão"
+        AppLanguage.SPANISH -> "Versión"
+        AppLanguage.FRENCH -> "Version"
+        AppLanguage.GERMAN -> "Version"
+        AppLanguage.RUSSIAN -> "Версия"
+        AppLanguage.JAPANESE -> "バージョン"
+        AppLanguage.KOREAN -> "버전"
+    }
+    val agentApkBuildMode: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "构建模式"
+        AppLanguage.ENGLISH -> "Build mode"
+        AppLanguage.ARABIC -> "وضع البناء"
+        AppLanguage.PORTUGUESE -> "Modo de build"
+        AppLanguage.SPANISH -> "Modo de compilación"
+        AppLanguage.FRENCH -> "Mode de build"
+        AppLanguage.GERMAN -> "Build-Modus"
+        AppLanguage.RUSSIAN -> "Режим сборки"
+        AppLanguage.JAPANESE -> "ビルドモード"
+        AppLanguage.KOREAN -> "빌드 모드"
+    }
+    val agentApkSize: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "大小"
+        AppLanguage.ENGLISH -> "Size"
+        AppLanguage.ARABIC -> "الحجم"
+        AppLanguage.PORTUGUESE -> "Tamanho"
+        AppLanguage.SPANISH -> "Tamaño"
+        AppLanguage.FRENCH -> "Taille"
+        AppLanguage.GERMAN -> "Größe"
+        AppLanguage.RUSSIAN -> "Размер"
+        AppLanguage.JAPANESE -> "サイズ"
+        AppLanguage.KOREAN -> "크기"
     }
     val agentNotifIdle: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "Agent 已就绪"

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentUiState.kt
@@ -6,6 +6,7 @@ import com.webtoapp.core.agent.permission.PermissionRequest
 import com.webtoapp.core.agent.session.AgentSession
 import com.webtoapp.core.agent.session.RecordedToolCall
 import com.webtoapp.core.agent.session.UserAttachment
+import com.webtoapp.core.agent.tool.BuiltApkInfo
 import com.webtoapp.core.agent.todo.TodoManager
 
 data class AgentUiState(
@@ -28,6 +29,7 @@ data class AgentUiState(
     val currentActivity: String? = null,
 
     val projectFiles: List<ProjectFileManager.FileInfo> = emptyList(),
+    val builtApks: List<BuiltApkInfo> = emptyList(),
     val selectedFilePath: String? = null,
     val selectedFileContent: String? = null,
 

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -606,6 +606,18 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun selectFile(path: String) {
+        // "apk:<name>" is a virtual path for a built APK artifact — no file content
+        // to read, just surface the path so PreviewPane renders an info card.
+        if (path.startsWith("apk:")) {
+            _ui.update {
+                it.copy(
+                    selectedFilePath = path,
+                    selectedFileContent = null,
+                    previewFilePath = path
+                )
+            }
+            return
+        }
         val sid = _ui.value.currentSession?.id ?: return
         val text = files.readText(sid, path)
         _ui.update {
@@ -1528,6 +1540,13 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                     )
                 }
             }
+            is AgentEvent.ApkBuilt -> {
+                _ui.update { state ->
+                    // Replace any previous build for the same appId, keep others.
+                    val rest = state.builtApks.filterNot { it.appId == ev.info.appId }
+                    state.copy(builtApks = rest + ev.info)
+                }
+            }
             is AgentEvent.PermissionDenied -> {
                 _ui.update { it.copy(info = Strings.agentToolDenied.format(ev.name)) }
             }
@@ -1763,6 +1782,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
                 projectFiles = files.listAll(session.id),
 
                 pendingChanges = if (sessionChanged) emptyList() else it.pendingChanges,
+                builtApks = if (sessionChanged) emptyList() else it.builtApks,
                 changesReviewExpanded = if (sessionChanged) false else it.changesReviewExpanded,
 
                 previewFilePath = if (sessionChanged) null else it.previewFilePath,

--- a/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -21,6 +22,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Android
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Folder
@@ -115,7 +117,9 @@ fun AgentDrawer(
             )
             AgentUiState.DrawerTab.Files -> FilesTab(
                 files = state.projectFiles,
-                onPick = onPickFile
+                builtApks = state.builtApks,
+                onPick = onPickFile,
+                onPickApk = { apkName -> onPickFile("apk:$apkName") }
             )
         }
     }
@@ -266,9 +270,11 @@ private val DRAWER_TIME = SimpleDateFormat("MM-dd HH:mm", Locale.getDefault())
 @Composable
 private fun FilesTab(
     files: List<com.webtoapp.core.agent.files.ProjectFileManager.FileInfo>,
-    onPick: (String) -> Unit
+    builtApks: List<com.webtoapp.core.agent.tool.BuiltApkInfo>,
+    onPick: (String) -> Unit,
+    onPickApk: (String) -> Unit
 ) {
-    if (files.isEmpty()) {
+    if (files.isEmpty() && builtApks.isEmpty()) {
         WtaFullEmptyState(
             title = Strings.agentEmptyFiles,
             message = Strings.agentEmptyFilesHint,
@@ -277,6 +283,27 @@ private fun FilesTab(
         return
     }
     LazyColumn(modifier = Modifier.fillMaxSize()) {
+        if (builtApks.isNotEmpty()) {
+            item(key = "__apk_header__") {
+                Text(
+                    text = Strings.agentBuiltApks,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = WtaSpacing.ScreenHorizontal, vertical = WtaSpacing.Small)
+                )
+            }
+            items(builtApks, key = { "apk_${it.appId}_${it.apkName}" }) { apk ->
+                WtaSettingRow(
+                    title = apk.apkName,
+                    subtitle = "${apk.formatSize()} · ${apk.buildMode}",
+                    icon = Icons.Outlined.Android,
+                    onClick = { onPickApk(apk.apkName) }
+                )
+                WtaSectionDivider()
+            }
+            item(key = "__apk_spacer__") { Spacer(Modifier.height(WtaSpacing.Small)) }
+        }
         items(files, key = { it.relativePath }) { f ->
             WtaSettingRow(
                 title = f.relativePath,

--- a/app/src/main/java/com/webtoapp/ui/agent/components/PreviewPane.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/PreviewPane.kt
@@ -19,12 +19,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Android
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.UnfoldMore
 import androidx.compose.material.icons.outlined.Web
 import androidx.compose.material3.DropdownMenu
@@ -102,6 +107,15 @@ fun PreviewPane(
         )
         if (sessionId == null || resolvedPath == null) {
             EmptyPreview()
+        } else if (resolvedPath.startsWith("apk:")) {
+            // Virtual APK artifact — render an info card instead of a WebView.
+            val apkName = resolvedPath.removePrefix("apk:")
+            val apkInfo = state.builtApks.firstOrNull { it.apkName == apkName }
+            if (apkInfo != null) {
+                ApkInfoCard(info = apkInfo, modifier = Modifier.fillMaxSize())
+            } else {
+                EmptyPreview()
+            }
         } else {
             PreviewWebView(
                 fileManager = fileManager,
@@ -403,4 +417,135 @@ private fun isImage(path: String): Boolean {
         lower.endsWith(".gif") ||
         lower.endsWith(".webp") ||
         lower.endsWith(".svg")
+}
+
+@Composable
+private fun ApkInfoCard(
+    info: com.webtoapp.core.agent.tool.BuiltApkInfo,
+    modifier: Modifier = Modifier
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(WtaSpacing.ScreenHorizontal),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(WtaSpacing.ExtraLarge))
+        // APK icon
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .background(
+                    MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(20.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Android,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(40.dp)
+            )
+        }
+        Spacer(Modifier.height(WtaSpacing.Medium))
+        Text(
+            text = info.apkName,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(WtaSpacing.ExtraLarge))
+
+        // Info rows
+        ApkInfoRow(label = Strings.agentApkSize, value = info.formatSize())
+        info.packageName?.let { ApkInfoRow(label = Strings.agentApkPackage, value = it) }
+        ApkInfoRow(label = Strings.agentApkVersion, value = info.versionName ?: "-")
+        ApkInfoRow(label = Strings.agentApkBuildMode, value = info.buildMode)
+
+        Spacer(Modifier.height(WtaSpacing.ExtraLarge))
+
+        // Install button
+        androidx.compose.material3.Button(
+            onClick = {
+                val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
+                    setDataAndType(
+                        androidx.core.content.FileProvider.getUriForFile(
+                            context,
+                            context.packageName + ".fileprovider",
+                            File(info.apkPath)
+                        ),
+                        "application/vnd.android.package-archive"
+                    )
+                    addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                runCatching { context.startActivity(intent) }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            content = {
+                Icon(
+                    imageVector = Icons.Outlined.Android,
+                    contentDescription = null,
+                    modifier = Modifier.size(WtaSize.IconSmall)
+                )
+                Spacer(Modifier.width(WtaSpacing.Small))
+                Text(Strings.agentApkInstall)
+            }
+        )
+        Spacer(Modifier.height(WtaSpacing.Small))
+        // Share button
+        androidx.compose.material3.OutlinedButton(
+            onClick = {
+                val uri = androidx.core.content.FileProvider.getUriForFile(
+                    context,
+                    context.packageName + ".fileprovider",
+                    File(info.apkPath)
+                )
+                val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                    type = "application/vnd.android.package-archive"
+                    putExtra(android.content.Intent.EXTRA_STREAM, uri)
+                    addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                runCatching {
+                    context.startActivity(android.content.Intent.createChooser(intent, Strings.agentApkShare))
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            content = {
+                Icon(
+                    imageVector = Icons.Outlined.Share,
+                    contentDescription = null,
+                    modifier = Modifier.size(WtaSize.IconSmall)
+                )
+                Spacer(Modifier.width(WtaSpacing.Small))
+                Text(Strings.agentApkShare)
+            }
+        )
+    }
+}
+
+@Composable
+private fun ApkInfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = WtaSpacing.Tiny),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
 }


### PR DESCRIPTION
## Summary

When the Agent builds an APK, the artifact now appears in the Files sidebar. Tapping it opens an info card (instead of a WebView) with Install and Share buttons.

### What the user sees
- **Files sidebar** gains a "Build Artifacts" section after a successful build
- Each APK entry shows name, size, and build mode (📦 Android icon)
- **Tap** → info card: APK icon, name, size, package, version, build mode
- **Install** button → system package installer
- **Share** button → system share sheet (sends the .apk file)

### How it works
```
BuildApk succeeds
  → ToolResult.builtApk = BuiltApkInfo(...)
  → AgentEngine.emitToolFinish sends AgentEvent.ApkBuilt
  → ViewModel adds to uiState.builtApks (replaces prior build for same appId)
  → FilesTab renders virtual APK entry under "Build Artifacts"
  → Tap → selectFile("apk:<name>") → PreviewPane renders ApkInfoCard
```

The APK is **not** copied into the session sandbox (saves space — APKs are 10MB+). The virtual entry points to the real file in `built_apks/`. Built APKs are per-session (cleared on session switch).

### Files changed (10)
- `ToolResult.kt` — new `BuiltApkInfo` data class + `builtApk` field
- `AgentEvent.kt` — new `ApkBuilt` event
- `AgentEngine.kt` — `emitToolFinish` forwards `builtApk`
- `AppLifecycleTools.kt` — `BuildApkTool` populates `builtApk` on success
- `AgentService.kt` — `persistEvent` handles `ApkBuilt` (no-op)
- `AgentUiState.kt` — `builtApks: List<BuiltApkInfo>`
- `AgentViewModel.kt` — handles `ApkBuilt`; clears on session switch; `selectFile` handles `apk:` prefix
- `AgentDrawer.kt` — `FilesTab` renders APK section
- `PreviewPane.kt` — `ApkInfoCard` with install/share via FileProvider
- `Strings.kt` — 7 new strings × 10 languages

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: Agent builds an HTML app → APK appears in Files sidebar → tap → info card → Install works.
- [ ] Manual: Share button opens system share sheet.
- [ ] Manual: Switch session → APK list clears.

Fixes #429