### PR TITLE
docs: sync docs with recent features + fix FCM wording in README_CN

### DIFF
--- a/.github/docs/README_CN.md
+++ b/.github/docs/README_CN.md
@@ -157,12 +157,13 @@ WebToApp 的开关非常多。下面按使用场景分组,并用可折叠区段�
 
 - **启动屏** —— 图片或视频,支持跳过、视频裁剪区间和固定方向。
 - **背景音乐** —— 播放列表 + LRC 同步歌词、歌词动画、自定义字体/颜色/描边/阴影和在线音乐搜索。
-- **工具栏、状态栏(亮色/暗色)、导航栏、悬浮窗模式和长按菜单样式。** 状态栏颜色可跟随主题、自定义色、全透明,或 **PAGE_TOP**(采样页面顶部像素,让系统栏跟内容同色)。
+- **工具栏、状态栏(亮色/暗色)、导航栏、悬浮窗模式和长按菜单样式。** 状态栏颜色可跟随主题、自定义色、全透明,或 **PAGE_TOP**(采样页面顶部像素,让系统栏跟内容同色)。运行时工具栏还提供 **页面缩放预设**(按应用保存,冷启动后保留)和 **控制台** 面板,便于在设备上调试。
 - **下载位置模式** —— 系统 Downloads、应用私有目录,或用户用 SAF 自选文件夹。
 - **公告模板**,可在启动、定时或无网络时触发。
 - **宿主应用语言** —— 整个打包器界面可在 10 种语言间切换(中文 / English / العربية / Português / Español / Français / Deutsch / Русский / 日本語 / 한국어);阿拉伯语完整 RTL。
 - **页内翻译覆盖层** —— 20 种目标语言,支持 Google、MyMemory、LibreTranslate、Lingva 引擎,并在引擎间自动故障转移(给*生成应用内容*做页内翻译,与宿主 UI 语言是两套能力)。
 - **打印桥接** —— 拦截 `window.print()` 和 blob/data-URL 的 PDF,交给 Android 打印框架 / 导出 PDF(onPageStarted 会再注入一次,避免晚导航丢 hook)。
+- **媒体会话桥接** —— 把网页媒体接入系统媒体通知和锁屏控制,支持蓝牙耳机和 Android Auto。
 - **通知** —— Web Notification polyfill、定时与持久化通知(含进度更新)、URL 轮询前台服务、深链、开机自启、定时启动和后台运行服务。
 - **每个 APK 的使用统计**、Vico 图表和 URL 健康监测。
 
@@ -281,7 +282,7 @@ App 会同时拉取 `registry.json` 和 `submissions.json`,只展示两边都存
 - `com.android.tools.build:apksig` 8.3.0 用于 APK 签名
 - BouncyCastle 1.78.1 用于加密与签名
 - `protobuf-javalite` 3.25.5 用于 AAB 元数据
-- Firebase Cloud Messaging(自带 Firebase 配置)用于推送通知
+- Firebase Cloud Messaging(需自行配置 Firebase)用于推送通知
 - GeckoView 作为可选浏览器引擎(原生库在首次使用时下载)
 - Coil 负责图片、视频、GIF 加载
 - Haze 用于毛玻璃 / 玻璃拟态 UI

--- a/README.md
+++ b/README.md
@@ -157,12 +157,13 @@ WebToApp has a large number of switches. The sections below group them by use ca
 
 - **Splash screens** — image or video, with skip behavior, trim ranges, and fixed orientation.
 - **Background music** — playlists with synced LRC lyrics, lyric animations, custom font/color/stroke/shadow, and online music search.
-- **Toolbar, status bar (light & dark), navigation, floating-window mode, and long-press menu styles.** Status bar color can follow theme, a custom color, full transparency, or **PAGE_TOP** (sample the page’s top pixels so the chrome matches the content).
+- **Toolbar, status bar (light & dark), navigation, floating-window mode, and long-press menu styles.** Status bar color can follow theme, a custom color, full transparency, or **PAGE_TOP** (sample the page’s top pixels so the chrome matches the content). The runtime toolbar also offers a per-app **page-zoom preset** (saved across cold starts) and a **console** panel for on-device debugging.
 - **Download location mode** — system Downloads, app-private directory, or a custom SAF folder picked by the user.
 - **Announcement templates** for launch, interval, and no-network moments.
 - **Host app language** — switch the entire builder UI among 10 languages (中文 / English / العربية / Português / Español / Français / Deutsch / Русский / 日本語 / 한국어); Arabic is full RTL.
 - **Translation overlay** — 20 target languages via Google, MyMemory, LibreTranslate, or Lingva engines, with automatic failover across them (in-page translate for the *content* of generated apps, separate from host UI language).
 - **Print bridge** — intercept `window.print()` and blob/data-URL PDFs to the Android print framework / PDF export (with an onPageStarted re-inject fallback so late navigations stay hooked).
+- **Media Session bridge** — surface web media on the system media notification and lock-screen controls, with Bluetooth and Android Auto support.
 - **Notifications** — Web Notification polyfill, scheduled and persistent notifications with progress, URL-polling foreground service, deep links, boot auto-start, scheduled launch, and background-run service.
 - **Per-app usage stats** with Vico charts and URL health monitoring.
 

--- a/docs/guide/app-actions/edit-common-config/hide-toolbar.md
+++ b/docs/guide/app-actions/edit-common-config/hide-toolbar.md
@@ -15,6 +15,13 @@ Controls the in-app browser toolbar (the bar with back/forward/refresh/title/URL
   - show forward (`toolbarShowForward`)
   - show refresh (`toolbarShowRefresh`)
 
+## Runtime toolbar controls
+
+These controls live in the toolbar at runtime (inside the generated APK or the host preview), not in the build-time config above:
+
+- **Page zoom** — a toolbar action opens a preset picker (50% / 67% / 75% / 80% / 90% / 100% / 110% / 125% / 150%, mirroring Chrome's stops). The chosen zoom is saved **per app** (by package name) and re-applied on cold start without a page reload. Separate from the build-time [Zoom](/guide/app-actions/edit-common-config/advanced-settings) toggle.
+- **Console** — a toolbar button opens a console panel showing `console.log` / error output. Useful for debugging the loaded page at runtime.
+
 ## Notes
 
 - For hiding the system status/navigation bars, see [Fullscreen Mode](/guide/app-actions/edit-common-config/fullscreen).

--- a/docs/guide/app-actions/edit-common-config/special-settings.md
+++ b/docs/guide/app-actions/edit-common-config/special-settings.md
@@ -12,6 +12,7 @@ Compatibility polyfills, bridges, and other specialized toggles. This card colle
 - **Compat polyfills** — a bundle of compatibility shims (`enableCompatPolyfills`).
 - **Native bridge** — expose a native bridge with capability gates (`enableNativeBridge`, `nativeBridgeCapabilities`).
 - **Print bridge** — intercept `window.print()` and PDF output to the Android print framework (`enablePrintBridge`).
+- **Media Session bridge** — bridge web media to the system media notification and lock-screen controls, including Bluetooth headsets and Android Auto (`enableMediaSession`).
 - **Share bridge** — `enableShareBridge`.
 - **Zoom polyfill** — `enableZoomPolyfill`.
 

--- a/docs/zh/guide/app-actions/edit-common-config/hide-toolbar.md
+++ b/docs/zh/guide/app-actions/edit-common-config/hide-toolbar.md
@@ -15,6 +15,13 @@
   - 显示前进(`toolbarShowForward`)
   - 显示刷新(`toolbarShowRefresh`)
 
+## 运行时工具栏控件
+
+以下控件位于运行时工具栏(在生成的 APK 或宿主预览内),而非上方的构建期配置:
+
+- **页面缩放** —— 工具栏动作打开预设选择器(50% / 67% / 75% / 80% / 90% / 100% / 110% / 125% / 150%,对齐 Chrome 的档位)。所选缩放**按应用**保存(以包名为键),冷启动后无需重载页面即可重新应用。与构建期的[缩放](/zh/guide/app-actions/edit-common-config/advanced-settings)开关是两回事。
+- **控制台** —— 工具栏按钮打开控制台面板,显示 `console.log` / 错误输出。便于在运行时调试已加载的页面。
+
 ## 说明
 
 - 隐藏系统状态栏/导航栏见[全屏模式](/zh/guide/app-actions/edit-common-config/fullscreen)。

--- a/docs/zh/guide/app-actions/edit-common-config/special-settings.md
+++ b/docs/zh/guide/app-actions/edit-common-config/special-settings.md
@@ -12,6 +12,7 @@
 - **兼容 polyfill** —— 一组兼容 shim(`enableCompatPolyfills`)。
 - **原生桥** —— 暴露带能力门控的原生桥(`enableNativeBridge`、`nativeBridgeCapabilities`)。
 - **打印桥** —— 拦截 `window.print()` 和 PDF 输出到 Android 打印框架(`enablePrintBridge`)。
+- **媒体会话桥** —— 把网页媒体接入系统媒体通知和锁屏控制,支持蓝牙耳机和 Android Auto(`enableMediaSession`)。
 - **分享桥** —— `enableShareBridge`。
 - **缩放 polyfill** —— `enableZoomPolyfill`。
 


### PR DESCRIPTION
Closes #463.

## Summary

Syncs the user-facing docs with three recently shipped features and fixes a Chinese/English contradiction in the README.

### 1. Fix FCM wording (README_CN)
`.github/docs/README_CN.md` translated "BYO Firebase config" as **"自带 Firebase 配置"** (built-in), contradicting the English README and the code (FCM fields are user-supplied). Fixed to **"需自行配置 Firebase"**.

### 2. Document Media Session bridge (#453)
`enableMediaSession` is a build-time flag that flows through the **full export chain** (`WebApp` → `ApkConfig.WebViewBehaviorBlock` → `ApkConfigJsonFactory` → `ShellModeManager` `@SerializedName("enableMediaSession")` → `MediaSessionBridge` in `ShellActivity`/`WebViewActivity`). Bridges web media to the system media notification + lock-screen controls (Bluetooth, Android Auto).

- Added to `special-settings.md` (EN + ZH) next to Print bridge, with the `enableMediaSession` field name.
- Added an App-experience bullet to `README.md` + `README_CN.md`.

### 3. Document runtime toolbar controls (#460, #454)
Added a **Runtime toolbar controls** section to `hide-toolbar.md` (EN + ZH) covering:
- **Page zoom preset** (#460) — toolbar action opens a 50–150% preset picker (mirrors Chrome); persisted **per app** by package name via `PageZoomStore`, re-applied on cold start without a reload. Explicitly noted as distinct from the build-time `zoomEnabled`/`initialScale` toggle in Advanced settings.
- **Console** (#454) — toolbar button opening a console panel for on-device debugging.

Mirrored as bullets in the README/README_CN App-experience toolbar entry.

## Verification
- `npm run build` (VitePress) passes locally — no broken links or markdown errors.
- All additions kept EN/ZH in parity (grep-verified across all 6 files).
- Docs-only change; no code, config, or export-pipeline impact.

## Files changed (6)
- `.github/docs/README_CN.md`
- `README.md`
- `docs/guide/app-actions/edit-common-config/special-settings.md`
- `docs/zh/guide/app-actions/edit-common-config/special-settings.md`
- `docs/guide/app-actions/edit-common-config/hide-toolbar.md`
- `docs/zh/guide/app-actions/edit-common-config/hide-toolbar.md`