### PR TITLE
fix(shell): add terminal/console button to built APK toolbar

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ConsolePanel.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ConsolePanel.kt
@@ -1,4 +1,4 @@
-package com.webtoapp.ui.webview
+package com.webtoapp.ui.shell
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.*
@@ -62,6 +63,12 @@ fun BoxScope.ShellScaffoldLayout(
     onShowActivationDialog: () -> Unit,
     onErrorDismiss: () -> Unit,
     onActivityFinish: () -> Unit,
+
+    showConsole: Boolean,
+    onToggleConsole: () -> Unit,
+    consoleMessages: List<ConsoleLogEntry>,
+    onClearConsole: () -> Unit,
+    onRunScript: (String) -> Unit,
 
     statusBarHeightDp: Int
 ) {
@@ -117,7 +124,10 @@ fun BoxScope.ShellScaffoldLayout(
                     showRefresh = config.webViewConfig.toolbarShowRefresh,
                     canGoBack = canGoBack,
                     canGoForward = canGoForward,
-                    webViewRef = webViewRef
+                    webViewRef = webViewRef,
+                    showConsole = showConsole,
+                    onToggleConsole = onToggleConsole,
+                    consoleErrorCount = consoleMessages.count { it.level == ConsoleLevel.ERROR }
                 )
             }
         }
@@ -208,6 +218,23 @@ fun BoxScope.ShellScaffoldLayout(
                 errorMessage = errorMessage,
                 onDismiss = onErrorDismiss
             )
+
+            // Console panel (slides up from bottom when toggled)
+            AnimatedVisibility(
+                visible = showConsole,
+                enter = androidx.compose.animation.slideInVertically(initialOffsetY = { it }) + fadeIn(),
+                exit = androidx.compose.animation.slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+                modifier = Modifier.align(Alignment.BottomCenter)
+            ) {
+                ConsolePanel(
+                    consoleMessages = consoleMessages,
+                    isExpanded = false,
+                    onExpandToggle = onToggleConsole,
+                    onClear = onClearConsole,
+                    onRunScript = onRunScript,
+                    onClose = onToggleConsole
+                )
+            }
         }
     }
 }
@@ -225,7 +252,10 @@ private fun ShellTopAppBar(
     showRefresh: Boolean,
     canGoBack: Boolean,
     canGoForward: Boolean,
-    webViewRef: WebView?
+    webViewRef: WebView?,
+    showConsole: Boolean = false,
+    onToggleConsole: () -> Unit = {},
+    consoleErrorCount: Int = 0
 ) {
     val context = LocalContext.current
 
@@ -280,6 +310,23 @@ private fun ShellTopAppBar(
                     icon = Icons.Default.Refresh,
                     contentDescription = "Refresh"
                 )
+            }
+            // Console / terminal button
+            IconButton(onClick = onToggleConsole) {
+                BadgedBox(
+                    badge = {
+                        if (consoleErrorCount > 0) {
+                            Badge { Text("$consoleErrorCount") }
+                        }
+                    }
+                ) {
+                    Icon(
+                        if (showConsole) Icons.Default.Terminal
+                        else Icons.Outlined.Terminal,
+                        contentDescription = Strings.console,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         },
         colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -69,6 +69,10 @@ fun ShellScreen(
     var showActivationDialog by remember { mutableStateOf(false) }
     var showAnnouncementDialog by remember { mutableStateOf(false) }
 
+    // Console / terminal panel state
+    var showConsole by remember { mutableStateOf(false) }
+    var consoleMessages by remember { mutableStateOf<List<ConsoleLogEntry>>(emptyList()) }
+
     var isActivated by remember { mutableStateOf(!config.activationEnabled) }
 
     var isActivationChecked by remember { mutableStateOf(!config.activationEnabled) }
@@ -312,7 +316,8 @@ fun ShellScreen(
             scheduleStatusBarAutoColorSample = {
                 statusBarColorTracker?.scheduleSample(56L)
             },
-            onRefreshFinished = { isRefreshing = false }
+            onRefreshFinished = { isRefreshing = false },
+            onConsoleLog = { entry -> consoleMessages = consoleMessages + entry }
         )
     }
 
@@ -401,6 +406,21 @@ fun ShellScreen(
         onShowActivationDialog = { showActivationDialog = true },
         onErrorDismiss = { errorMessage = null },
         onActivityFinish = { activity.finish() },
+        showConsole = showConsole,
+        onToggleConsole = { showConsole = !showConsole },
+        consoleMessages = consoleMessages,
+        onClearConsole = { consoleMessages = emptyList() },
+        onRunScript = { script ->
+            webViewRef?.evaluateJavascript(script) { result ->
+                consoleMessages = consoleMessages + ConsoleLogEntry(
+                    level = ConsoleLevel.LOG,
+                    message = "=> $result",
+                    source = "eval",
+                    lineNumber = 0,
+                    timestamp = System.currentTimeMillis()
+                )
+            }
+        },
         statusBarHeightDp = statusBarHeightDp
     )
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
@@ -41,7 +41,8 @@ fun createShellWebViewCallbacks(
     notifyLongPressMenu: (LongPressHandler.LongPressResult, Float, Float) -> Unit,
     resetStatusBarAutoColor: () -> Unit = {},
     scheduleStatusBarAutoColorSample: () -> Unit = {},
-    onRefreshFinished: () -> Unit = {}
+    onRefreshFinished: () -> Unit = {},
+    onConsoleLog: (ConsoleLogEntry) -> Unit = {}
 ): WebViewCallbacks {
     return object : WebViewCallbacks {
         override fun onPageStarted(url: String?) {
@@ -53,15 +54,16 @@ fun createShellWebViewCallbacks(
         }
 
         override fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {
-            val levelStr = when (level) {
-                0 -> "DEBUG"
-                1 -> "LOG"
-                2 -> "INFO"
-                3 -> "WARN"
-                4 -> "ERROR"
-                else -> "LOG"
+            val consoleLevel = when (level) {
+                0 -> ConsoleLevel.DEBUG
+                1 -> ConsoleLevel.LOG
+                2 -> ConsoleLevel.INFO
+                3 -> ConsoleLevel.WARNING
+                4 -> ConsoleLevel.ERROR
+                else -> ConsoleLevel.LOG
             }
-            AppLogger.d("ShellConsole", "[$levelStr] $message ($sourceId:$lineNumber)")
+            AppLogger.d("ShellConsole", "[$consoleLevel] $message ($sourceId:$lineNumber)")
+            onConsoleLog(ConsoleLogEntry(consoleLevel, message, sourceId, lineNumber, System.currentTimeMillis()))
         }
 
         override fun onUrlChanged(webView: WebView?, url: String?) {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -72,6 +72,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import com.webtoapp.ui.shared.WindowHelper
+import com.webtoapp.ui.shell.ConsoleLevel
+import com.webtoapp.ui.shell.ConsoleLogEntry
+import com.webtoapp.ui.shell.ConsolePanel
 import com.webtoapp.ui.shell.ShellWebViewNavigation
 import com.webtoapp.ui.shell.GeolocationPermissionsSingleton
 import java.io.File

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
@@ -153,6 +153,7 @@ class WebViewConfigBooleanCoverageTest {
             allowMixedContent = bool("allowMixedContent"),
             enableBlobDownloadInterception = bool("enableBlobDownloadInterception"),
             enablePrintBridge = bool("enablePrintBridge"),
+            enableMediaSession = bool("enableMediaSession"),
             enableCloudflareCompat = bool("enableCloudflareCompat"),
             enableCookiePersistence = bool("enableCookiePersistence"),
             enablePrivateNetworkBridge = bool("enablePrivateNetworkBridge"),


### PR DESCRIPTION
## Summary

Built APKs were missing the terminal/console button that the preview had. The shell toolbar only showed Back/Forward/Refresh. Now both paths have the same console functionality.

### Changes
- **Moved `ConsolePanel.kt`** from `ui/webview/` → `ui/shell/` (so it's shell-synced and available in generated APKs)
- **`ShellTopAppBar`** gains a terminal `IconButton` with error-count badge (matching WebViewActivity)
- **`ShellWebViewCallbacks`** `onConsoleMessage` now collects messages to a UI list (was AppLogger-only)
- **`ShellScreen`** adds `showConsole`/`consoleMessages` state + `ConsolePanel` at the bottom with JS script execution
- **`WebViewActivity`** imports updated for the moved types

## Test plan
- [x] `:app:compileDebugKotlin` + `:shell:compileDebugKotlin` green
- [x] Shell template rebuilt
- [ ] Manual: build HTML app → install → toolbar shows terminal button → tap → ConsolePanel shows console.log output → run JS script.

Fixes #429