### PR TITLE
chore: bump version to 2.4.0 (versionCode 51)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.3.5** (`versionCode 50`).
+This guide targets **WebToApp 2.4.0** (`versionCode 51`).
 
 ---
 
@@ -218,7 +218,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.3.5**（`versionCode 50`）。
+本指南对应 **WebToApp 2.4.0**（`versionCode 51`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 50
-        versionName = "2.3.5"
+        versionCode = 51
+        versionName = "2.4.0"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/modules/README.md
+++ b/modules/README.md
@@ -201,7 +201,7 @@ entry mirrors the module manifest plus a `path` (folder name) and a
 
 `minAppVersion` lets you ship a module that needs APIs only present from a
 specific WebToApp `versionCode` onwards — older clients hide the entry.
-The current `versionCode` is **50** (`v2.3.5`); set this only if you
+The current `versionCode` is **51** (`v2.4.0`); set this only if you
 genuinely depend on a newer build.
 
 `iconUrl` is optional. Either a relative path (`"icon.png"`, `"icon.svg"`,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 50
-        versionName = "2.3.5"
+        versionCode = 51
+        versionName = "2.4.0"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
Bumps the WebToApp version from **2.3.5** (`versionCode 50`) to **2.4.0** (`versionCode 51`).

## Changes
| File | Change |
|------|--------|
| `app/build.gradle.kts` | `versionCode 50 → 51`, `versionName "2.3.5" → "2.4.0"` |
| `shell/build.gradle.kts` | same (the two modules are kept in lockstep) |
| `.github/CONTRIBUTING.md` | EN + ZH header `WebToApp 2.3.5 (versionCode 50) → 2.4.0 (51)` |
| `modules/README.md` | `minAppVersion` reference `current versionCode 50 (v2.3.5) → 51 (v2.4.0)` |

## Notes
- `versionCode` follows the existing **monotonic +1** convention (verified against git history: 40→41→…→49→50).
- No hardcoded version references remain in code or tests — runtime code reads `BuildConfig.VERSION_CODE` / `BuildConfig.VERSION_NAME` dynamically (e.g. `ModuleMarketRepository`, `minAppVersion` filtering).
- `grep`-confirmed: zero stale `2.3.5` / `versionCode 50` references left.

## Verification
- `./gradlew :shell:compileReleaseKotlin :app:compileDebugKotlin` — BUILD SUCCESSFUL.