### PR TITLE
feat(agent): "Open with…" — system file chooser for any file

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1599,6 +1599,9 @@ object Strings {
     val agentFileOpen: String get() = StringsB.agentFileOpen
     val agentFileCopyPath: String get() = StringsB.agentFileCopyPath
     val agentPathCopied: String get() = StringsB.agentPathCopied
+    val agentFileOpenWith: String get() = StringsB.agentFileOpenWith
+    val agentFileNotFound: String get() = StringsB.agentFileNotFound
+    val agentFileOpenFailed: String get() = StringsB.agentFileOpenFailed
     val lrcGenerationDesc: String get() = StringsB.lrcGenerationDesc
     val translationDesc: String get() = StringsB.translationDesc
     val generalChatDesc: String get() = StringsB.generalChatDesc
@@ -24877,6 +24880,42 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Путь скопирован"
         AppLanguage.JAPANESE -> "パスをコピーしました"
         AppLanguage.KOREAN -> "경로가 복사됨"
+    }
+    val agentFileOpenWith: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "打开方式…"
+        AppLanguage.ENGLISH -> "Open with…"
+        AppLanguage.ARABIC -> "فتح باستخدام…"
+        AppLanguage.PORTUGUESE -> "Abrir com…"
+        AppLanguage.SPANISH -> "Abrir con…"
+        AppLanguage.FRENCH -> "Ouvrir avec…"
+        AppLanguage.GERMAN -> "Öffnen mit…"
+        AppLanguage.RUSSIAN -> "Открыть с помощью…"
+        AppLanguage.JAPANESE -> "別のアプリで開く…"
+        AppLanguage.KOREAN -> "다른 앱으로 열기…"
+    }
+    val agentFileNotFound: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "文件不存在"
+        AppLanguage.ENGLISH -> "File not found"
+        AppLanguage.ARABIC -> "الملف غير موجود"
+        AppLanguage.PORTUGUESE -> "Arquivo não encontrado"
+        AppLanguage.SPANISH -> "Archivo no encontrado"
+        AppLanguage.FRENCH -> "Fichier introuvable"
+        AppLanguage.GERMAN -> "Datei nicht gefunden"
+        AppLanguage.RUSSIAN -> "Файл не найден"
+        AppLanguage.JAPANESE -> "ファイルが見つかりません"
+        AppLanguage.KOREAN -> "파일을 찾을 수 없습니다"
+    }
+    val agentFileOpenFailed: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "无法打开此文件"
+        AppLanguage.ENGLISH -> "Cannot open this file"
+        AppLanguage.ARABIC -> "تعذر فتح هذا الملف"
+        AppLanguage.PORTUGUESE -> "Não é possível abrir este arquivo"
+        AppLanguage.SPANISH -> "No se puede abrir este archivo"
+        AppLanguage.FRENCH -> "Impossible d'ouvrir ce fichier"
+        AppLanguage.GERMAN -> "Diese Datei kann nicht geöffnet werden"
+        AppLanguage.RUSSIAN -> "Невозможно открыть этот файл"
+        AppLanguage.JAPANESE -> "このファイルを開けません"
+        AppLanguage.KOREAN -> "이 파일을 열 수 없습니다"
     }
 
     val lrcGenerationDesc: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -228,6 +228,10 @@ fun AgentScreen(
                         onCopyFilePath = { path ->
                             clipboard.setText(AnnotatedString(path))
                             scope.launch { snackbar.showSnackbar(Strings.agentPathCopied) }
+                        },
+                        onOpenWith = { path ->
+                            scope.launch { drawerState.close() }
+                            vm.openWithSystemChooser(path)
                         }
                     )
                 }

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -35,6 +35,7 @@ import com.webtoapp.core.agent.tool.BuiltApkInfo
 import com.webtoapp.core.agent.tool.ToolRegistryFactory
 import com.webtoapp.core.agent.prompt.SystemPromptBuilder
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.data.model.AiFeature
 import com.webtoapp.data.model.toManifestJson
 import kotlinx.coroutines.Dispatchers
@@ -633,6 +634,59 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setPreviewFile(path: String?) {
         _ui.update { it.copy(previewFilePath = path) }
+    }
+
+    /**
+     * Open a file with the system chooser ("Open with…") so the user can pick an
+     * external app (file manager, browser, etc.) to view or locate the file.
+     * For APK artifacts it uses the absolute built_apks path; for project files
+     * it resolves the sandbox-relative path to an absolute file first.
+     */
+    fun openWithSystemChooser(path: String) {
+        val file: java.io.File = if (path.startsWith("apk:")) {
+            val apkName = path.removePrefix("apk:")
+            val apk = _ui.value.builtApks.firstOrNull { it.apkName == apkName }
+            if (apk != null) java.io.File(apk.apkPath) else return
+        } else {
+            val sid = _ui.value.currentSession?.id ?: return
+            files.resolveSafe(sid, path) ?: return
+        }
+        if (!file.exists()) {
+            _ui.update { it.copy(info = Strings.agentFileNotFound) }
+            return
+        }
+        runCatching {
+            val uri = androidx.core.content.FileProvider.getUriForFile(
+                ctx, ctx.packageName + ".fileprovider", file
+            )
+            val mime = if (path.startsWith("apk:")) "application/vnd.android.package-archive"
+                       else getMimeType(file.name)
+            val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, mime)
+                addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            ctx.startActivity(
+                android.content.Intent.createChooser(intent, Strings.agentFileOpenWith)
+                    .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }.onFailure { e ->
+            AppLogger.w("AgentViewModel", "openWithSystemChooser failed: ${e.message}")
+            _ui.update { it.copy(info = Strings.agentFileOpenFailed) }
+        }
+    }
+
+    private fun getMimeType(fileName: String): String {
+        val ext = fileName.substringAfterLast('.', "").lowercase()
+        return android.webkit.MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+            ?: when (ext) {
+                "html", "htm" -> "text/html"
+                "js" -> "application/javascript"
+                "json" -> "application/json"
+                "css" -> "text/css"
+                "md" -> "text/markdown"
+                else -> "*/*"
+            }
     }
 
     fun saveSelectedFile(content: String) {

--- a/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/AgentDrawer.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Android
+import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
@@ -80,7 +81,8 @@ fun AgentDrawer(
     onDeleteSession: (String) -> Unit,
     onPinSession: (String, Boolean) -> Unit,
     onPickFile: (String) -> Unit,
-    onCopyFilePath: (String) -> Unit
+    onCopyFilePath: (String) -> Unit,
+    onOpenWith: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -132,7 +134,8 @@ fun AgentDrawer(
                 builtApks = state.builtApks,
                 onPick = onPickFile,
                 onPickApk = { apkName -> onPickFile("apk:$apkName") },
-                onCopyPath = onCopyFilePath
+                onCopyPath = onCopyFilePath,
+                onOpenWith = onOpenWith
             )
         }
     }
@@ -286,7 +289,8 @@ private fun FilesTab(
     builtApks: List<com.webtoapp.core.agent.tool.BuiltApkInfo>,
     onPick: (String) -> Unit,
     onPickApk: (String) -> Unit,
-    onCopyPath: (String) -> Unit
+    onCopyPath: (String) -> Unit,
+    onOpenWith: (String) -> Unit
 ) {
     if (files.isEmpty() && builtApks.isEmpty()) {
         WtaFullEmptyState(
@@ -308,11 +312,13 @@ private fun FilesTab(
                 )
             }
             items(builtApks, key = { "apk_${it.appId}_${it.apkName}" }) { apk ->
+                val apkVirtualPath = "apk:${apk.apkName}"
                 FileEntryRow(
                     title = apk.apkName,
                     subtitle = "${apk.formatSize()} · ${apk.buildMode}",
                     icon = Icons.Outlined.Android,
                     onOpen = { onPickApk(apk.apkName) },
+                    onOpenWith = { onOpenWith(apkVirtualPath) },
                     onCopyPath = { onCopyPath(apk.apkPath) }
                 )
                 WtaSectionDivider()
@@ -325,6 +331,7 @@ private fun FilesTab(
                 subtitle = "${f.formatSize()} · ${f.formatTime()}",
                 icon = Icons.Outlined.Code,
                 onOpen = { onPick(f.relativePath) },
+                onOpenWith = { onOpenWith(f.relativePath) },
                 onCopyPath = { onCopyPath(f.relativePath) }
             )
             WtaSectionDivider()
@@ -338,6 +345,7 @@ private fun FileEntryRow(
     subtitle: String,
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     onOpen: () -> Unit,
+    onOpenWith: () -> Unit,
     onCopyPath: () -> Unit
 ) {
     var menuOpen by remember { mutableStateOf(false) }
@@ -360,6 +368,11 @@ private fun FileEntryRow(
                         text = { Text(Strings.agentFileOpen) },
                         leadingIcon = { Icon(Icons.Outlined.OpenInNew, contentDescription = null) },
                         onClick = { menuOpen = false; onOpen() }
+                    )
+                    DropdownMenuItem(
+                        text = { Text(Strings.agentFileOpenWith) },
+                        leadingIcon = { Icon(Icons.Outlined.Apps, contentDescription = null) },
+                        onClick = { menuOpen = false; onOpenWith() }
                     )
                     DropdownMenuItem(
                         text = { Text(Strings.agentFileCopyPath) },


### PR DESCRIPTION
## Summary

The file context menu (⋮) now has a third option: **"Open with…"** which launches the system chooser so the user can open the file with an external app (file manager, browser, etc.) or navigate to its directory.

### Menu items (⋮ per file/APK row)
| Option | Action |
|--------|--------|
| **Open** | In-app preview (WebView for HTML, info card for APK) |
| **Open with…** | System chooser (`createChooser`) — pick an external app |
| **Copy path** | Copies path to clipboard |

### How it works (`ViewModel.openWithSystemChooser`)
- **APK**: uses absolute `built_apks/` path, MIME `application/vnd.android.package-archive`
- **Project file**: resolves sandbox-relative path to absolute file, infers MIME from extension (HTML→`text/html`, JS→`application/javascript`, etc.)
- Builds `ACTION_VIEW` intent with FileProvider URI, wrapped in `createChooser` → system shows all apps that can handle the file type

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: ⋮ → "Open with…" on an HTML file → system chooser appears (browser, file manager, etc.).
- [ ] Manual: ⋮ → "Open with…" on an APK → system chooser / package installer.

Fixes #429