### PR TITLE
fix(shell): restore normal-mode toolbar buttons after Hide Toolbar toggle

### DIFF
--- a/app/src/main/java/com/webtoapp/data/model/ToolbarVisibility.kt
+++ b/app/src/main/java/com/webtoapp/data/model/ToolbarVisibility.kt
@@ -1,0 +1,47 @@
+package com.webtoapp.data.model
+
+/**
+ * Resolved visibility of each toolbar control in the shell/preview browser toolbar.
+ *
+ * Semantics: the "hide browser toolbar" toggle (`hideBrowserToolbar`) switches the
+ * toolbar into a customized slim mode where only the explicitly-checked items
+ * (`toolbarShow*`) appear. In the normal mode (`hideBrowserToolbar = false`) the
+ * toolbar always shows the full button set — the `toolbarShow*` checkboxes are only
+ * editable while the hide toggle is on, so their values must not be applied in the
+ * normal mode (doing so leaves a toolbar with every button hidden once the toggle is
+ * turned back off).
+ */
+data class ToolbarButtonVisibility(
+    val showTitle: Boolean,
+    val showUrl: Boolean,
+    val showBack: Boolean,
+    val showForward: Boolean,
+    val showRefresh: Boolean,
+    val showConsoleButton: Boolean
+)
+
+/**
+ * Resolves which toolbar buttons are visible given the hide-toggle state and the
+ * customized toolbar content flags. See [ToolbarButtonVisibility] for the contract.
+ */
+fun resolveToolbarButtons(
+    hideBrowserToolbar: Boolean,
+    browserToolbarCustomized: Boolean,
+    toolbarShowTitle: Boolean,
+    toolbarShowUrl: Boolean,
+    toolbarShowBack: Boolean,
+    toolbarShowForward: Boolean,
+    toolbarShowRefresh: Boolean
+): ToolbarButtonVisibility {
+    val customizedSlim = hideBrowserToolbar && browserToolbarCustomized
+    val hasAnyToolbarItem = toolbarShowTitle || toolbarShowUrl ||
+        toolbarShowBack || toolbarShowForward || toolbarShowRefresh
+    return ToolbarButtonVisibility(
+        showTitle = !customizedSlim || toolbarShowTitle,
+        showUrl = !customizedSlim || toolbarShowUrl,
+        showBack = !customizedSlim || toolbarShowBack,
+        showForward = !customizedSlim || toolbarShowForward,
+        showRefresh = !customizedSlim || toolbarShowRefresh,
+        showConsoleButton = !customizedSlim || hasAnyToolbarItem
+    )
+}

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -52,6 +52,7 @@ import com.webtoapp.ui.components.BgmCard
 import com.webtoapp.ui.components.*
 import com.webtoapp.ui.viewmodel.EditState
 import com.webtoapp.ui.viewmodel.hasPreviewableContent
+import com.webtoapp.ui.viewmodel.withHideBrowserToolbar
 import com.webtoapp.ui.viewmodel.MainViewModel
 import com.webtoapp.ui.viewmodel.UiState
 import androidx.compose.ui.platform.LocalContext
@@ -218,19 +219,7 @@ fun CreateAppScreen(
                     webViewConfig = editState.webViewConfig,
                     onEnabledChange = { enabled ->
                         viewModel.updateEditState {
-                            if (enabled && !webViewConfig.browserToolbarCustomized) {
-                                copy(webViewConfig = webViewConfig.copy(
-                                    hideBrowserToolbar = true,
-                                    toolbarShowTitle = false,
-                                    toolbarShowUrl = false,
-                                    toolbarShowBack = false,
-                                    toolbarShowForward = false,
-                                    toolbarShowRefresh = false,
-                                    browserToolbarCustomized = true
-                                ))
-                            } else {
-                                copy(webViewConfig = webViewConfig.copy(hideBrowserToolbar = enabled))
-                            }
+                            copy(webViewConfig = webViewConfig.withHideBrowserToolbar(enabled))
                         }
                     },
                     onWebViewConfigChange = { newConfig ->

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -26,6 +26,7 @@ import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.shell.ShellConfig
 import com.webtoapp.core.webview.WebViewCallbacks
 import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.data.model.resolveToolbarButtons
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -103,6 +104,19 @@ fun BoxScope.ShellScaffoldLayout(
     val showToolbar = (!hideToolbar || config.webViewConfig.showToolbarInFullscreen) &&
         (!hideBrowserToolbar || showSlimToolbar)
 
+    // In normal (non-hide) mode the toolbar always shows the full button set; only the
+    // customized slim mode applies the toolbarShow* filters. This keeps a normal-mode
+    // app from ending up with every button hidden after the hide toggle was turned off.
+    val toolbarVisibility = resolveToolbarButtons(
+        hideBrowserToolbar = toolbarCfg.hideBrowserToolbar,
+        browserToolbarCustomized = toolbarCfg.browserToolbarCustomized,
+        toolbarShowTitle = toolbarCfg.toolbarShowTitle,
+        toolbarShowUrl = toolbarCfg.toolbarShowUrl,
+        toolbarShowBack = toolbarCfg.toolbarShowBack,
+        toolbarShowForward = toolbarCfg.toolbarShowForward,
+        toolbarShowRefresh = toolbarCfg.toolbarShowRefresh
+    )
+
     Scaffold(
 
         contentWindowInsets = if (hideToolbar && !showToolbar) {
@@ -117,14 +131,15 @@ fun BoxScope.ShellScaffoldLayout(
                     pageTitle = pageTitle,
                     appName = config.appName,
                     currentUrl = currentUrl,
-                    showTitle = config.webViewConfig.toolbarShowTitle,
-                    showUrl = config.webViewConfig.toolbarShowUrl,
-                    showBack = config.webViewConfig.toolbarShowBack,
-                    showForward = config.webViewConfig.toolbarShowForward,
-                    showRefresh = config.webViewConfig.toolbarShowRefresh,
+                    showTitle = toolbarVisibility.showTitle,
+                    showUrl = toolbarVisibility.showUrl,
+                    showBack = toolbarVisibility.showBack,
+                    showForward = toolbarVisibility.showForward,
+                    showRefresh = toolbarVisibility.showRefresh,
                     canGoBack = canGoBack,
                     canGoForward = canGoForward,
                     webViewRef = webViewRef,
+                    showConsoleButton = toolbarVisibility.showConsoleButton,
                     showConsole = showConsole,
                     onToggleConsole = onToggleConsole,
                     consoleErrorCount = consoleMessages.count { it.level == ConsoleLevel.ERROR }
@@ -253,6 +268,7 @@ private fun ShellTopAppBar(
     canGoBack: Boolean,
     canGoForward: Boolean,
     webViewRef: WebView?,
+    showConsoleButton: Boolean = true,
     showConsole: Boolean = false,
     onToggleConsole: () -> Unit = {},
     consoleErrorCount: Int = 0
@@ -311,21 +327,24 @@ private fun ShellTopAppBar(
                     contentDescription = "Refresh"
                 )
             }
-            // Console / terminal button
-            IconButton(onClick = onToggleConsole) {
-                BadgedBox(
-                    badge = {
-                        if (consoleErrorCount > 0) {
-                            Badge { Text("$consoleErrorCount") }
+            // Console / terminal button (hidden along with the other toolbar buttons,
+            // so a stripped-down toolbar doesn't leave it as the only visible control)
+            if (showConsoleButton) {
+                IconButton(onClick = onToggleConsole) {
+                    BadgedBox(
+                        badge = {
+                            if (consoleErrorCount > 0) {
+                                Badge { Text("$consoleErrorCount") }
+                            }
                         }
+                    ) {
+                        Icon(
+                            if (showConsole) Icons.Default.Terminal
+                            else Icons.Outlined.Terminal,
+                            contentDescription = Strings.console,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
-                ) {
-                    Icon(
-                        if (showConsole) Icons.Default.Terminal
-                        else Icons.Outlined.Terminal,
-                        contentDescription = Strings.console,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
                 }
             }
         },

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/EditState.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/EditState.kt
@@ -115,6 +115,40 @@ fun EditState.withRuntimePermissionsSyncedFromFeatures(): EditState {
 }
 
 
+/**
+ * Applies the "hide browser toolbar" toggle to a [WebViewConfig].
+ *
+ * Enabling the toggle for the first time enters a customized slim-toolbar mode: it
+ * clears every toolbar-content flag and marks the toolbar as customized so the user
+ * picks which items to show. Disabling the toggle returns to the normal full toolbar:
+ * it restores every toolbar-content flag to `true` and clears the customized marker.
+ *
+ * The restore on disable is what keeps the "hide toolbar" toggle from leaving a
+ * normal-mode app with every toolbar button hidden (a state where only the console
+ * button — if it were unconditionally rendered — would survive).
+ */
+fun WebViewConfig.withHideBrowserToolbar(enabled: Boolean): WebViewConfig = when {
+    enabled && !browserToolbarCustomized -> copy(
+        hideBrowserToolbar = true,
+        toolbarShowTitle = false,
+        toolbarShowUrl = false,
+        toolbarShowBack = false,
+        toolbarShowForward = false,
+        toolbarShowRefresh = false,
+        browserToolbarCustomized = true
+    )
+    !enabled -> copy(
+        hideBrowserToolbar = false,
+        toolbarShowTitle = true,
+        toolbarShowUrl = true,
+        toolbarShowBack = true,
+        toolbarShowForward = true,
+        toolbarShowRefresh = true,
+        browserToolbarCustomized = false
+    )
+    else -> copy(hideBrowserToolbar = enabled)
+}
+
 fun EditState.hasPreviewableContent(): Boolean = when (appType) {
     AppType.WEB -> url.isNotBlank()
     AppType.HTML, AppType.FRONTEND -> htmlConfig?.files?.isNotEmpty() == true

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -64,6 +64,7 @@ import com.webtoapp.data.model.HtmlLoadMode
 import com.webtoapp.data.model.SplashOrientation
 import com.webtoapp.data.model.SplashType
 import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.resolveToolbarButtons
 import android.content.pm.ActivityInfo
 import com.webtoapp.ui.theme.WebToAppTheme
 import com.webtoapp.util.DownloadHelper
@@ -2674,6 +2675,20 @@ fun WebViewScreen(
     val showSlimToolbar = hideBrowserToolbar && toolbarCfg?.browserToolbarCustomized == true && hasAnyToolbarItem
     val shouldShowTopBar = showToolbarInPreview && (!hideBrowserToolbar || showSlimToolbar)
 
+    // Normal (non-hide) mode always shows the full button set; only the customized slim
+    // mode applies the toolbarShow* filters (mirrors the shell/export layout).
+    val browserToolbarVisibility = toolbarCfg?.let {
+        resolveToolbarButtons(
+            hideBrowserToolbar = it.hideBrowserToolbar,
+            browserToolbarCustomized = it.browserToolbarCustomized,
+            toolbarShowTitle = it.toolbarShowTitle,
+            toolbarShowUrl = it.toolbarShowUrl,
+            toolbarShowBack = it.toolbarShowBack,
+            toolbarShowForward = it.toolbarShowForward,
+            toolbarShowRefresh = it.toolbarShowRefresh
+        )
+    }
+
     LaunchedEffect(hideToolbar) {
 
         onFullscreenModeChanged(hideToolbar)
@@ -2689,7 +2704,7 @@ fun WebViewScreen(
                 TopAppBar(
                     title = {
                         Column {
-                            if (isTestMode || webApp?.webViewConfig?.toolbarShowTitle == true) {
+                            if (isTestMode || browserToolbarVisibility?.showTitle == true) {
                                 Text(
                                     text = if (isTestMode) Strings.moduleTestMode else pageTitle.ifEmpty { webApp?.name ?: "WebApp" },
                                     style = MaterialTheme.typography.titleMedium,
@@ -2704,7 +2719,7 @@ fun WebViewScreen(
                                     color = MaterialTheme.colorScheme.primary,
                                     maxLines = 1
                                 )
-                            } else if (currentUrl.isNotEmpty() && webApp?.webViewConfig?.toolbarShowUrl == true) {
+                            } else if (currentUrl.isNotEmpty() && (isTestMode || browserToolbarVisibility?.showUrl == true)) {
                                 Text(
                                     text = currentUrl,
                                     style = MaterialTheme.typography.bodySmall,
@@ -2716,7 +2731,7 @@ fun WebViewScreen(
                         }
                     },
                     actions = {
-                        if (isTestMode || webApp?.webViewConfig?.toolbarShowBack == true) {
+                        if (isTestMode || browserToolbarVisibility?.showBack == true) {
                             IconButton(
                                 onClick = {
                                     (context as? AppCompatActivity)?.let { activity ->
@@ -2728,7 +2743,7 @@ fun WebViewScreen(
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
                             }
                         }
-                        if (isTestMode || webApp?.webViewConfig?.toolbarShowForward == true) {
+                        if (isTestMode || browserToolbarVisibility?.showForward == true) {
                             IconButton(
                                 onClick = { webViewRef?.goForward() },
                                 enabled = canGoForward
@@ -2736,29 +2751,31 @@ fun WebViewScreen(
                                 Icon(Icons.AutoMirrored.Filled.ArrowForward, "Forward")
                             }
                         }
-                        if (isTestMode || webApp?.webViewConfig?.toolbarShowRefresh == true) {
+                        if (isTestMode || browserToolbarVisibility?.showRefresh == true) {
                             IconButton(onClick = { reloadBrowser() }) {
                                 Icon(Icons.Default.Refresh, "Refresh")
                             }
                         }
 
-                        IconButton(
-                            onClick = { showConsole = !showConsole },
-                            modifier = Modifier.size(48.dp).offset(x = (-4).dp)
-                        ) {
-                            Box(modifier = Modifier.padding(start = 4.dp, top = 4.dp)) {
-                                BadgedBox(
-                                    badge = {
-                                        val errorCount = consoleMessages.count { it.level == ConsoleLevel.ERROR }
-                                        if (errorCount > 0) {
-                                            Badge { Text("$errorCount") }
+                        if (isTestMode || browserToolbarVisibility?.showConsoleButton == true) {
+                            IconButton(
+                                onClick = { showConsole = !showConsole },
+                                modifier = Modifier.size(48.dp).offset(x = (-4).dp)
+                            ) {
+                                Box(modifier = Modifier.padding(start = 4.dp, top = 4.dp)) {
+                                    BadgedBox(
+                                        badge = {
+                                            val errorCount = consoleMessages.count { it.level == ConsoleLevel.ERROR }
+                                            if (errorCount > 0) {
+                                                Badge { Text("$errorCount") }
+                                            }
                                         }
+                                    ) {
+                                        Icon(
+                                            if (showConsole) Icons.Filled.Terminal else Icons.Outlined.Terminal,
+                                            Strings.console
+                                        )
                                     }
-                                ) {
-                                    Icon(
-                                        if (showConsole) Icons.Filled.Terminal else Icons.Outlined.Terminal,
-                                        Strings.console
-                                    )
                                 }
                             }
                         }

--- a/app/src/test/java/com/webtoapp/data/model/ToolbarVisibilityTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/ToolbarVisibilityTest.kt
@@ -1,0 +1,90 @@
+package com.webtoapp.data.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ToolbarVisibilityTest {
+
+    @Test
+    fun `normal mode always shows the full button set even when toolbar flags are all false`() {
+        // A fresh app in normal mode never has the toolbar flags hit; but a config that
+        // was polluted by toggling "hide toolbar" on then off leaves every flag false.
+        // The renderer must still show the full toolbar in normal (non-hide) mode.
+        val visibility = resolveToolbarButtons(
+            hideBrowserToolbar = false,
+            browserToolbarCustomized = true,
+            toolbarShowTitle = false,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false
+        )
+
+        assertThat(visibility.showTitle).isTrue()
+        assertThat(visibility.showUrl).isTrue()
+        assertThat(visibility.showBack).isTrue()
+        assertThat(visibility.showForward).isTrue()
+        assertThat(visibility.showRefresh).isTrue()
+        assertThat(visibility.showConsoleButton).isTrue()
+    }
+
+    @Test
+    fun `customized slim mode applies the toolbar flags`() {
+        val visibility = resolveToolbarButtons(
+            hideBrowserToolbar = true,
+            browserToolbarCustomized = true,
+            toolbarShowTitle = true,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = true,
+            toolbarShowRefresh = false
+        )
+
+        assertThat(visibility.showTitle).isTrue()
+        assertThat(visibility.showUrl).isFalse()
+        assertThat(visibility.showBack).isFalse()
+        assertThat(visibility.showForward).isTrue()
+        assertThat(visibility.showRefresh).isFalse()
+        assertThat(visibility.showConsoleButton).isTrue() // at least one item checked
+    }
+
+    @Test
+    fun `customized slim mode with all items unchecked hides the console button too`() {
+        val visibility = resolveToolbarButtons(
+            hideBrowserToolbar = true,
+            browserToolbarCustomized = true,
+            toolbarShowTitle = false,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false
+        )
+
+        assertThat(visibility.showTitle).isFalse()
+        assertThat(visibility.showUrl).isFalse()
+        assertThat(visibility.showBack).isFalse()
+        assertThat(visibility.showForward).isFalse()
+        assertThat(visibility.showRefresh).isFalse()
+        assertThat(visibility.showConsoleButton).isFalse()
+    }
+
+    @Test
+    fun `hide toolbar on but not customized behaves as normal full toolbar`() {
+        // hideBrowserToolbar = true but browserToolbarCustomized = false: the slim
+        // toolbar is not shown (showSlimToolbar is false), so the full button set wins.
+        val visibility = resolveToolbarButtons(
+            hideBrowserToolbar = true,
+            browserToolbarCustomized = false,
+            toolbarShowTitle = false,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false
+        )
+
+        assertThat(visibility.showTitle).isTrue()
+        assertThat(visibility.showBack).isTrue()
+        assertThat(visibility.showRefresh).isTrue()
+        assertThat(visibility.showConsoleButton).isTrue()
+    }
+}

--- a/app/src/test/java/com/webtoapp/ui/viewmodel/HideBrowserToolbarToggleTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/viewmodel/HideBrowserToolbarToggleTest.kt
@@ -1,0 +1,66 @@
+package com.webtoapp.ui.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.WebViewConfig
+import org.junit.Test
+
+class HideBrowserToolbarToggleTest {
+
+    @Test
+    fun `first enable clears toolbar flags and marks customized`() {
+        val config = WebViewConfig()
+        val result = config.withHideBrowserToolbar(true)
+
+        assertThat(result.hideBrowserToolbar).isTrue()
+        assertThat(result.browserToolbarCustomized).isTrue()
+        assertThat(result.toolbarShowTitle).isFalse()
+        assertThat(result.toolbarShowUrl).isFalse()
+        assertThat(result.toolbarShowBack).isFalse()
+        assertThat(result.toolbarShowForward).isFalse()
+        assertThat(result.toolbarShowRefresh).isFalse()
+    }
+
+    @Test
+    fun `disable restores the full toolbar flag set`() {
+        // Simulate a config that was polluted: hide toggle off but every toolbar flag false.
+        val config = WebViewConfig(
+            hideBrowserToolbar = false,
+            toolbarShowTitle = false,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false,
+            browserToolbarCustomized = true
+        )
+        val result = config.withHideBrowserToolbar(false)
+
+        assertThat(result.hideBrowserToolbar).isFalse()
+        assertThat(result.browserToolbarCustomized).isFalse()
+        assertThat(result.toolbarShowTitle).isTrue()
+        assertThat(result.toolbarShowUrl).isTrue()
+        assertThat(result.toolbarShowBack).isTrue()
+        assertThat(result.toolbarShowForward).isTrue()
+        assertThat(result.toolbarShowRefresh).isTrue()
+    }
+
+    @Test
+    fun `re-enable keeps customizations instead of re-clearing`() {
+        val customized = WebViewConfig(
+            hideBrowserToolbar = true,
+            toolbarShowTitle = true,
+            toolbarShowUrl = false,
+            toolbarShowBack = true,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false,
+            browserToolbarCustomized = true
+        )
+        val result = customized.withHideBrowserToolbar(true)
+
+        assertThat(result.hideBrowserToolbar).isTrue()
+        assertThat(result.browserToolbarCustomized).isTrue()
+        // Already-customized config is not wiped again.
+        assertThat(result.toolbarShowTitle).isTrue()
+        assertThat(result.toolbarShowUrl).isFalse()
+        assertThat(result.toolbarShowBack).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #458 — after toggling **Hide Toolbar** on and back off, a generated app's
browser toolbar showed **only the console button**; the title, URL, back, forward and
refresh buttons all disappeared.

The "Hide Toolbar" toggle zeroed every `toolbarShow*` flag on first enable and never
restored them on disable. The console button was also rendered unconditionally on both
the preview and export paths, so an otherwise-empty toolbar was left showing only the
terminal icon.

## What changed

| File | Change |
|------|--------|
| `data/model/ToolbarVisibility.kt` (new) | `resolveToolbarButtons()` — normal (non-hide) mode always shows the full button set; only the customized slim mode applies `toolbarShow*` filters |
| `viewmodel/EditState.kt` | `withHideBrowserToolbar()` — disabling the toggle restores the full flag set and clears the customized marker |
| `screens/CreateAppScreen.kt` | editor "Hide Toolbar" toggle uses the helper |
| `shell/ShellScaffoldLayout.kt` (export) | applies new semantics; console button conditionally rendered |
| `webview/WebViewActivity.kt` (preview) | same semantics as export; console button conditionally rendered |
| `test/.../ToolbarVisibilityTest.kt` (new) | 4 cases covering normal/slim/all-unchecked/not-customized |
| `test/.../HideBrowserToolbarToggleTest.kt` (new) | 3 cases covering first-enable/disable/re-enable |

## Why this approach

Rather than only patching the symptom (hide the console button), this fixes the three
layers underneath: the editor no longer leaves polluted config, the renderer shows the
full toolbar in normal mode (which also heals already-polluted saved apps without
migration), and the console button follows the same visibility rule as the other
buttons — consistently in both preview and export.

## Test plan

- `:app:compileDebugKotlin` ✅
- New unit tests (`ToolbarVisibilityTest`, `HideBrowserToolbarToggleTest`) — 7/7 pass ✅
- Export-link regression tests pass (`WebViewConfigBooleanCoverageTest`,
  `ApkConfigJsonFactoryTest`) ✅
- Rebuilt shell template (`:shell:assembleRelease` + `:app:syncShellTemplateApk`) ✅
- `check_config_field_drift` OK ✅

## Notes

- No i18n string changes, no new third-party dependencies.
- `webview_shell.apk` template is git-ignored; rebuilt locally (CI runs
  `skipShellTemplateSync=true`).