### PR TITLE
fix(i18n): retire resource fallback path, close 7-locale translation gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,9 @@ Mental model:
 ## i18n
 
 - Host UI strings live in `app/src/main/java/com/webtoapp/core/i18n/Strings.kt` (split across `Strings` / `StringsA` … `StringsE`).
-- Any new user-facing host string needs all 10 languages: Chinese, English, Arabic, Portuguese, Spanish, French, German, Russian, Japanese, Korean.
+- **All** user-visible strings must be inline `when (Strings.lang)` blocks covering all 10 languages: Chinese, English, Arabic, Portuguese, Spanish, French, German, Russian, Japanese, Korean. `when(lang)` blocks may never use `else ->` — `AppStringsResourceConsistencyTest` and `StringsKtTranslationParityTest` enforce this.
+- **Never** load user-visible text via `context.getString(R.string.*)` / `stringResource(R.string.*)`. `res/values*/` is only maintained for zh/en/ar; the other 7 locales have no `values-*/` directory, so resource lookups silently fall back to the default `values/` (Chinese). Use `Strings.xxx` (or `Strings.funName(arg)` for parameterised strings — see `linuxEnvInstalledToast(name)` for the pattern). A test gates this: `kotlin source never references R string for user-visible text`.
+- `R.string` is reserved for `translatable="false"` non-localised resources only (e.g. `app_name`).
 - Prefer adding properties on the existing split objects; match surrounding style.
 
 ## Android and packaging constraints

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1,10 +1,8 @@
 package com.webtoapp.core.i18n
 
 import android.content.Context
-import androidx.annotation.StringRes
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
-import com.webtoapp.R
 
 object Strings {
 
@@ -41,12 +39,6 @@ object Strings {
             appContext
         }
         contextVersion.intValue++
-    }
-
-    internal fun getString(@StringRes resId: Int, vararg formatArgs: Any): String {
-        contextVersion.intValue
-        val ctx = localizedContext ?: fallbackContext ?: return ""
-        return if (formatArgs.isNotEmpty()) ctx.getString(resId, *formatArgs) else ctx.getString(resId)
     }
 
     internal val lang: AppLanguage
@@ -307,6 +299,10 @@ object Strings {
     val msgNoApps: String get() = StringsA.msgNoApps
     val msgLanguageChanged: String get() = StringsA.msgLanguageChanged
     val msgImportSuccess: String get() = StringsA.msgImportSuccess
+    fun moduleImportSuccess(name: String): String = StringsA.moduleImportSuccess(name)
+    fun moduleImportFailed(message: String): String = StringsA.moduleImportFailed(message)
+    val languageSettings: String get() = StringsA.languageSettings
+    val sslError: String get() = StringsA.sslError
     val msgCopied: String get() = StringsA.msgCopied
     val menuRuntimeDeps: String get() = StringsA.menuRuntimeDeps
     val menuPortManager: String get() = StringsA.menuPortManager
@@ -4941,43 +4937,133 @@ object StringsA {
     }
 
     val myApps: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.title_my_apps)
+        AppLanguage.CHINESE -> "我的应用"
+        AppLanguage.ENGLISH -> "My Apps"
+        AppLanguage.ARABIC -> "تطبيقاتي"
+        AppLanguage.PORTUGUESE -> "Meus Aplicativos"
+        AppLanguage.SPANISH -> "Mis Aplicaciones"
+        AppLanguage.FRENCH -> "Mes Applications"
+        AppLanguage.GERMAN -> "Meine Apps"
+        AppLanguage.RUSSIAN -> "Мои приложения"
+        AppLanguage.JAPANESE -> "マイアプリ"
+        AppLanguage.KOREAN -> "내 앱"
     }
 
     val createApp: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.title_create_app)
+        AppLanguage.CHINESE -> "创建应用"
+        AppLanguage.ENGLISH -> "Create App"
+        AppLanguage.ARABIC -> "إنشاء تطبيق"
+        AppLanguage.PORTUGUESE -> "Criar Aplicativo"
+        AppLanguage.SPANISH -> "Crear Aplicación"
+        AppLanguage.FRENCH -> "Créer une Application"
+        AppLanguage.GERMAN -> "App erstellen"
+        AppLanguage.RUSSIAN -> "Создать приложение"
+        AppLanguage.JAPANESE -> "アプリ作成"
+        AppLanguage.KOREAN -> "앱 만들기"
     }
 
     val search: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.search_placeholder)
+        AppLanguage.CHINESE -> "搜索..."
+        AppLanguage.ENGLISH -> "Search..."
+        AppLanguage.ARABIC -> "بحث..."
+        AppLanguage.PORTUGUESE -> "Pesquisar..."
+        AppLanguage.SPANISH -> "Buscar..."
+        AppLanguage.FRENCH -> "Rechercher..."
+        AppLanguage.GERMAN -> "Suchen..."
+        AppLanguage.RUSSIAN -> "Поиск..."
+        AppLanguage.JAPANESE -> "検索..."
+        AppLanguage.KOREAN -> "검색..."
     }
 
     val more: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.menu_more)
+        AppLanguage.CHINESE -> "更多"
+        AppLanguage.ENGLISH -> "More"
+        AppLanguage.ARABIC -> "المزيد"
+        AppLanguage.PORTUGUESE -> "Mais"
+        AppLanguage.SPANISH -> "Más"
+        AppLanguage.FRENCH -> "Plus"
+        AppLanguage.GERMAN -> "Mehr"
+        AppLanguage.RUSSIAN -> "Ещё"
+        AppLanguage.JAPANESE -> "その他"
+        AppLanguage.KOREAN -> "더보기"
     }
 
     val back: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.webview_back)
+        AppLanguage.CHINESE -> "返回"
+        AppLanguage.ENGLISH -> "Back"
+        AppLanguage.ARABIC -> "رجوع"
+        AppLanguage.PORTUGUESE -> "Voltar"
+        AppLanguage.SPANISH -> "Atrás"
+        AppLanguage.FRENCH -> "Retour"
+        AppLanguage.GERMAN -> "Zurück"
+        AppLanguage.RUSSIAN -> "Назад"
+        AppLanguage.JAPANESE -> "戻る"
+        AppLanguage.KOREAN -> "뒤로"
     }
 
     val menuAgent: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.menu_agent)
+        AppLanguage.CHINESE -> "Agent"
+        AppLanguage.ENGLISH -> "Agent"
+        AppLanguage.ARABIC -> "Agent"
+        AppLanguage.PORTUGUESE -> "Agent"
+        AppLanguage.SPANISH -> "Agent"
+        AppLanguage.FRENCH -> "Agent"
+        AppLanguage.GERMAN -> "Agent"
+        AppLanguage.RUSSIAN -> "Agent"
+        AppLanguage.JAPANESE -> "Agent"
+        AppLanguage.KOREAN -> "Agent"
     }
 
     val menuAiSettings: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.menu_ai_settings)
+        AppLanguage.CHINESE -> "AI 设置"
+        AppLanguage.ENGLISH -> "AI Settings"
+        AppLanguage.ARABIC -> "إعدادات AI"
+        AppLanguage.PORTUGUESE -> "Configurações de IA"
+        AppLanguage.SPANISH -> "Ajustes de IA"
+        AppLanguage.FRENCH -> "Paramètres IA"
+        AppLanguage.GERMAN -> "KI-Einstellungen"
+        AppLanguage.RUSSIAN -> "Настройки ИИ"
+        AppLanguage.JAPANESE -> "AI設定"
+        AppLanguage.KOREAN -> "AI 설정"
     }
 
     val menuAppModifier: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.menu_app_modifier)
+        AppLanguage.CHINESE -> "应用修改器"
+        AppLanguage.ENGLISH -> "App Modifier"
+        AppLanguage.ARABIC -> "معدل التطبيق"
+        AppLanguage.PORTUGUESE -> "Modificador de Aplicativos"
+        AppLanguage.SPANISH -> "Modificador de Aplicaciones"
+        AppLanguage.FRENCH -> "Modificateur d'Applications"
+        AppLanguage.GERMAN -> "App-Modifikator"
+        AppLanguage.RUSSIAN -> "Модификатор приложений"
+        AppLanguage.JAPANESE -> "アプリ変更ツール"
+        AppLanguage.KOREAN -> "앱 수정기"
     }
 
     val menuExtensionModules: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.menu_extension_modules)
+        AppLanguage.CHINESE -> "扩展模块"
+        AppLanguage.ENGLISH -> "Extension Modules"
+        AppLanguage.ARABIC -> "الوحدات الإضافية"
+        AppLanguage.PORTUGUESE -> "Módulos de Extensão"
+        AppLanguage.SPANISH -> "Módulos de Extensión"
+        AppLanguage.FRENCH -> "Modules d'Extension"
+        AppLanguage.GERMAN -> "Erweiterungsmodule"
+        AppLanguage.RUSSIAN -> "Модули расширений"
+        AppLanguage.JAPANESE -> "拡張モジュール"
+        AppLanguage.KOREAN -> "확장 모듈"
     }
 
     val menuAbout: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.menu_about)
+        AppLanguage.CHINESE -> "关于"
+        AppLanguage.ENGLISH -> "About"
+        AppLanguage.ARABIC -> "حول"
+        AppLanguage.PORTUGUESE -> "Sobre"
+        AppLanguage.SPANISH -> "Acerca de"
+        AppLanguage.FRENCH -> "À propos"
+        AppLanguage.GERMAN -> "Über"
+        AppLanguage.RUSSIAN -> "О приложении"
+        AppLanguage.JAPANESE -> "について"
+        AppLanguage.KOREAN -> "정보"
     }
 
     val tabMore: String get() = when (Strings.lang) {
@@ -6749,47 +6835,146 @@ object StringsA {
     }
 
     val previewNotRunningBadge: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_not_running_badge)
+        AppLanguage.CHINESE -> "预览（未运行）"
+        AppLanguage.ENGLISH -> "Preview (not running)"
+        AppLanguage.ARABIC -> "معاينة (غير قيد التشغيل)"
+        AppLanguage.PORTUGUESE -> "Pré-visualização (não executando)"
+        AppLanguage.SPANISH -> "Vista previa (no ejecutándose)"
+        AppLanguage.FRENCH -> "Aperçu (non démarré)"
+        AppLanguage.GERMAN -> "Vorschau (wird nicht ausgeführt)"
+        AppLanguage.RUSSIAN -> "Предпросмотр (не запущен)"
+        AppLanguage.JAPANESE -> "プレビュー（未実行）"
+        AppLanguage.KOREAN -> "미리보기 (실행 중 아님)"
     }
 
     val previewNotRunningNote: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_not_running_note)
+        AppLanguage.CHINESE -> "这是未运行状态的预览，点击进入后会真正启动服务器并加载实际页面。"
+        AppLanguage.ENGLISH -> "This is a non-running preview. Opening the app starts the server and loads the real page."
+        AppLanguage.ARABIC -> "هذه معاينة في حالة عدم التشغيل. عند فتح التطبيق سيبدأ الخادم ويُحمّل الصفحة الفعلية."
+        AppLanguage.PORTUGUESE -> "Esta é uma pré-visualização sem execução. Abrir o app inicia o servidor e carrega a página real."
+        AppLanguage.SPANISH -> "Esta es una vista previa sin ejecución. Abrir la app inicia el servidor y carga la página real."
+        AppLanguage.FRENCH -> "Ceci est un aperçu non démarré. Ouvrir l'app démarre le serveur et charge la page réelle."
+        AppLanguage.GERMAN -> "Dies ist eine Vorschau ohne Ausführung. Beim Öffnen der App wird der Server gestartet und die echte Seite geladen."
+        AppLanguage.RUSSIAN -> "Это предпросмотр без запуска. При открытии приложения запускается сервер и загружается реальная страница."
+        AppLanguage.JAPANESE -> "これは非実行状態のプレビューです。アプリを開くとサーバーが起動し、実際のページが読み込まれます。"
+        AppLanguage.KOREAN -> "실행 중이 아닌 미리보기입니다. 앱을 열면 서버가 시작되고 실제 페이지가 로드됩니다."
     }
 
     val previewLabelTheme: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_theme)
+        AppLanguage.CHINESE -> "主题"
+        AppLanguage.ENGLISH -> "Theme"
+        AppLanguage.ARABIC -> "السمة"
+        AppLanguage.PORTUGUESE -> "Tema"
+        AppLanguage.SPANISH -> "Tema"
+        AppLanguage.FRENCH -> "Thème"
+        AppLanguage.GERMAN -> "Theme"
+        AppLanguage.RUSSIAN -> "Тема"
+        AppLanguage.JAPANESE -> "テーマ"
+        AppLanguage.KOREAN -> "테마"
     }
 
     val previewLabelPlugins: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_plugins)
+        AppLanguage.CHINESE -> "插件"
+        AppLanguage.ENGLISH -> "Plugins"
+        AppLanguage.ARABIC -> "الإضافات"
+        AppLanguage.PORTUGUESE -> "Plugins"
+        AppLanguage.SPANISH -> "Plugins"
+        AppLanguage.FRENCH -> "Plugins"
+        AppLanguage.GERMAN -> "Plugins"
+        AppLanguage.RUSSIAN -> "Плагины"
+        AppLanguage.JAPANESE -> "プラグイン"
+        AppLanguage.KOREAN -> "플러그인"
     }
 
     val previewLabelAdmin: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_admin)
+        AppLanguage.CHINESE -> "管理员"
+        AppLanguage.ENGLISH -> "Admin"
+        AppLanguage.ARABIC -> "المسؤول"
+        AppLanguage.PORTUGUESE -> "Administrador"
+        AppLanguage.SPANISH -> "Administrador"
+        AppLanguage.FRENCH -> "Admin"
+        AppLanguage.GERMAN -> "Admin"
+        AppLanguage.RUSSIAN -> "Админ"
+        AppLanguage.JAPANESE -> "管理者"
+        AppLanguage.KOREAN -> "관리자"
     }
 
     val previewLabelFramework: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_framework)
+        AppLanguage.CHINESE -> "框架"
+        AppLanguage.ENGLISH -> "Framework"
+        AppLanguage.ARABIC -> "الإطار"
+        AppLanguage.PORTUGUESE -> "Framework"
+        AppLanguage.SPANISH -> "Framework"
+        AppLanguage.FRENCH -> "Framework"
+        AppLanguage.GERMAN -> "Framework"
+        AppLanguage.RUSSIAN -> "Фреймворк"
+        AppLanguage.JAPANESE -> "フレームワーク"
+        AppLanguage.KOREAN -> "프레임워크"
     }
 
     val previewLabelEntry: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_entry)
+        AppLanguage.CHINESE -> "入口文件"
+        AppLanguage.ENGLISH -> "Entry"
+        AppLanguage.ARABIC -> "ملف الدخول"
+        AppLanguage.PORTUGUESE -> "Arquivo de Entrada"
+        AppLanguage.SPANISH -> "Archivo de Entrada"
+        AppLanguage.FRENCH -> "Fichier d'Entrée"
+        AppLanguage.GERMAN -> "Einstiegspunkt"
+        AppLanguage.RUSSIAN -> "Точка входа"
+        AppLanguage.JAPANESE -> "エントリファイル"
+        AppLanguage.KOREAN -> "진입 파일"
     }
 
     val previewLabelDocumentRoot: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_document_root)
+        AppLanguage.CHINESE -> "Web 根目录"
+        AppLanguage.ENGLISH -> "Document Root"
+        AppLanguage.ARABIC -> "جذر المستند"
+        AppLanguage.PORTUGUESE -> "Raiz do Documento"
+        AppLanguage.SPANISH -> "Raíz del Documento"
+        AppLanguage.FRENCH -> "Racine du Document"
+        AppLanguage.GERMAN -> "Document Root"
+        AppLanguage.RUSSIAN -> "Корневой каталог"
+        AppLanguage.JAPANESE -> "ドキュメントルート"
+        AppLanguage.KOREAN -> "문서 루트"
     }
 
     val previewLabelBinary: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_label_binary)
+        AppLanguage.CHINESE -> "二进制文件"
+        AppLanguage.ENGLISH -> "Binary"
+        AppLanguage.ARABIC -> "الملف الثنائي"
+        AppLanguage.PORTUGUESE -> "Binário"
+        AppLanguage.SPANISH -> "Binario"
+        AppLanguage.FRENCH -> "Binaire"
+        AppLanguage.GERMAN -> "Binärdatei"
+        AppLanguage.RUSSIAN -> "Бинарный файл"
+        AppLanguage.JAPANESE -> "バイナリファイル"
+        AppLanguage.KOREAN -> "바이너리 파일"
     }
 
     val previewValueDefault: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_value_default)
+        AppLanguage.CHINESE -> "默认"
+        AppLanguage.ENGLISH -> "Default"
+        AppLanguage.ARABIC -> "افتراضي"
+        AppLanguage.PORTUGUESE -> "Padrão"
+        AppLanguage.SPANISH -> "Predeterminado"
+        AppLanguage.FRENCH -> "Par défaut"
+        AppLanguage.GERMAN -> "Standard"
+        AppLanguage.RUSSIAN -> "По умолчанию"
+        AppLanguage.JAPANESE -> "デフォルト"
+        AppLanguage.KOREAN -> "기본값"
     }
 
     val previewValueUnknown: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_value_unknown)
+        AppLanguage.CHINESE -> "未知"
+        AppLanguage.ENGLISH -> "Unknown"
+        AppLanguage.ARABIC -> "غير معروف"
+        AppLanguage.PORTUGUESE -> "Desconhecido"
+        AppLanguage.SPANISH -> "Desconocido"
+        AppLanguage.FRENCH -> "Inconnu"
+        AppLanguage.GERMAN -> "Unbekannt"
+        AppLanguage.RUSSIAN -> "Неизвестно"
+        AppLanguage.JAPANESE -> "不明"
+        AppLanguage.KOREAN -> "알 수 없음"
     }
 
     val wpDownloadDeps: String get() = when (Strings.lang) {
@@ -8314,6 +8499,58 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Импорт выполнен"
         AppLanguage.JAPANESE -> "インポートに成功しました"
         AppLanguage.KOREAN -> "가져오기 성공"
+    }
+
+    fun moduleImportSuccess(name: String): String = when (Strings.lang) {
+        AppLanguage.CHINESE -> "模块 $name 导入成功"
+        AppLanguage.ENGLISH -> "Module $name imported successfully"
+        AppLanguage.ARABIC -> "تم استيراد الوحدة $name بنجاح"
+        AppLanguage.PORTUGUESE -> "Módulo $name importado com sucesso"
+        AppLanguage.SPANISH -> "Módulo $name importado con éxito"
+        AppLanguage.FRENCH -> "Module $name importé avec succès"
+        AppLanguage.GERMAN -> "Modul $name erfolgreich importiert"
+        AppLanguage.RUSSIAN -> "Модуль $name успешно импортирован"
+        AppLanguage.JAPANESE -> "モジュール $name のインポートに成功しました"
+        AppLanguage.KOREAN -> "모듈 $name 가져오기 성공"
+    }
+
+    fun moduleImportFailed(message: String): String = when (Strings.lang) {
+        AppLanguage.CHINESE -> "模块导入失败: $message"
+        AppLanguage.ENGLISH -> "Module import failed: $message"
+        AppLanguage.ARABIC -> "فشل استيراد الوحدة: $message"
+        AppLanguage.PORTUGUESE -> "Falha ao importar o módulo: $message"
+        AppLanguage.SPANISH -> "Error al importar el módulo: $message"
+        AppLanguage.FRENCH -> "Échec de l'importation du module : $message"
+        AppLanguage.GERMAN -> "Modulimport fehlgeschlagen: $message"
+        AppLanguage.RUSSIAN -> "Ошибка импорта модуля: $message"
+        AppLanguage.JAPANESE -> "モジュールのインポートに失敗: $message"
+        AppLanguage.KOREAN -> "모듈 가져오기 실패: $message"
+    }
+
+    val languageSettings: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "语言"
+        AppLanguage.ENGLISH -> "Language"
+        AppLanguage.ARABIC -> "اللغة"
+        AppLanguage.PORTUGUESE -> "Idioma"
+        AppLanguage.SPANISH -> "Idioma"
+        AppLanguage.FRENCH -> "Langue"
+        AppLanguage.GERMAN -> "Sprache"
+        AppLanguage.RUSSIAN -> "Язык"
+        AppLanguage.JAPANESE -> "言語"
+        AppLanguage.KOREAN -> "언어"
+    }
+
+    val sslError: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "SSL 安全错误"
+        AppLanguage.ENGLISH -> "SSL Security Error"
+        AppLanguage.ARABIC -> "خطأ أمان SSL"
+        AppLanguage.PORTUGUESE -> "Erro de segurança SSL"
+        AppLanguage.SPANISH -> "Error de seguridad SSL"
+        AppLanguage.FRENCH -> "Erreur de sécurité SSL"
+        AppLanguage.GERMAN -> "SSL-Sicherheitsfehler"
+        AppLanguage.RUSSIAN -> "Ошибка безопасности SSL"
+        AppLanguage.JAPANESE -> "SSLセキュリティエラー"
+        AppLanguage.KOREAN -> "SSL 보안 오류"
     }
 
     val msgCopied: String get() = when (Strings.lang) {
@@ -62929,121 +63166,263 @@ object StringsE {
         AppLanguage.KOREAN -> "웹 미디어를 시스템 알림 및 잠금 화면 컨트롤에 연결 (Bluetooth, Android Auto)"
     }
     val previewBackendAppIntro: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_backend_app_intro)
+        AppLanguage.CHINESE -> "此项目是 %s 后端应用。"
+        AppLanguage.ENGLISH -> "This project is a %s backend app."
+        AppLanguage.ARABIC -> "هذا المشروع تطبيق خلفي بإطار %s."
+        AppLanguage.PORTUGUESE -> "Este projeto é um app backend %s."
+        AppLanguage.SPANISH -> "Este proyecto es una app backend %s."
+        AppLanguage.FRENCH -> "Ce projet est une app backend %s."
+        AppLanguage.GERMAN -> "Dieses Projekt ist eine %s-Backend-App."
+        AppLanguage.RUSSIAN -> "Этот проект — серверное приложение %s."
+        AppLanguage.JAPANESE -> "このプロジェクトは %s バックエンドアプリです。"
+        AppLanguage.KOREAN -> "이 프로젝트는 %s 백엔드 앱입니다."
     }
-
-
 
     val previewEntryNotFound: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_entry_not_found)
+        AppLanguage.CHINESE -> "未找到入口文件"
+        AppLanguage.ENGLISH -> "Entry file not found"
+        AppLanguage.ARABIC -> "لم يُعثر على ملف الدخول"
+        AppLanguage.PORTUGUESE -> "Arquivo de entrada não encontrado"
+        AppLanguage.SPANISH -> "Archivo de entrada no encontrado"
+        AppLanguage.FRENCH -> "Fichier d'entrée introuvable"
+        AppLanguage.GERMAN -> "Einstiegsdatei nicht gefunden"
+        AppLanguage.RUSSIAN -> "Точка входа не найдена"
+        AppLanguage.JAPANESE -> "エントリファイルが見つかりません"
+        AppLanguage.KOREAN -> "진입 파일을 찾을 수 없습니다"
     }
-
-
 
     val previewFileNotFound: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_file_not_found)
+        AppLanguage.CHINESE -> "文件不存在：%s"
+        AppLanguage.ENGLISH -> "File not found: %s"
+        AppLanguage.ARABIC -> "الملف غير موجود: %s"
+        AppLanguage.PORTUGUESE -> "Arquivo não encontrado: %s"
+        AppLanguage.SPANISH -> "Archivo no encontrado: %s"
+        AppLanguage.FRENCH -> "Fichier introuvable : %s"
+        AppLanguage.GERMAN -> "Datei nicht gefunden: %s"
+        AppLanguage.RUSSIAN -> "Файл не найден: %s"
+        AppLanguage.JAPANESE -> "ファイルが見つかりません: %s"
+        AppLanguage.KOREAN -> "파일을 찾을 수 없습니다: %s"
     }
-
-
 
     val previewFileUnreadable: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_file_unreadable)
+        AppLanguage.CHINESE -> "无法读取文件内容"
+        AppLanguage.ENGLISH -> "Unable to read file contents"
+        AppLanguage.ARABIC -> "تعذّرت قراءة محتوى الملف"
+        AppLanguage.PORTUGUESE -> "Não foi possível ler o conteúdo do arquivo"
+        AppLanguage.SPANISH -> "No se pudo leer el contenido del archivo"
+        AppLanguage.FRENCH -> "Impossible de lire le contenu du fichier"
+        AppLanguage.GERMAN -> "Dateiinhalt konnte nicht gelesen werden"
+        AppLanguage.RUSSIAN -> "Не удалось прочитать содержимое файла"
+        AppLanguage.JAPANESE -> "ファイルの内容を読み取れません"
+        AppLanguage.KOREAN -> "파일 내용을 읽을 수 없습니다"
     }
-
-
 
     val previewGoBinaryMissingBadge: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_go_binary_missing)
+        AppLanguage.CHINESE -> "缺少预编译二进制"
+        AppLanguage.ENGLISH -> "Missing precompiled binary"
+        AppLanguage.ARABIC -> "ملف ثنائي مُترجَم مفقود"
+        AppLanguage.PORTUGUESE -> "Binário pré-compilado ausente"
+        AppLanguage.SPANISH -> "Binario precompilado faltante"
+        AppLanguage.FRENCH -> "Binaire précompilé manquant"
+        AppLanguage.GERMAN -> "Vorkompilierte Binärdatei fehlt"
+        AppLanguage.RUSSIAN -> "Отсутствует предкомпилированный бинарный файл"
+        AppLanguage.JAPANESE -> "プリコンパイル済みバイナリがありません"
+        AppLanguage.KOREAN -> "미리 컴파일된 바이너리 없음"
     }
-
-
 
     val previewGoBinaryReadyBadge: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_go_binary_ready)
+        AppLanguage.CHINESE -> "可运行二进制已就绪：%s"
+        AppLanguage.ENGLISH -> "Runnable binary ready: %s"
+        AppLanguage.ARABIC -> "الملف الثنائي القابل للتشغيل جاهز: %s"
+        AppLanguage.PORTUGUESE -> "Binário executável pronto: %s"
+        AppLanguage.SPANISH -> "Binario ejecutable listo: %s"
+        AppLanguage.FRENCH -> "Binaire exécutable prêt : %s"
+        AppLanguage.GERMAN -> "Ausführbare Binärdatei bereit: %s"
+        AppLanguage.RUSSIAN -> "Исполняемый бинарный файл готов: %s"
+        AppLanguage.JAPANESE -> "実行可能バイナリの準備完了: %s"
+        AppLanguage.KOREAN -> "실행 가능한 바이너리 준비됨: %s"
     }
-
-
 
     val previewGoNoGoMod: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_go_no_gomod)
+        AppLanguage.CHINESE -> "无 go.mod"
+        AppLanguage.ENGLISH -> "No go.mod"
+        AppLanguage.ARABIC -> "لا يوجد go.mod"
+        AppLanguage.PORTUGUESE -> "Sem go.mod"
+        AppLanguage.SPANISH -> "Sin go.mod"
+        AppLanguage.FRENCH -> "Pas de go.mod"
+        AppLanguage.GERMAN -> "Kein go.mod"
+        AppLanguage.RUSSIAN -> "Нет go.mod"
+        AppLanguage.JAPANESE -> "go.mod がありません"
+        AppLanguage.KOREAN -> "go.mod 없음"
     }
-
-
 
     val previewGoTipNotReady: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_go_tip_not_ready)
+        AppLanguage.CHINESE -> "当前 GO_APP 仅支持运行预编译二进制。请先为目标 ABI 构建可执行文件。"
+        AppLanguage.ENGLISH -> "GO_APP currently only runs precompiled binaries. Build an executable for the target ABI first."
+        AppLanguage.ARABIC -> "يشغّل GO_APP حاليًا الملفات الثنائية المُترجَمة مسبقًا فقط. ابنِ ملفًا تنفيذيًا لمعمارية الـ ABI المستهدفة أولاً."
+        AppLanguage.PORTUGUESE -> "O GO_APP atualmente executa apenas binários pré-compilados. Compile um executável para a ABI de destino primeiro."
+        AppLanguage.SPANISH -> "GO_APP actualmente solo ejecuta binarios precompilados. Compila un ejecutable para la ABI de destino primero."
+        AppLanguage.FRENCH -> "GO_APP n'exécute actuellement que les binaires précompilés. Compilez d'abord un exécutable pour l'ABI cible."
+        AppLanguage.GERMAN -> "GO_APP führt derzeit nur vorkompilierte Binärdateien aus. Kompilieren Sie zuerst eine ausführbare Datei für die Ziel-ABI."
+        AppLanguage.RUSSIAN -> "GO_APP сейчас запускает только предкомпилированные бинарные файлы. Сначала соберите исполняемый файл для целевого ABI."
+        AppLanguage.JAPANESE -> "GO_APPは現在プリコンパイル済みバイナリのみ実行できます。対象ABI用の実行ファイルを先にビルドしてください。"
+        AppLanguage.KOREAN -> "GO_APP은 현재 미리 컴파일된 바이너리만 실행할 수 있습니다. 대상 ABI용 실행 파일을 먼저 빌드하세요."
     }
-
-
 
     val previewGoTipReady: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_go_tip_ready)
+        AppLanguage.CHINESE -> "已检测到可运行二进制（%s），可直接启动服务器。"
+        AppLanguage.ENGLISH -> "A runnable binary was detected (%s); the server can start directly."
+        AppLanguage.ARABIC -> "تم اكتشاف ملف ثنائي قابل للتشغيل (%s)؛ يمكن تشغيل الخادم مباشرة."
+        AppLanguage.PORTUGUESE -> "Um binário executável foi detectado (%s); o servidor pode iniciar diretamente."
+        AppLanguage.SPANISH -> "Se detectó un binario ejecutable (%s); el servidor puede iniciar directamente."
+        AppLanguage.FRENCH -> "Un binaire exécutable a été détecté (%s) ; le serveur peut démarrer directement."
+        AppLanguage.GERMAN -> "Eine ausführbare Binärdatei wurde erkannt (%s); der Server kann direkt starten."
+        AppLanguage.RUSSIAN -> "Обнаружен исполняемый бинарный файл (%s); сервер можно запустить напрямую."
+        AppLanguage.JAPANESE -> "実行可能バイナリ（%s）を検出しました。サーバーを直接起動できます。"
+        AppLanguage.KOREAN -> "실행 가능한 바이너리(%s)가 감지되었습니다. 서버를 바로 시작할 수 있습니다."
     }
-
-
 
     val previewNodeNeedRuntime: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_node_need_runtime)
+        AppLanguage.CHINESE -> "需要下载 Node.js 运行时"
+        AppLanguage.ENGLISH -> "Node.js runtime required"
+        AppLanguage.ARABIC -> "مطلوب وقت تشغيل Node.js"
+        AppLanguage.PORTUGUESE -> "Runtime do Node.js necessário"
+        AppLanguage.SPANISH -> "Se requiere el runtime de Node.js"
+        AppLanguage.FRENCH -> "Runtime Node.js requis"
+        AppLanguage.GERMAN -> "Node.js-Runtime erforderlich"
+        AppLanguage.RUSSIAN -> "Требуется среда выполнения Node.js"
+        AppLanguage.JAPANESE -> "Node.jsランタイムが必要です"
+        AppLanguage.KOREAN -> "Node.js 런타임 필요"
     }
-
-
 
     val previewNodeTipNotReady: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_node_tip_not_ready)
+        AppLanguage.CHINESE -> "这是一个 %s 后端应用。当前在预览模式（仅显示源码）。请到「运行时管理」下载 Node.js 运行时后再回来即可正常运行。"
+        AppLanguage.ENGLISH -> "This is a %s backend app, currently in preview mode (source only). Download the Node.js runtime in Runtime Management, then come back to run it."
+        AppLanguage.ARABIC -> "هذا تطبيق خلفي بإطار %s، وهو حاليًا في وضع المعاينة (الكود المصدري فقط). نزّل وقت تشغيل Node.js من إدارة أوقات التشغيل ثم عُد لتشغيله."
+        AppLanguage.PORTUGUESE -> "Este é um app backend %s, atualmente em modo de pré-visualização (somente código-fonte). Baixe o runtime do Node.js em Gerenciamento de Runtime e volte para executá-lo."
+        AppLanguage.SPANISH -> "Esta es una app backend %s, actualmente en modo vista previa (solo código fuente). Descarga el runtime de Node.js en Gestión de Runtimes y vuelve para ejecutarla."
+        AppLanguage.FRENCH -> "Ceci est une app backend %s, actuellement en mode aperçu (code source uniquement). Téléchargez le runtime Node.js dans Gestion des runtimes, puis revenez pour l'exécuter."
+        AppLanguage.GERMAN -> "Dies ist eine %s-Backend-App, derzeit im Vorschaumodus (nur Quellcode). Laden Sie die Node.js-Runtime in der Runtime-Verwaltung herunter und kehren Sie zurück, um sie auszuführen."
+        AppLanguage.RUSSIAN -> "Это серверное приложение %s, сейчас в режиме предпросмотра (только исходный код). Скачайте среду выполнения Node.js в «Управлении средами выполнения» и вернитесь для запуска."
+        AppLanguage.JAPANESE -> "これは %s バックエンドアプリで、現在プレビューモード（ソースのみ）です。ランタイム管理で Node.js ランタイムをダウンロードしてから戻ると実行できます。"
+        AppLanguage.KOREAN -> "%s 백엔드 앱이며 현재 미리보기 모드(소스만)입니다. 런타임 관리에서 Node.js 런타임을 다운로드한 뒤 다시 돌아와 실행하세요."
     }
-
-
 
     val previewNodeTipReady: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_node_tip_ready)
+        AppLanguage.CHINESE -> "Node.js 运行时已就绪，但本次启动 server 失败 / 未配置入口。检查 entryFile 是否存在、package.json 的 dependencies 是否需要先 npm install。"
+        AppLanguage.ENGLISH -> "Node.js runtime is ready, but the server failed to start or no entry is configured. Check that entryFile exists and whether package.json dependencies need npm install first."
+        AppLanguage.ARABIC -> "وقت تشغيل Node.js جاهز، لكن فشل تشغيل الخادم أو لم يُضبط ملف الدخول. تحقق من وجود entryFile وما إذا كانت تبعيات package.json تحتاج إلى npm install أولاً."
+        AppLanguage.PORTUGUESE -> "O runtime do Node.js está pronto, mas o servidor falhou ao iniciar ou nenhum entry foi configurado. Verifique se o entryFile existe e se as dependências do package.json precisam de npm install primeiro."
+        AppLanguage.SPANISH -> "El runtime de Node.js está listo, pero el servidor falló al iniciar o no se configuró un entry. Verifica si entryFile existe y si las dependencias de package.json necesitan npm install primero."
+        AppLanguage.FRENCH -> "Le runtime Node.js est prêt, mais le serveur n'a pas démarré ou aucune entrée n'est configurée. Vérifiez que entryFile existe et si les dépendances de package.json nécessitent d'abord npm install."
+        AppLanguage.GERMAN -> "Die Node.js-Runtime ist bereit, aber der Server startete nicht oder es ist kein Einstieg konfiguriert. Prüfen Sie, ob entryFile existiert und ob die package.json-Abhängigkeiten zunächst npm install benötigen."
+        AppLanguage.RUSSIAN -> "Среда выполнения Node.js готова, но сервер не запустился или точка входа не настроена. Проверьте существование entryFile и не нужен ли сначала npm install для зависимостей package.json."
+        AppLanguage.JAPANESE -> "Node.jsランタイムの準備は完了していますが、サーバー起動に失敗したかエントリが未設定です。entryFile の存在や、package.json の dependencies に先に npm install が必要か確認してください。"
+        AppLanguage.KOREAN -> "Node.js 런타임이 준비되었지만 서버 시작에 실패했거나 진입점이 설정되지 않았습니다. entryFile이 있는지, package.json의 dependencies에 먼저 npm install이 필요한지 확인하세요."
     }
-
-
 
     val previewProjectFilesLabel: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_files_label)
+        AppLanguage.CHINESE -> "项目文件"
+        AppLanguage.ENGLISH -> "Project Files"
+        AppLanguage.ARABIC -> "ملفات المشروع"
+        AppLanguage.PORTUGUESE -> "Arquivos do Projeto"
+        AppLanguage.SPANISH -> "Archivos del Proyecto"
+        AppLanguage.FRENCH -> "Fichiers du Projet"
+        AppLanguage.GERMAN -> "Projektdateien"
+        AppLanguage.RUSSIAN -> "Файлы проекта"
+        AppLanguage.JAPANESE -> "プロジェクトファイル"
+        AppLanguage.KOREAN -> "프로젝트 파일"
     }
-
-
 
     val previewProjectSuffix: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_suffix)
+        AppLanguage.CHINESE -> "项目预览"
+        AppLanguage.ENGLISH -> "Project Preview"
+        AppLanguage.ARABIC -> "معاينة المشروع"
+        AppLanguage.PORTUGUESE -> "Pré-visualização do Projeto"
+        AppLanguage.SPANISH -> "Vista Previa del Proyecto"
+        AppLanguage.FRENCH -> "Aperçu du Projet"
+        AppLanguage.GERMAN -> "Projektvorschau"
+        AppLanguage.RUSSIAN -> "Предпросмотр проекта"
+        AppLanguage.JAPANESE -> "プロジェクトプレビュー"
+        AppLanguage.KOREAN -> "프로젝트 미리보기"
     }
-
-
 
     val previewPythonNeedRuntime: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_python_need_runtime)
+        AppLanguage.CHINESE -> "需要下载 Python 运行时"
+        AppLanguage.ENGLISH -> "Python runtime required"
+        AppLanguage.ARABIC -> "مطلوب وقت تشغيل Python"
+        AppLanguage.PORTUGUESE -> "Runtime do Python necessário"
+        AppLanguage.SPANISH -> "Se requiere el runtime de Python"
+        AppLanguage.FRENCH -> "Runtime Python requis"
+        AppLanguage.GERMAN -> "Python-Runtime erforderlich"
+        AppLanguage.RUSSIAN -> "Требуется среда выполнения Python"
+        AppLanguage.JAPANESE -> "Pythonランタイムが必要です"
+        AppLanguage.KOREAN -> "Python 런타임 필요"
     }
-
-
 
     val previewPythonTipNotReady: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_python_tip_not_ready)
+        AppLanguage.CHINESE -> "需要先下载 Python 运行时才能运行。"
+        AppLanguage.ENGLISH -> "Download the Python runtime first to run it."
+        AppLanguage.ARABIC -> "نزّل وقت تشغيل Python أولاً لتتمكن من تشغيله."
+        AppLanguage.PORTUGUESE -> "Baixe o runtime do Python primeiro para executá-lo."
+        AppLanguage.SPANISH -> "Descarga el runtime de Python primero para ejecutarlo."
+        AppLanguage.FRENCH -> "Téléchargez d'abord le runtime Python pour l'exécuter."
+        AppLanguage.GERMAN -> "Laden Sie zuerst die Python-Runtime herunter, um sie auszuführen."
+        AppLanguage.RUSSIAN -> "Сначала скачайте среду выполнения Python, чтобы запустить."
+        AppLanguage.JAPANESE -> "実行するには先に Python ランタイムをダウンロードしてください。"
+        AppLanguage.KOREAN -> "실행하려면 먼저 Python 런타임을 다운로드하세요."
     }
-
-
 
     val previewPythonTipReady: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_python_tip_ready)
+        AppLanguage.CHINESE -> "Python 运行时已就绪，可直接启动服务器。"
+        AppLanguage.ENGLISH -> "Python runtime is ready; the server can start directly."
+        AppLanguage.ARABIC -> "وقت تشغيل Python جاهز؛ يمكن تشغيل الخادم مباشرة."
+        AppLanguage.PORTUGUESE -> "O runtime do Python está pronto; o servidor pode iniciar diretamente."
+        AppLanguage.SPANISH -> "El runtime de Python está listo; el servidor puede iniciar directamente."
+        AppLanguage.FRENCH -> "Le runtime Python est prêt ; le serveur peut démarrer directement."
+        AppLanguage.GERMAN -> "Die Python-Runtime ist bereit; der Server kann direkt starten."
+        AppLanguage.RUSSIAN -> "Среда выполнения Python готова; сервер можно запустить напрямую."
+        AppLanguage.JAPANESE -> "Pythonランタイムの準備が完了しました。サーバーを直接起動できます。"
+        AppLanguage.KOREAN -> "Python 런타임이 준비되었습니다. 서버를 바로 시작할 수 있습니다."
     }
-
-
 
     val previewRuntimeReadyBadge: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_runtime_ready)
+        AppLanguage.CHINESE -> "运行时就绪"
+        AppLanguage.ENGLISH -> "Runtime Ready"
+        AppLanguage.ARABIC -> "وقت التشغيل جاهز"
+        AppLanguage.PORTUGUESE -> "Runtime Pronto"
+        AppLanguage.SPANISH -> "Runtime Listo"
+        AppLanguage.FRENCH -> "Runtime Prêt"
+        AppLanguage.GERMAN -> "Runtime Bereit"
+        AppLanguage.RUSSIAN -> "Среда выполнения готова"
+        AppLanguage.JAPANESE -> "ランタイム準備完了"
+        AppLanguage.KOREAN -> "런타임 준비됨"
     }
-
-
 
     val previewServerStartFailedTitle: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_server_start_failed_title)
+        AppLanguage.CHINESE -> "服务器启动失败 — 详细错误"
+        AppLanguage.ENGLISH -> "Server startup failed — details"
+        AppLanguage.ARABIC -> "فشل تشغيل الخادم — التفاصيل"
+        AppLanguage.PORTUGUESE -> "Falha ao iniciar o servidor — detalhes"
+        AppLanguage.SPANISH -> "Error al iniciar el servidor — detalles"
+        AppLanguage.FRENCH -> "Échec du démarrage du serveur — détails"
+        AppLanguage.GERMAN -> "Serverstart fehlgeschlagen — Details"
+        AppLanguage.RUSSIAN -> "Не удалось запустить сервер — подробности"
+        AppLanguage.JAPANESE -> "サーバー起動失敗 — 詳細"
+        AppLanguage.KOREAN -> "서버 시작 실패 — 상세 정보"
     }
 
-
-
     val previewStartupFailedBadge: String get() = when (Strings.lang) {
-        else -> Strings.getString(R.string.appstr_project_preview_startup_failed)
+        AppLanguage.CHINESE -> "启动失败"
+        AppLanguage.ENGLISH -> "Startup Failed"
+        AppLanguage.ARABIC -> "فشل بدء التشغيل"
+        AppLanguage.PORTUGUESE -> "Falha na Inicialização"
+        AppLanguage.SPANISH -> "Error de Inicio"
+        AppLanguage.FRENCH -> "Échec du Démarrage"
+        AppLanguage.GERMAN -> "Start fehlgeschlagen"
+        AppLanguage.RUSSIAN -> "Ошибка запуска"
+        AppLanguage.JAPANESE -> "起動失敗"
+        AppLanguage.KOREAN -> "시작 실패"
     }
 
 

--- a/app/src/main/java/com/webtoapp/ui/components/LanguageSelector.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/LanguageSelector.kt
@@ -19,13 +19,12 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.webtoapp.R
 import com.webtoapp.core.i18n.AppLanguage
 import com.webtoapp.core.i18n.LanguageManager
+import com.webtoapp.core.i18n.Strings
 import com.webtoapp.util.isRunningOnTv
 import kotlinx.coroutines.launch
 
@@ -78,7 +77,7 @@ fun LanguageSelectorButton(
     ) {
         Icon(
             imageVector = Icons.Outlined.Language,
-            contentDescription = stringResource(R.string.language_settings),
+            contentDescription = Strings.languageSettings,
             modifier = Modifier.size(22.dp),
             tint = MaterialTheme.colorScheme.onSurface
         )
@@ -112,7 +111,7 @@ fun LanguageSelectionDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
-                text = stringResource(R.string.language_settings),
+                text = Strings.languageSettings,
                 style = MaterialTheme.typography.titleLarge
             )
         },
@@ -135,7 +134,7 @@ fun LanguageSelectionDialog(
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.btn_cancel))
+                Text(Strings.btnCancel)
             }
         }
     )
@@ -482,7 +481,7 @@ fun LanguageSettingsCard(
                         tint = MaterialTheme.colorScheme.primary
                     )
                     Text(
-                        text = stringResource(R.string.language_settings),
+                        text = Strings.languageSettings,
                         style = MaterialTheme.typography.titleMedium
                     )
                 }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateNodeJsAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateNodeJsAppScreen.kt
@@ -161,7 +161,7 @@ fun CreateNodeJsAppScreen(
                         val projectDir = runtime.createProjectFromUri(newProjectId, treeUri)
 
                         if (!File(projectDir, "package.json").exists()) {
-                            errorMessage = context.getString(com.webtoapp.R.string.njs_package_json_not_found)
+                            errorMessage = Strings.importPackageJsonNotFound
                             projectDir.deleteRecursively()
                             isCreating = false
                             return@withContext

--- a/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ExtensionModuleScreen.kt
@@ -67,7 +67,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Spring
-import com.webtoapp.R
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -108,13 +107,13 @@ fun ExtensionModuleScreen(
                     context.contentResolver.openInputStream(it)?.use { stream ->
                         val result = extensionManager.importModule(stream)
                         result.onSuccess { module ->
-                            Toast.makeText(context, context.getString(R.string.msg_import_success, module.name), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, Strings.moduleImportSuccess(module.name), Toast.LENGTH_SHORT).show()
                         }.onFailure { e ->
-                            Toast.makeText(context, context.getString(R.string.msg_import_failed, e.message ?: context.getString(R.string.unknown_error)), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, Strings.moduleImportFailed(e.message ?: Strings.unknownError), Toast.LENGTH_SHORT).show()
                         }
                     }
                 } catch (e: Exception) {
-                    Toast.makeText(context, context.getString(R.string.msg_import_failed, e.message ?: context.getString(R.string.unknown_error)), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, Strings.moduleImportFailed(e.message ?: Strings.unknownError), Toast.LENGTH_SHORT).show()
                 } finally {
                     isImporting = false
                 }
@@ -133,7 +132,7 @@ fun ExtensionModuleScreen(
                         showUserScriptPreview = result.parseResult
                     }
                     is ExtensionFileManager.ImportResult.Error -> {
-                        Toast.makeText(context, context.getString(R.string.msg_import_failed, result.message), Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, Strings.moduleImportFailed(result.message), Toast.LENGTH_SHORT).show()
                     }
                     else -> {}
                 }
@@ -160,7 +159,7 @@ fun ExtensionModuleScreen(
                         showJsPackagePreview = result
                     }
                     is ExtensionFileManager.ImportResult.Error -> {
-                        Toast.makeText(context, context.getString(R.string.msg_import_failed, result.message), Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, Strings.moduleImportFailed(result.message), Toast.LENGTH_SHORT).show()
                     }
                     else -> {}
                 }
@@ -181,7 +180,7 @@ fun ExtensionModuleScreen(
                         showJsPackagePreview = result
                     }
                     is ExtensionFileManager.ImportResult.Error -> {
-                        Toast.makeText(context, context.getString(R.string.msg_import_failed, result.message), Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, Strings.moduleImportFailed(result.message), Toast.LENGTH_SHORT).show()
                     }
                     else -> {}
                 }
@@ -201,9 +200,9 @@ fun ExtensionModuleScreen(
                             val qrContent = QrCodeUtils.decodeQrCode(bitmap)
                             if (qrContent != null) {
                                 extensionManager.importFromShareCode(qrContent).onSuccess { module ->
-                                    Toast.makeText(context, context.getString(R.string.msg_import_success, module.name), Toast.LENGTH_SHORT).show()
+                                    Toast.makeText(context, Strings.moduleImportSuccess(module.name), Toast.LENGTH_SHORT).show()
                                 }.onFailure { e ->
-                                    Toast.makeText(context, context.getString(R.string.msg_import_failed, e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
+                                    Toast.makeText(context, Strings.moduleImportFailed(e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
                                 }
                             } else {
                                 Toast.makeText(context, Strings.qrCodeNotFound, Toast.LENGTH_SHORT).show()
@@ -213,7 +212,7 @@ fun ExtensionModuleScreen(
                         }
                     }
                 } catch (e: Exception) {
-                    Toast.makeText(context, context.getString(R.string.msg_import_failed, e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, Strings.moduleImportFailed(e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
                 }
             }
         }
@@ -555,7 +554,7 @@ fun ExtensionModuleScreen(
                                 }
                             }
                         }.onFailure { e ->
-                            Toast.makeText(context, context.getString(R.string.msg_import_failed, e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, Strings.moduleImportFailed(e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
                         }
                         showUserScriptPreview = null
                     }
@@ -720,9 +719,9 @@ fun ExtensionModuleScreen(
                             name = editableName.ifBlank { jsPackage.module.name }
                         )
                         extensionManager.addModule(finalModule).onSuccess { module ->
-                            Toast.makeText(context, context.getString(R.string.msg_import_success, module.name), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, Strings.moduleImportSuccess(module.name), Toast.LENGTH_SHORT).show()
                         }.onFailure { e ->
-                            Toast.makeText(context, context.getString(R.string.msg_import_failed, e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, Strings.moduleImportFailed(e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
                         }
                     }
                     showJsPackagePreview = null
@@ -834,11 +833,11 @@ fun ExtensionModuleScreen(
                         if (successCount > 0) {
                             Toast.makeText(
                                 context,
-                                "${context.getString(R.string.msg_import_success, parseResult.extensionName)} ($successCount ${Strings.contentScripts})",
+                                "${Strings.moduleImportSuccess(parseResult.extensionName)} ($successCount ${Strings.contentScripts})",
                                 Toast.LENGTH_SHORT
                             ).show()
                         } else {
-                            Toast.makeText(context, context.getString(R.string.msg_import_failed, context.getString(R.string.unknown_error)), Toast.LENGTH_SHORT).show()
+                            Toast.makeText(context, Strings.moduleImportFailed(Strings.unknownError), Toast.LENGTH_SHORT).show()
                         }
                         showChromeExtPreview = null
                         pendingChromeExtDir = null

--- a/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import com.webtoapp.R
 import coil.ImageLoader
 import coil.compose.AsyncImage
@@ -276,9 +275,9 @@ fun HomeScreen(
                         Icon(
                             imageVector = if (isDarkNow) Icons.Outlined.DarkMode else Icons.Outlined.LightMode,
                             contentDescription = if (isDarkNow) {
-                                stringResource(com.webtoapp.R.string.theme_dark)
+                                Strings.statusBarDarkModeLabel
                             } else {
-                                stringResource(com.webtoapp.R.string.theme_light)
+                                Strings.statusBarLightModeLabel
                             },
                             modifier = Modifier.size(22.dp),
                             tint = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2294,7 +2294,7 @@ fun WebViewScreen(
             }
 
             override fun onSslError(error: String) {
-                errorMessage = context.getString(com.webtoapp.R.string.webview_ssl_error)
+                errorMessage = Strings.sslError
             }
 
             override fun onExternalLink(url: String) {
@@ -2307,7 +2307,7 @@ fun WebViewScreen(
                     AppLogger.w("WebViewActivity", "No app to handle external link: $url", e)
                     android.widget.Toast.makeText(
                         context,
-                        context.getString(com.webtoapp.R.string.webview_cannot_open_link),
+                        Strings.cannotOpenLink,
                         android.widget.Toast.LENGTH_SHORT
                     ).show()
                 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -52,7 +52,6 @@
     <string name="btn_preview">معاينة</string>
     <string name="btn_export">تصدير APK</string>
     <string name="btn_save">حفظ</string>
-    <string name="btn_cancel">إلغاء</string>
     <string name="btn_delete">حذف</string>
     <string name="btn_edit">تعديل</string>
     <string name="btn_launch">تشغيل</string>
@@ -72,17 +71,14 @@
 
     
     <string name="webview_error">فشل تحميل الصفحة</string>
-    <string name="webview_ssl_error">خطأ أمان SSL</string>
     <string name="webview_retry">إعادة المحاولة</string>
     <string name="webview_back">رجوع</string>
     <string name="webview_forward">تقدم</string>
     <string name="webview_refresh">تحديث</string>
     <string name="webview_share">مشاركة</string>
     <string name="webview_open_browser">فتح في المتصفح</string>
-    <string name="webview_cannot_open_link">تعذر فتح الرابط</string>
 
     
-    <string name="language_settings">اللغة</string>
     <string name="language_chinese">الصينية</string>
     <string name="language_english">الإنجليزية</string>
     <string name="language_arabic">العربية</string>
@@ -110,11 +106,8 @@
     <string name="module_disabled">معطل</string>
     <string name="ai_module_developer">مطور وحدات AI</string>
 
-    <string name="njs_package_json_not_found">لم يتم العثور على package.json. يرجى اختيار مجلد مشروع Node.js صالح.</string>
 
 
-    <string name="theme_dark">الوضع الداكن</string>
-    <string name="theme_light">الوضع الفاتح</string>
 
     <string name="ai_generating">AI يولد…</string>
     <string name="ai_analyzing">تحليل المتطلبات…</string>
@@ -265,7 +258,6 @@
     <string name="saved">تم الحفظ</string>
     <string name="operation_success">تمت العملية بنجاح</string>
     <string name="operation_failed">فشلت العملية</string>
-    <string name="unknown_error">خطأ غير معروف</string>
     <string name="please_wait">يرجى الانتظار…</string>
     <string name="processing">جاري المعالجة…</string>
     <string name="enabled">مفعل</string>
@@ -561,8 +553,6 @@
     <string name="delete_account_button">حذف الحساب نهائيًا</string>
 
     
-    <string name="msg_import_success">تم استيراد الوحدة %s بنجاح</string>
-    <string name="msg_import_failed">فشل استيراد الوحدة: %s</string>
 
     <string name="click_button_to_experience">انقر على الزر أدناه للتجربة</string>
     <string name="animation_disabled">الرسوم المتحركة معطلة</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -52,7 +52,6 @@
     <string name="btn_preview">Preview</string>
     <string name="btn_export">Export APK</string>
     <string name="btn_save">Save</string>
-    <string name="btn_cancel">Cancel</string>
     <string name="btn_delete">Delete</string>
     <string name="btn_edit">Edit</string>
     <string name="btn_launch">Launch</string>
@@ -72,17 +71,14 @@
 
     
     <string name="webview_error">Load failed</string>
-    <string name="webview_ssl_error">SSL security error</string>
     <string name="webview_retry">Retry</string>
     <string name="webview_back">Back</string>
     <string name="webview_forward">Forward</string>
     <string name="webview_refresh">Refresh</string>
     <string name="webview_share">Share</string>
     <string name="webview_open_browser">Open in Browser</string>
-    <string name="webview_cannot_open_link">Unable to open link</string>
 
     
-    <string name="language_settings">Language</string>
     <string name="language_chinese">Chinese</string>
     <string name="language_english">English</string>
     <string name="language_arabic">Arabic</string>
@@ -110,11 +106,8 @@
     <string name="module_disabled">Disabled</string>
     <string name="ai_module_developer">AI Module Developer</string>
 
-    <string name="njs_package_json_not_found">package.json not found. Select a valid project folder.</string>
 
 
-    <string name="theme_dark">Dark mode</string>
-    <string name="theme_light">Light mode</string>
 
     <string name="ai_generating">AI Generating…</string>
     <string name="ai_analyzing">Analyzing requirements…</string>
@@ -265,7 +258,6 @@
     <string name="saved">Saved</string>
     <string name="operation_success">Operation successful</string>
     <string name="operation_failed">Operation failed</string>
-    <string name="unknown_error">Unknown error</string>
     <string name="please_wait">Please wait…</string>
     <string name="processing">Processing…</string>
     <string name="enabled">Enabled</string>
@@ -623,8 +615,6 @@
     <string name="delete_account_button">Permanently Delete Account</string>
 
     
-    <string name="msg_import_success">Module %s imported successfully</string>
-    <string name="msg_import_failed">Module import failed: %s</string>
 
     
     <string name="change_password">Change Password</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -53,7 +53,6 @@
     <string name="btn_preview">预览</string>
     <string name="btn_export">导出APK</string>
     <string name="btn_save">保存</string>
-    <string name="btn_cancel">取消</string>
     <string name="btn_delete">删除</string>
     <string name="btn_edit">编辑</string>
     <string name="btn_launch">启动</string>
@@ -73,17 +72,14 @@
 
     
     <string name="webview_error">加载失败</string>
-    <string name="webview_ssl_error">SSL 安全错误</string>
     <string name="webview_retry">重试</string>
     <string name="webview_back">返回</string>
     <string name="webview_forward">前进</string>
     <string name="webview_refresh">刷新</string>
     <string name="webview_share">分享</string>
     <string name="webview_open_browser">在浏览器中打开</string>
-    <string name="webview_cannot_open_link">无法打开链接</string>
 
     
-    <string name="language_settings">语言</string>
     <string name="language_chinese">中文</string>
     <string name="language_english">英文</string>
     <string name="language_arabic">阿拉伯语</string>
@@ -111,11 +107,8 @@
     <string name="module_disabled">已禁用</string>
     <string name="ai_module_developer">AI 模块开发</string>
 
-    <string name="njs_package_json_not_found">未找到 package.json，请选有效项目目录</string>
 
 
-    <string name="theme_dark">深色模式</string>
-    <string name="theme_light">浅色模式</string>
 
     <string name="ai_generating">AI 生成中…</string>
     <string name="ai_analyzing">正在分析需求…</string>
@@ -358,7 +351,6 @@
     <string name="saved">已保存</string>
     <string name="operation_success">操作成功</string>
     <string name="operation_failed">操作失败</string>
-    <string name="unknown_error">未知错误</string>
     <string name="please_wait">请稍候…</string>
     <string name="processing">处理中…</string>
     <string name="enabled">已启用</string>
@@ -624,8 +616,6 @@
     <string name="delete_account_button">永久删除账号</string>
 
     
-    <string name="msg_import_success">模块 %s 导入成功</string>
-    <string name="msg_import_failed">模块导入失败: %s</string>
 
     
     <string name="auto_retry_after_seconds">%d秒后自动重试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,6 @@
     <string name="btn_preview">预览</string>
     <string name="btn_export">导出APK</string>
     <string name="btn_save">保存</string>
-    <string name="btn_cancel">取消</string>
     <string name="btn_delete">删除</string>
     <string name="btn_edit">编辑</string>
     <string name="btn_launch">启动</string>
@@ -74,17 +73,14 @@
 
     
     <string name="webview_error">加载失败</string>
-    <string name="webview_ssl_error">SSL 安全错误</string>
     <string name="webview_retry">重试</string>
     <string name="webview_back">返回</string>
     <string name="webview_forward">前进</string>
     <string name="webview_refresh">刷新</string>
     <string name="webview_share">分享</string>
     <string name="webview_open_browser">在浏览器中打开</string>
-    <string name="webview_cannot_open_link">无法打开链接</string>
 
     
-    <string name="language_settings">语言</string>
     <string name="language_chinese">中文</string>
     <string name="language_english">英文</string>
     <string name="language_arabic">阿拉伯语</string>
@@ -112,11 +108,8 @@
     <string name="module_disabled">已禁用</string>
     <string name="ai_module_developer">AI 模块开发</string>
 
-    <string name="njs_package_json_not_found">未找到 package.json，请选有效项目目录</string>
 
 
-    <string name="theme_dark">深色模式</string>
-    <string name="theme_light">浅色模式</string>
 
     <string name="ai_generating">AI 生成中…</string>
     <string name="ai_analyzing">正在分析需求…</string>
@@ -359,7 +352,6 @@
     <string name="saved">已保存</string>
     <string name="operation_success">操作成功</string>
     <string name="operation_failed">操作失败</string>
-    <string name="unknown_error">未知错误</string>
     <string name="please_wait">请稍候…</string>
     <string name="processing">处理中…</string>
     <string name="enabled">已启用</string>
@@ -625,8 +617,6 @@
     <string name="delete_account_button">永久删除账号</string>
 
     
-    <string name="msg_import_success">模块 %s 导入成功</string>
-    <string name="msg_import_failed">模块导入失败: %s</string>
 
     
     <string name="change_password">修改密码</string>

--- a/app/src/test/java/com/webtoapp/core/i18n/AppStringsResourceConsistencyTest.kt
+++ b/app/src/test/java/com/webtoapp/core/i18n/AppStringsResourceConsistencyTest.kt
@@ -107,6 +107,55 @@ class AppStringsResourceConsistencyTest {
         }
     }
 
+    @Test
+    fun `kotlin source never references R string for user-visible text`() {
+        val sourceRoots = listOf(
+            "app/src/main/java",
+            "src/main/java",
+        ).map(::File).filter(File::exists)
+        assertWithMessage("Could not locate Kotlin source root")
+            .that(sourceRoots).isNotEmpty()
+
+        val offenders = mutableListOf<String>()
+        sourceRoots.forEach { root ->
+            root.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relPath = file.relativeTo(root).path
+                    file.useLines { lines ->
+                        lines.forEachIndexed { index, raw ->
+                            val line = raw.trim()
+                            if (line.startsWith("//") || line.startsWith("*")) {
+                                return@forEachIndexed
+                            }
+                            if (R_STRING_REFERENCE.containsMatchIn(line)) {
+                                offenders += "${relPath}:${index + 1}: ${raw.trim()}"
+                            }
+                        }
+                    }
+                }
+        }
+
+        assertWithMessage(
+            buildString {
+                appendLine("Kotlin source references R.string.* for user-visible text.")
+                appendLine("All user-facing strings must live in Strings.kt as inline")
+                appendLine("when(Strings.lang) blocks covering all 10 languages.")
+                appendLine()
+                appendLine("R.string.* is forbidden because res/values*/ is not maintained")
+                appendLine("for all 10 locales — resource lookups silently fall back to the")
+                appendLine("default values/ (Chinese) for pt/es/fr/de/ru/ja/ko, masking")
+                appendLine("missing translations. Use Strings.xxx (or Strings.funName(arg)")
+                appendLine("for parameterised strings) instead.")
+                appendLine()
+                appendLine("Offending references:")
+                offenders.forEach { appendLine("  $it") }
+            }
+        ).that(offenders).isEmpty()
+    }
+
+    private val R_STRING_REFERENCE = Regex("""\bR\.string\.[A-Za-z_][A-Za-z0-9_]*""")
+
     private fun resolveExistingDir(vararg candidates: String): File {
         return candidates
             .asSequence()

--- a/app/src/test/java/com/webtoapp/core/i18n/StringsKtTranslationParityTest.kt
+++ b/app/src/test/java/com/webtoapp/core/i18n/StringsKtTranslationParityTest.kt
@@ -13,10 +13,16 @@ class StringsKtTranslationParityTest {
         assertWithMessage(
             buildString {
                 appendLine("Strings.kt has when(lang) blocks that fail i18n parity rules.")
-                appendLine("Each block must either:")
-                appendLine("  - list all ten branches: CHINESE, ENGLISH, ARABIC, PORTUGUESE,")
-                appendLine("    SPANISH, FRENCH, GERMAN, RUSSIAN, JAPANESE, KOREAN")
-                appendLine("  - or defer to Android resources: else -> getString(R.string.x)")
+                appendLine("Each block must list all ten branches explicitly:")
+                appendLine("  CHINESE, ENGLISH, ARABIC, PORTUGUESE, SPANISH,")
+                appendLine("  FRENCH, GERMAN, RUSSIAN, JAPANESE, KOREAN")
+                appendLine()
+                appendLine("'else ->' branches are forbidden. A resource deferral")
+                appendLine("(else -> getString(R.string.*)) silently falls back to the")
+                appendLine("default values/ (Chinese) for locales without a values-*/")
+                appendLine("directory, so it masks missing translations instead of")
+                appendLine("providing them. pt/es/fr/de/ru/ja/ko have no values-*/ folder")
+                appendLine("and must therefore be served by inline branches.")
                 appendLine()
                 appendLine("Offending blocks (line number is the line containing 'when (Strings.lang)'):")
                 problems.forEach { appendLine("  $it") }
@@ -84,7 +90,7 @@ class StringsKtTranslationParityTest {
 
     private data class BlockAnalysis(
         val presentLanguages: Set<String>,
-        val nonDeferralElseAtTopLevel: Boolean,
+        val anyElseAtTopLevel: Boolean,
     )
 
     private val ALL_LANGUAGES = listOf(
@@ -94,7 +100,7 @@ class StringsKtTranslationParityTest {
 
     private fun analyseBlock(source: String, openingBraceIndex: Int): Pair<BlockAnalysis, Int> {
         val present = mutableSetOf<String>()
-        var nonDeferralElseAtTopLevel = false
+        var anyElseAtTopLevel = false
 
         var depth = 1
         var i = openingBraceIndex + 1
@@ -116,7 +122,7 @@ class StringsKtTranslationParityTest {
                 '}' -> {
                     depth--
                     if (depth == 0) {
-                        return BlockAnalysis(present.toSet(), nonDeferralElseAtTopLevel) to i
+                        return BlockAnalysis(present.toSet(), anyElseAtTopLevel) to i
                     }
                     i++
                     continue
@@ -131,19 +137,13 @@ class StringsKtTranslationParityTest {
                 if (matchAt(source, i, "else") && isAtWordStart(source, i) &&
                     looksLikeArrowAfter(source, i + 4)
                 ) {
-                    val arrow = indexOfArrow(source, i)
-                    if (arrow != null) {
-                        val rhsStart = skipSpacesAndTabs(source, arrow + 2)
-                        if (!isPureGetStringDeferral(source, rhsStart)) {
-                            nonDeferralElseAtTopLevel = true
-                        }
-                    }
+                    anyElseAtTopLevel = true
                 }
             }
             i++
         }
 
-        return BlockAnalysis(present.toSet(), nonDeferralElseAtTopLevel) to (source.length - 1)
+        return BlockAnalysis(present.toSet(), anyElseAtTopLevel) to (source.length - 1)
     }
 
     private fun isAtWordStart(source: String, i: Int): Boolean {
@@ -156,60 +156,6 @@ class StringsKtTranslationParityTest {
         var i = from
         while (i < source.length && (source[i] == ' ' || source[i] == '\t')) i++
         return i + 1 < source.length && source[i] == '-' && source[i + 1] == '>'
-    }
-
-    private fun indexOfArrow(source: String, from: Int): Int? {
-        var i = from
-        while (i < source.length - 1) {
-            if (source[i] == '\n') return null
-            if (source[i] == '-' && source[i + 1] == '>') return i
-            i++
-        }
-        return null
-    }
-
-    private fun skipSpacesAndTabs(source: String, from: Int): Int {
-        var i = from
-        while (i < source.length && (source[i] == ' ' || source[i] == '\t')) i++
-        return i
-    }
-
-    private fun isPureGetStringDeferral(source: String, from: Int): Boolean {
-        var start = from
-        if (source.regionMatches(start, "Strings.", 0, "Strings.".length)) {
-            start += "Strings.".length
-        }
-        val needle = "getString(R.string."
-        if (!source.regionMatches(start, needle, 0, needle.length)) return false
-        var i = start + needle.length
-
-        if (i >= source.length || !(source[i].isLetter() || source[i] == '_')) return false
-        while (i < source.length && (source[i].isLetterOrDigit() || source[i] == '_')) i++
-
-        if (i < source.length && source[i] == ',') {
-
-            var parenDepth = 1
-            i++
-            while (i < source.length && parenDepth > 0) {
-                val (next, _) = skipNonCode(source, i)
-                if (next != i) {
-                    i = next
-                    continue
-                }
-                when (source[i]) {
-                    '(' -> parenDepth++
-                    ')' -> parenDepth--
-                    '\n' -> return false
-                }
-                if (parenDepth == 0) break
-                i++
-            }
-        }
-        if (i >= source.length || source[i] != ')') return false
-
-        var j = i + 1
-        while (j < source.length && (source[j] == ' ' || source[j] == '\t')) j++
-        return j < source.length && (source[j] == '\n' || source[j] == '\r' || source[j] == '}')
     }
 
     private fun matchAt(source: String, i: Int, literal: String): Boolean {
@@ -294,13 +240,15 @@ class StringsKtTranslationParityTest {
         val problems = mutableListOf<String>()
 
         val anyBranch = analysis.presentLanguages.isNotEmpty()
-        if (!anyBranch && !analysis.nonDeferralElseAtTopLevel) {
+        if (!anyBranch && !analysis.anyElseAtTopLevel) {
 
             return problems
         }
-        if (analysis.nonDeferralElseAtTopLevel) {
-            problems += "L$openerLine: when(lang) contains 'else ->' that is not a getString(R.string.*) deferral. " +
-                "Hard-coded else branches mask missing translations — list all ten AppLanguage cases instead."
+        if (analysis.anyElseAtTopLevel) {
+            problems += "L$openerLine: when(lang) uses an 'else ->' branch. " +
+                "List all ten AppLanguage cases instead — 'else ->' (including resource " +
+                "deferrals via getString(R.string.*)) silently falls back to Chinese for " +
+                "locales without a values-*/ directory."
             return problems
         }
         val missing = ALL_LANGUAGES.filter { it !in analysis.presentLanguages }


### PR DESCRIPTION
Closes #467

## Summary

7 of 10 UI locales (pt/es/fr/de/ru/ja/ko) silently showed **Chinese** for any string that deferred to Android resources, because `res/values*/` only maintains zh/en/ar directories and Android falls back to the default `values/` (Chinese) for the missing 7 locales.

This fully retires the resource path for user-visible text so `Strings.kt` is the single source of truth, and adds gates so the split can't silently regress.

## Changes

**Translation source unification**
- Converted **41 `when(lang)` blocks** in `Strings.kt` from `else -> getString(R.string.*)` to inline 10-language branches (main-screen nav/menu + Node/PHP/Python/Go/WordPress project-preview cards/state copy).
- Replaced **14 `R.string.*` call sites** in 5 host-only files with `Strings.xxx` properties:
  - `ExtensionModuleScreen` — module import toasts
  - `WebViewActivity` — SSL error / cannot-open-link
  - `CreateNodeJsAppScreen` — package.json not found
  - `HomeScreen` — theme icon descriptions
  - `LanguageSelector` — cancel button / dialog title
- Reused 6 existing equivalent properties; added **4 new** ones (`moduleImportSuccess(name)`, `moduleImportFailed(msg)`, `languageSettings`, `sslError`) — all 10 languages, following the `linuxEnvInstalledToast(name)` function-style pattern for the parameterised ones.
- Deleted the **10 now-dead keys** from all 4 `values*/strings.xml` (zh/en/ar parity preserved).
- Dropped dead `getString()` / `@StringRes` / `R` imports left after the migration.

**Regression gates**
- `StringsKtTranslationParityTest`: any `else ->` branch is now a failure (previously `else -> getString(R.string.*)` was wrongly exempted — the blind spot that let the 41 blocks ship).
- `AppStringsResourceConsistencyTest`: new test forbids `R.string.*` references across `app/src/main/java/` Kotlin source.
- `AGENTS.md` i18n section: documented the single-source policy and the `R.string` ban.

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] `:app:testDebugUnitTest --tests com.webtoapp.core.i18n.*` — all pass (parity + resource-consistency + new gate)
- [x] 0 `R.string.*` references remain in `app/src/main/java/`
- [x] 0 `else -> getString` blocks remain in `Strings.kt`
- [x] Deleted keys absent from all 4 `values*/strings.xml`; zh/en/ar key parity intact

## Impact / risk

- Host preview only — the 5 affected files are host-only (not shell-synced); exported APKs are unaffected.
- No new dependencies. No shell template rebuild needed (no shell-synced source changed).
- Translation choices follow existing terminology conventions (AI → IA/KI/ИИ, Agent kept verbatim, etc.).