### PR TITLE
fix(agent): file click opens preview; per-file ⋮ menu (open / copy path)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1596,6 +1596,9 @@ object Strings {
     val agentContinuing: String get() = StringsB.agentContinuing
     val agentRateLimitRetry: (Int, Int, Long) -> String get() = StringsB.agentRateLimitRetry
     val agentFileSaved: String get() = StringsB.agentFileSaved
+    val agentFileOpen: String get() = StringsB.agentFileOpen
+    val agentFileCopyPath: String get() = StringsB.agentFileCopyPath
+    val agentPathCopied: String get() = StringsB.agentPathCopied
     val lrcGenerationDesc: String get() = StringsB.lrcGenerationDesc
     val translationDesc: String get() = StringsB.translationDesc
     val generalChatDesc: String get() = StringsB.generalChatDesc
@@ -24838,6 +24841,42 @@ object StringsB {
         AppLanguage.RUSSIAN -> "%s сохранён"
         AppLanguage.JAPANESE -> "%sを保存しました"
         AppLanguage.KOREAN -> "%s 저장됨"
+    }
+    val agentFileOpen: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "打开"
+        AppLanguage.ENGLISH -> "Open"
+        AppLanguage.ARABIC -> "فتح"
+        AppLanguage.PORTUGUESE -> "Abrir"
+        AppLanguage.SPANISH -> "Abrir"
+        AppLanguage.FRENCH -> "Ouvrir"
+        AppLanguage.GERMAN -> "Öffnen"
+        AppLanguage.RUSSIAN -> "Открыть"
+        AppLanguage.JAPANESE -> "開く"
+        AppLanguage.KOREAN -> "열기"
+    }
+    val agentFileCopyPath: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "复制路径"
+        AppLanguage.ENGLISH -> "Copy path"
+        AppLanguage.ARABIC -> "نسخ المسار"
+        AppLanguage.PORTUGUESE -> "Copiar caminho"
+        AppLanguage.SPANISH -> "Copiar ruta"
+        AppLanguage.FRENCH -> "Copier le chemin"
+        AppLanguage.GERMAN -> "Pfad kopieren"
+        AppLanguage.RUSSIAN -> "Копировать путь"
+        AppLanguage.JAPANESE -> "パスをコピー"
+        AppLanguage.KOREAN -> "경로 복사"
+    }
+    val agentPathCopied: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "路径已复制"
+        AppLanguage.ENGLISH -> "Path copied"
+        AppLanguage.ARABIC -> "تم نسخ المسار"
+        AppLanguage.PORTUGUESE -> "Caminho copiado"
+        AppLanguage.SPANISH -> "Ruta copiada"
+        AppLanguage.FRENCH -> "Chemin copié"
+        AppLanguage.GERMAN -> "Pfad kopiert"
+        AppLanguage.RUSSIAN -> "Путь скопирован"
+        AppLanguage.JAPANESE -> "パスをコピーしました"
+        AppLanguage.KOREAN -> "경로가 복사됨"
     }
 
     val lrcGenerationDesc: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -223,6 +223,11 @@ fun AgentScreen(
                         onPickFile = { path ->
                             scope.launch { drawerState.close() }
                             vm.selectFile(path)
+                            vm.openPreview()
+                        },
+                        onCopyFilePath = { path ->
+                            clipboard.setText(AnnotatedString(path))
+                            scope.launch { snackbar.showSnackbar(Strings.agentPathCopied) }
                         }
                     )
                 }

--- a/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
@@ -24,22 +24,33 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Android
 import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import com.webtoapp.core.agent.session.AgentSession
 import com.webtoapp.core.i18n.Strings
@@ -68,7 +79,8 @@ fun AgentDrawer(
     onNewSession: () -> Unit,
     onDeleteSession: (String) -> Unit,
     onPinSession: (String, Boolean) -> Unit,
-    onPickFile: (String) -> Unit
+    onPickFile: (String) -> Unit,
+    onCopyFilePath: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -119,7 +131,8 @@ fun AgentDrawer(
                 files = state.projectFiles,
                 builtApks = state.builtApks,
                 onPick = onPickFile,
-                onPickApk = { apkName -> onPickFile("apk:$apkName") }
+                onPickApk = { apkName -> onPickFile("apk:$apkName") },
+                onCopyPath = onCopyFilePath
             )
         }
     }
@@ -272,7 +285,8 @@ private fun FilesTab(
     files: List<com.webtoapp.core.agent.files.ProjectFileManager.FileInfo>,
     builtApks: List<com.webtoapp.core.agent.tool.BuiltApkInfo>,
     onPick: (String) -> Unit,
-    onPickApk: (String) -> Unit
+    onPickApk: (String) -> Unit,
+    onCopyPath: (String) -> Unit
 ) {
     if (files.isEmpty() && builtApks.isEmpty()) {
         WtaFullEmptyState(
@@ -294,26 +308,68 @@ private fun FilesTab(
                 )
             }
             items(builtApks, key = { "apk_${it.appId}_${it.apkName}" }) { apk ->
-                WtaSettingRow(
+                FileEntryRow(
                     title = apk.apkName,
                     subtitle = "${apk.formatSize()} · ${apk.buildMode}",
                     icon = Icons.Outlined.Android,
-                    onClick = { onPickApk(apk.apkName) }
+                    onOpen = { onPickApk(apk.apkName) },
+                    onCopyPath = { onCopyPath(apk.apkPath) }
                 )
                 WtaSectionDivider()
             }
             item(key = "__apk_spacer__") { Spacer(Modifier.height(WtaSpacing.Small)) }
         }
         items(files, key = { it.relativePath }) { f ->
-            WtaSettingRow(
+            FileEntryRow(
                 title = f.relativePath,
                 subtitle = "${f.formatSize()} · ${f.formatTime()}",
                 icon = Icons.Outlined.Code,
-                onClick = { onPick(f.relativePath) }
+                onOpen = { onPick(f.relativePath) },
+                onCopyPath = { onCopyPath(f.relativePath) }
             )
             WtaSectionDivider()
         }
     }
+}
+
+@Composable
+private fun FileEntryRow(
+    title: String,
+    subtitle: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    onOpen: () -> Unit,
+    onCopyPath: () -> Unit
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    WtaSettingRow(
+        title = title,
+        subtitle = subtitle,
+        icon = icon,
+        onClick = onOpen,
+        trailing = {
+            Box {
+                IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(WtaSize.TouchTarget)) {
+                    Icon(
+                        imageVector = Icons.Outlined.MoreVert,
+                        contentDescription = Strings.more,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text(Strings.agentFileOpen) },
+                        leadingIcon = { Icon(Icons.Outlined.OpenInNew, contentDescription = null) },
+                        onClick = { menuOpen = false; onOpen() }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(Strings.agentFileCopyPath) },
+                        leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                        onClick = { menuOpen = false; onCopyPath() }
+                    )
+                }
+            }
+        }
+    )
 }
 
 private fun filterSessions(all: List<AgentSession>, query: String): List<AgentSession> {


### PR DESCRIPTION
## Summary

Two fixes for the Agent Files sidebar.

### 1. Clicking a file did nothing
`selectFile` set `previewFilePath` but never called `openPreview()`, so the `PreviewSheet` never became visible. Now `onPickFile` calls both `selectFile` and `openPreview`.

### 2. Per-file context menu
Each file/APK row now has a trailing **⋮** button with:
- **Open** — opens the preview (WebView for HTML, info card for APK)
- **Copy path** — copies the path to clipboard (relative path for project files, absolute `built_apks/` path for APKs) + snackbar confirmation

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: click HTML file → preview opens.
- [ ] Manual: click APK → info card opens.
- [ ] Manual: ⋮ → "Copy path" → clipboard has the path + snackbar shows.

Fixes #429