### PR TITLE
fix(apkbuilder): include native libs in cache identity, hard-fail on 16KB misalignment

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
@@ -107,6 +107,7 @@ class ApkBuildCache(private val context: Context) {
         htmlFiles: List<com.webtoapp.data.model.HtmlFile>,
         galleryItems: List<com.webtoapp.data.model.GalleryItem>,
         errorPageMediaPath: String?,
+        nativeLibsFingerprint: String? = null,
         forceFullRebuild: Boolean
     ): IncrementalPlan {
         val shellId = shellTemplateId(templateApk)
@@ -115,7 +116,8 @@ class ApkBuildCache(private val context: Context) {
             shellTemplateId = shellId,
             encryptionEnabled = encryptionEnabled,
             abiFilters = abiFilters,
-            iconPath = webApp.iconPath
+            iconPath = webApp.iconPath,
+            nativeLibsFingerprint = nativeLibsFingerprint
         )
         val content = contentFingerprint(
             config = config,
@@ -330,7 +332,8 @@ class ApkBuildCache(private val context: Context) {
         shellTemplateId: String,
         encryptionEnabled: Boolean,
         abiFilters: List<String>,
-        iconPath: String?
+        iconPath: String?,
+        nativeLibsFingerprint: String? = null
     ): String {
         val parts = mutableListOf<String>()
         parts += "shell=$shellTemplateId"
@@ -348,6 +351,11 @@ class ApkBuildCache(private val context: Context) {
         parts += "deeplinkSchemes=${config.deepLinkSchemes.sorted().joinToString(",")}"
         parts += "runtimePerms=${config.runtimePermissions}"
         parts += "networkTrust=${config.networkTrustConfig}"
+        // Native libs (libnode.so / libnode_bridge.so / libc++_shared.so) must participate
+        // so a host upgrade that ships a new/realigned libnode.so invalidates the cached
+        // unsigned APK. Otherwise REUSE_UNSIGNED serves a stale unaligned lib that dlopen
+        // rejects on Android 15+ (16KB-page) devices.
+        parts += "nativeLibs=${nativeLibsFingerprint ?: "none"}"
         return sha256(parts.joinToString("\n"))
     }
 
@@ -408,7 +416,7 @@ class ApkBuildCache(private val context: Context) {
         return digest.digest().toHexString()
     }
 
-    private fun fileSha256(file: File): String {
+    internal fun fileSha256(file: File): String {
         val digest = MessageDigest.getInstance("SHA-256")
         file.inputStream().buffered().use { input ->
             val buffer = ByteArray(DEFAULT_BUFFER_SIZE)

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -624,6 +624,11 @@ class ApkBuilder(private val context: Context) {
                 htmlFiles = htmlFiles,
                 galleryItems = galleryItems,
                 errorPageMediaPath = errorPageMediaPath,
+                nativeLibsFingerprint = if (webApp.appType == com.webtoapp.data.model.AppType.NODEJS_APP) {
+                    nativeLibsFingerprint()
+                } else {
+                    null
+                },
                 forceFullRebuild = forceFullRebuild
             )
             logger.logKeyValue("incrementalMode", incrementalPlan.mode.name)
@@ -800,9 +805,18 @@ class ApkBuilder(private val context: Context) {
             val zipAligned = ZipAligner.alignInPlace(unsignedApk)
             logger.logKeyValue("zipAlign16kNativeLibs", zipAligned)
             if (!zipAligned) {
-                logger.warn("ZipAlign failed; APK signing will continue with the generated artifact")
-            } else if (!ZipAligner.verifyNativeLibAlignment(unsignedApk)) {
-                logger.warn("One or more native libraries are not 16KB zip-aligned after ZipAlign")
+                logger.error("16KB zip-alignment of native libraries failed; aborting build")
+                throw IllegalStateException(
+                    "16KB zip-alignment of native libraries failed. The generated APK would crash on " +
+                        "Android 15+ (16KB-page) devices at dlopen time. Clear the app's build cache and retry."
+                )
+            }
+            if (!ZipAligner.verifyNativeLibAlignment(unsignedApk)) {
+                logger.error("Native lib zip-alignment verification failed after ZipAlign; aborting build")
+                throw IllegalStateException(
+                    "One or more native libraries are not 16KB zip-aligned after ZipAlign. The generated APK " +
+                        "would crash on Android 15+ (16KB-page) devices at dlopen time. Clear the app's build cache and retry."
+                )
             }
 
             logger.section("Verify APK Artifact")
@@ -1961,6 +1975,43 @@ class ApkBuilder(private val context: Context) {
             return downloaded
         }
         return null
+    }
+
+    /**
+     * Fingerprint of the native libs that would be injected into a NODEJS_APP export
+     * (libnode.so, libnode_bridge.so, libc++_shared.so). Fed into the incremental build
+     * cache's identity fingerprint so a host upgrade that ships a new/realigned libnode.so
+     * invalidates the cached unsigned APK — otherwise REUSE_UNSIGNED serves a stale lib
+     * that dlopen rejects on Android 15+ (16KB-page) devices.
+     *
+     * Returns null for non-Node.js apps (no native lib injection), which is treated as
+     * "not applicable" by the cache and does not affect other app types' cache keys.
+     */
+    private fun nativeLibsFingerprint(): String? {
+        val nativeDir = File(context.applicationInfo.nativeLibraryDir)
+        val bridge = File(nativeDir, "libnode_bridge.so")
+        val cxxShared = File(nativeDir, "libc++_shared.so")
+        val node = resolveNodeJsBinary() ?: return null
+        val parts = mutableListOf<String>()
+        parts += "bridge=${libFingerprint(bridge)}"
+        parts += "cxx=${libFingerprint(cxxShared)}"
+        parts += "node=${libFingerprint(node)}"
+        return parts.joinToString("|")
+    }
+
+    private fun libFingerprint(file: File): String {
+        if (!file.isFile || !file.canRead() || file.length() <= 0L) return "missing"
+        val sha = try {
+            buildCache.fileSha256(file)
+        } catch (_: Exception) {
+            "err"
+        }
+        val aligned = try {
+            ElfAligner16k.isAligned16k(file)
+        } catch (_: Exception) {
+            false
+        }
+        return "sha256=$sha,size=${file.length()},aligned16k=$aligned"
     }
 
     private fun injectNodeJsNativeLibs(zipOut: ZipOutputStream) {

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuildCacheTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuildCacheTest.kt
@@ -161,4 +161,132 @@ class ApkBuildCacheTest {
         assertThat(plan2.mode).isEqualTo(IncrementalBuildMode.REUSE_UNSIGNED)
         assertThat(plan2.reason).isEqualTo("identityAndContentMatch")
     }
+
+    @Test
+    fun `native libs fingerprint change forces full rebuild instead of reuse`() {
+        val context = RuntimeEnvironment.getApplication()
+        val cache = ApkBuildCache(context)
+        cache.clearAll()
+
+        val webApp = com.webtoapp.data.model.WebApp(
+            id = 11,
+            name = "NodeApp",
+            url = "nodejs://localhost"
+        )
+        val template = File(context.cacheDir, "shell_template_node.apk").apply {
+            writeBytes(ByteArray(48) { 5 })
+        }
+        val config = ApkConfig(
+            meta = MetaBlock(
+                appName = "NodeApp",
+                packageName = "com.demo.node",
+                targetUrl = "nodejs://localhost",
+                versionCode = 1,
+                versionName = "1.0",
+                appType = "NODEJS_APP"
+            )
+        )
+
+        fun planWith(nativeLibs: String?) = cache.plan(
+            webApp = webApp,
+            packageName = "com.demo.node",
+            config = config,
+            templateApk = template,
+            encryptionEnabled = false,
+            abiFilters = listOf("arm64-v8a"),
+            projectDirs = emptyList(),
+            mediaContentPath = null,
+            splashMediaPath = null,
+            bgmPlaylistPaths = emptyList(),
+            htmlFiles = emptyList(),
+            galleryItems = emptyList(),
+            errorPageMediaPath = null,
+            nativeLibsFingerprint = nativeLibs,
+            forceFullRebuild = false
+        )
+
+        // First build with the "old" libnode.so fingerprint → cache miss → FULL.
+        val plan1 = planWith("sha256=oldlibnode,size=1,aligned16k=false")
+        assertThat(plan1.mode).isEqualTo(IncrementalBuildMode.FULL)
+
+        val unsigned = File(context.cacheDir, "node_unsigned.apk").apply {
+            writeBytes(ByteArray(128) { 9 })
+        }
+        cache.saveUnsigned(
+            webApp = webApp,
+            packageName = "com.demo.node",
+            unsignedApk = unsigned,
+            identityFingerprint = plan1.identityFingerprint,
+            contentFingerprint = plan1.contentFingerprint,
+            shellTemplateId = plan1.shellTemplateId
+        )
+
+        // Same config but host upgraded libnode.so to a 16KB-aligned build → the native
+        // libs fingerprint changed. This must NOT reuse the stale cached unsigned APK;
+        // it must rebuild so the new aligned lib is re-injected.
+        val plan2 = planWith("sha256=newlibnode,size=2,aligned16k=true")
+        assertThat(plan2.mode).isEqualTo(IncrementalBuildMode.FULL)
+        assertThat(plan2.identityFingerprint).isNotEqualTo(plan1.identityFingerprint)
+    }
+
+    @Test
+    fun `native libs fingerprint null and non-null produce different identity fingerprints`() {
+        val context = RuntimeEnvironment.getApplication()
+        val cache = ApkBuildCache(context)
+
+        val webApp = com.webtoapp.data.model.WebApp(
+            id = 12,
+            name = "NodeApp2",
+            url = "nodejs://localhost"
+        )
+        val template = File(context.cacheDir, "shell_t2.apk").apply {
+            writeBytes(ByteArray(16) { 7 })
+        }
+        val config = ApkConfig(
+            meta = MetaBlock(
+                appName = "NodeApp2",
+                packageName = "com.demo.node2",
+                targetUrl = "nodejs://localhost",
+                versionCode = 1,
+                versionName = "1.0",
+                appType = "NODEJS_APP"
+            )
+        )
+
+        val nullPlan = cache.plan(
+            webApp = webApp,
+            packageName = "com.demo.node2",
+            config = config,
+            templateApk = template,
+            encryptionEnabled = false,
+            abiFilters = emptyList(),
+            projectDirs = emptyList(),
+            mediaContentPath = null,
+            splashMediaPath = null,
+            bgmPlaylistPaths = emptyList(),
+            htmlFiles = emptyList(),
+            galleryItems = emptyList(),
+            errorPageMediaPath = null,
+            nativeLibsFingerprint = null,
+            forceFullRebuild = false
+        )
+        val withLibsPlan = cache.plan(
+            webApp = webApp,
+            packageName = "com.demo.node2",
+            config = config,
+            templateApk = template,
+            encryptionEnabled = false,
+            abiFilters = emptyList(),
+            projectDirs = emptyList(),
+            mediaContentPath = null,
+            splashMediaPath = null,
+            bgmPlaylistPaths = emptyList(),
+            htmlFiles = emptyList(),
+            galleryItems = emptyList(),
+            errorPageMediaPath = null,
+            nativeLibsFingerprint = "sha256=abc,size=100,aligned16k=true",
+            forceFullRebuild = false
+        )
+        assertThat(nullPlan.identityFingerprint).isNotEqualTo(withLibsPlan.identityFingerprint)
+    }
 }


### PR DESCRIPTION
Closes #469

## Summary

Exported NODEJS_APPs could reach Android 15+ (16KB-page kernel) devices with an unaligned `libnode.so`, crashing at `dlopen` ("libnode.so 加载失败"). The export-time `ElfAligner16k` logic is correct, but a **stale unaligned lib was served from the incremental build cache**.

## Root cause

`ApkBuildCache.identityFingerprint()` did not include any native-lib content hash or alignment state. When the host app upgraded (shipping a new/realigned libnode.so), a NODEJS_APP built previously got an identical identity fingerprint → `REUSE_UNSIGNED` → the cached unsigned APK (containing the old unaligned libnode.so) was copied verbatim. Native libs are never re-injected (`isContentReplaceableEntry()` returns `false` for `lib/*`), so even `CONTENT_OVERLAY` mode preserved the stale libs.

Secondary: `ZipAligner.alignInPlace` failure and `verifyNativeLibAlignment` failure were soft-fails (warn + continue), shipping a known-bad APK.

## Changes

**Cache identity now tracks native libs**
- `ApkBuildCache.identityFingerprint()` takes a new `nativeLibsFingerprint` param, folded into the fingerprint. A host lib upgrade changes it → forces `FULL` → re-inject + realign.
- Backwards compatible: default `null`; old cache meta without the field deserialises as `null` ≠ new value → triggers `FULL` (exactly the desired behaviour on first run after upgrade).
- `ApkBuilder.nativeLibsFingerprint()` / `libFingerprint()` compute `sha256 + size + ElfAligner16k.isAligned16k()` for the same three libs (`libnode.so` / `libnode_bridge.so` / `libc++_shared.so`) that `injectNodeJsNativeLibs` embeds. Applied to `NODEJS_APP` only; other app types pass `null`.

**Alignment failures now abort the build**
- `ZipAligner.alignInPlace` returning `false` → `IllegalStateException` (was: warn + continue).
- `verifyNativeLibAlignment` returning `false` → `IllegalStateException` (was: warn).
- Rationale: a misaligned native lib is guaranteed to crash on Android 15+ (16KB-page) devices at `dlopen`. There is no "ship it anyway" option; failing the build surfaces the problem immediately instead of producing an APK that crashes on launch.

**Tests** (`ApkBuildCacheTest`)
- `native libs fingerprint change forces full rebuild instead of reuse`: same config + changed libnode.so fingerprint → `FULL` (not `REUSE_UNSIGNED`), and identity fingerprints differ.
- `native libs fingerprint null and non-null produce different identity fingerprints`: guards the null-vs-value distinction.

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] `:app:testDebugUnitTest --tests com.webtoapp.core.apkbuilder.*` — all pass (existing + 2 new)
- [x] Changes are host-only (`apkbuilder` is not shell-synced); no template rebuild needed.

## Impact / risk

- Fixes NODEJS_APP exports reused from a cache populated by an older host version on 16KB-page devices.
- Other app types unaffected (pass `null`, cache key unchanged for them).
- Low risk: identity fingerprint gains an input field; alignment soft-fail → hard-fail only affects builds that were already producing broken APKs.