### PR TITLE
fix(agent): always send reasoning_content for GLM thinking mode

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -162,8 +162,10 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
         }
         else addProperty("content", msg.content)
 
-        if (msg.role == LlmMessage.Role.ASSISTANT && !msg.reasoningContent.isNullOrEmpty()) {
-            addProperty("reasoning_content", msg.reasoningContent)
+        if (msg.role == LlmMessage.Role.ASSISTANT) {
+            // GLM thinking mode requires reasoning_content on every assistant message
+            // once thinking has been used; passing an empty string is safer than omitting it.
+            addProperty("reasoning_content", msg.reasoningContent ?: "")
         }
         msg.toolCallId?.let { addProperty("tool_call_id", it) }; msg.name?.let { addProperty("name", it) }
     }


### PR DESCRIPTION
## Summary

GLM thinking mode requires `reasoning_content` on **every** assistant message once thinking has been used in the conversation. Previously the field was omitted when `reasoningContent` was null/empty, causing:

```
Bad request (400): The `reasoning_content` in the thinking mode must be passed back to the API.
```

## Fix

Always send `reasoning_content` for assistant messages — empty string `""` when no thinking content. This is harmless for other OpenAI-compat APIs and is the approach GLM recommends.

## Test plan
- [x] `:app:compileDebugKotlin` green
- [ ] Manual: multi-turn Agent session with GLM model — no more 400 error on turn 2+.

Fixes #429