### PR TITLE
Fix: AAB resource validation for Google Play

### DIFF
--- a/app/src/main/java/com/webtoapp/core/playstore/aab/AabExporter.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/AabExporter.kt
@@ -75,6 +75,17 @@ class AabExporter(private val context: Context) {
             }
             onProgress?.invoke(Stage.SIGNED, 100)
 
+            // Validate the signed AAB to ensure all resources are present
+            // This prevents Google Play Console rejection due to missing resource files
+            val validationResult = AabValidationHelper.validateAab(outputAab)
+            if (!validationResult.isValid) {
+                throw AabExportException(
+                    failureStage = FailureStage.ASSEMBLE,
+                    message = "AAB validation failed: ${validationResult.issues.joinToString(", ")}",
+                    cause = null
+                )
+            }
+
             return Result(signedAab = outputAab, assembleStats = stats)
         } finally {
 

--- a/app/src/main/java/com/webtoapp/core/playstore/aab/AabValidationHelper.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/AabValidationHelper.kt
@@ -1,0 +1,107 @@
+package com.webtoapp.core.playstore.aab
+
+import com.android.aapt.Resources
+import com.google.protobuf.InvalidProtocolBufferException
+import com.webtoapp.core.logging.AppLogger
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * AAB validation helper to verify resource integrity before signing and uploading.
+ * This prevents Google Play Console rejection due to missing resource files.
+ */
+object AabValidationHelper {
+
+    private const val TAG = "AabValidationHelper"
+
+    /** Extract all file references from the proto table. */
+    private fun Resources.ResourceTable.fileReferences(): Set<String> {
+        val out = mutableSetOf<String>()
+        for (pkg in packageList) {
+            for (type in pkg.typeList) {
+                for (entry in type.entryList) {
+                    for (cv in entry.configValueList) {
+                        if (cv.value.item.hasFile()) {
+                            out.add(cv.value.item.file.path)
+                        }
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    /**
+     * Validate the AAB file for:
+     * 1. All resources referenced in resources.pb exist as actual files
+     * 2. No orphaned resource references
+     * 
+     * @return true if validation passes, false otherwise
+     */
+    fun validateAab(aabFile: File): ValidationResult {
+        AppLogger.d(TAG, "Validating AAB: ${aabFile.name}")
+
+        val issues = mutableListOf<String>()
+
+        try {
+            ZipFile(aabFile).use { zip ->
+                // Check if resources.pb exists
+                val resourcesPbEntry = zip.getEntry("base/resources.pb")
+                    ?: run {
+                        issues.add("Missing base/resources.pb (Android App Bundle format error)")
+                        return@validateAab ValidationResult(false, issues)
+                    }
+
+                // Parse resources.pb and get all referenced resource paths
+                val resourcesBytes = zip.getInputStream(resourcesPbEntry).readBytes()
+                
+                try {
+                    val protoTable = Resources.ResourceTable.parseFrom(resourcesBytes)
+                    
+                    // Collect all file references from the resource table
+                    val referencedResources = protoTable.fileReferences()
+                    AppLogger.d(TAG, "Found ${referencedResources.size} resource references in resources.pb")
+                    AppLogger.d(TAG, "All references validated against AAB contents")
+
+                    // Verify each referenced resource exists in the AAB
+                    for (resourcePath in referencedResources) {
+                        if (zip.getEntry("base/$resourcePath") == null &&
+                            zip.getEntry(resourcePath) == null &&
+                            zip.getEntry("res/$resourcePath") == null) {
+                            
+                            issues.add(
+                                "Referenced resource not found in AAB: $resourcePath\n" +
+                                    "This will cause bundletool to reject the bundle with:" +
+                                    "\"Resource table of module 'base' contains references to non-existing files\""
+                            )
+                        }
+                    }
+
+                } catch (e: InvalidProtocolBufferException) {
+                    issues.add("Failed to parse base/resources.pb: ${e.message}")
+                    AppLogger.e(TAG, "Invalid resources.pb", e)
+                }
+            }
+        } catch (e: Exception) {
+            issues.add("Validation error: ${e.message}")
+            AppLogger.e(TAG, "AAB validation failed", e)
+        }
+
+        if (issues.isNotEmpty()) {
+            AppLogger.w(
+                TAG,
+                "AAB validation failed with ${issues.size} issue(s):\n" +
+                    issues.joinToString("\n  - ") { "  - $it" }
+            )
+        } else {
+            AppLogger.d(TAG, "AAB validation passed successfully")
+        }
+
+        return ValidationResult(issues.isEmpty(), issues)
+    }
+}
+
+data class ValidationResult(
+    val isValid: Boolean,
+    val issues: List<String>
+)

--- a/app/src/main/java/com/webtoapp/core/playstore/aab/ApkToAabAssembler.kt
+++ b/app/src/main/java/com/webtoapp/core/playstore/aab/ApkToAabAssembler.kt
@@ -52,6 +52,7 @@ class ApkToAabAssembler {
 
         val abis = mutableSetOf<String>()
         val assetDirs = mutableSetOf<String>()
+        val missingResources = mutableSetOf<String>()
 
         ZipFile(sourceApk).use { zip ->
             ZipOutputStream(FileOutputStream(outputAab)).use { out ->
@@ -111,6 +112,21 @@ class ApkToAabAssembler {
                 val referencedResources = table.collectReferencedResourceFiles()
                 AppLogger.d(TAG, "Resource table references ${referencedResources.size} res/ paths")
 
+                // Validate resource integrity before processing: ensure all referenced resources
+                // (except plaintext XML) exist in the source APK. This prevents bundletool from
+                // rejecting the AAB with "resource table references non-existing files" errors.
+                for (resourcePath in referencedResources) {
+                    if (resourcePath in plaintextResFiles) continue
+                    if (!hasEntry(zip, resourcePath)) {
+                        missingResources.add(resourcePath)
+                        AppLogger.w(
+                            TAG,
+                            "Missing resource referenced in resources.arsc: $resourcePath."
+                                + " This may be a tools:keep marker file that should be excluded."
+                        )
+                    }
+                }
+
                 val entries = zip.entries().toList().sortedBy { it.name }
                 for (entry in entries) {
                     if (entry.isDirectory) continue
@@ -133,11 +149,6 @@ class ApkToAabAssembler {
                     when {
                         name.startsWith("res/") && name.endsWith(".xml") -> {
 
-                            if (name !in referencedResources) {
-                                AppLogger.d(TAG, "Skipping orphan res XML: $name")
-                                continue
-                            }
-
                             val xmlBytes = zip.getInputStream(entry).readBytes()
 
                             // Some res/*.xml entries are plain-text source XML, not compiled
@@ -151,6 +162,11 @@ class ApkToAabAssembler {
                             if (isPlaintextXml(xmlBytes)) {
                                 AppLogger.d(TAG, "Skipping plaintext res XML: $name")
                                 resourceXmlPlainTextSkipped++
+                                continue
+                            }
+
+                            if (name !in referencedResources) {
+                                AppLogger.d(TAG, "Skipping orphan res XML: $name")
                                 continue
                             }
 
@@ -241,6 +257,16 @@ class ApkToAabAssembler {
             assetDirCount = assetDirs.size
         )
         AppLogger.d(TAG, "Assembled AAB: $stats")
+        
+        if (missingResources.isNotEmpty()) {
+            AppLogger.w(
+                TAG,
+                "WARNING: ${missingResources.size} missing resource(s) detected in AAB."
+                    + " This may cause Google Play Console to reject the bundle."
+                    + " Missing files: ${missingResources.joinToString(", ")}"  
+            )
+        }
+        
         return stats
     }
 
@@ -265,6 +291,13 @@ class ApkToAabAssembler {
             input.copyTo(out)
         }
         out.closeEntry()
+    }
+
+    /** Check if the ZIP contains an entry with the given name. */
+    private fun hasEntry(zip: ZipFile, name: String): Boolean {
+        return zip.getEntry(name) != null ||
+            zip.getEntry("res/$name") != null ||
+            zip.getEntry("base/$name") != null
     }
 
     data class AssembleStats(


### PR DESCRIPTION
## Problem
AAB exports rejected by Google Play Console with "Resource table contains references to non-existing files"

## Fix
Added comprehensive resource integrity validation in AAB export pipeline:
1. Pre-scan APK for missing resources  
2. Post-assembly validation of resources.pb
3. Clear error messages before upload

## Testing
✅ BUILD SUCCESSFUL
✅ Tests pass