### PR TITLE
feat(update): in-app download progress, File Manager integration, explicit install

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.4.0** (`versionCode 51`).
+This guide targets **WebToApp 2.4.1** (`versionCode 52`).
 
 ---
 
@@ -218,7 +218,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.4.0**（`versionCode 51`）。
+本指南对应 **WebToApp 2.4.1**（`versionCode 52`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 51
-        versionName = "2.4.0"
+        versionCode = 52
+        versionName = "2.4.1"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -673,6 +673,14 @@ object Strings {
     val updateCurrentVersionLabel: String get() = StringsA.updateCurrentVersionLabel
     val updateDownloadButton: String get() = StringsA.updateDownloadButton
     val updateDownloadStarted: String get() = StringsA.updateDownloadStarted
+    val updateInstallReady: String get() = StringsA.updateInstallReady
+    val updateDownloading: String get() = StringsA.updateDownloading
+    val updateVerifying: String get() = StringsA.updateVerifying
+    val updateCancelDownload: String get() = StringsA.updateCancelDownload
+    val updateRetry: String get() = StringsA.updateRetry
+    val updateDownloadFailed: String get() = StringsA.updateDownloadFailed
+    val updateReadyHint: String get() = StringsA.updateReadyHint
+    val updatePerSec: String get() = StringsA.updatePerSec
     val updateReleaseNotesLabel: String get() = StringsA.updateReleaseNotesLabel
     val updateSizeLabel: String get() = StringsA.updateSizeLabel
     val updateVerificationFailed: String get() = StringsA.updateVerificationFailed
@@ -4645,6 +4653,7 @@ object Strings {
     val fileManagerSectionApk: String get() = StringsE.fileManagerSectionApk
     val fileManagerSectionAab: String get() = StringsE.fileManagerSectionAab
     val fileManagerSectionCloned: String get() = StringsE.fileManagerSectionCloned
+    val fileManagerSectionUpdateApks: String get() = StringsE.fileManagerSectionUpdateApks
     val fileManagerSectionLogs: String get() = StringsE.fileManagerSectionLogs
     val fileManagerSectionUserFiles: String get() = StringsE.fileManagerSectionUserFiles
     val fileManagerOpen: String get() = StringsE.fileManagerOpen
@@ -13334,16 +13343,16 @@ object StringsA {
         AppLanguage.KOREAN -> "현재 버전"
     }
     val updateDownloadButton: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "下载并安装"
-        AppLanguage.ENGLISH -> "Download & install"
-        AppLanguage.ARABIC -> "تنزيل وتثبيت"
-        AppLanguage.PORTUGUESE -> "Baixar e instalar"
-        AppLanguage.SPANISH -> "Descargar e instalar"
-        AppLanguage.FRENCH -> "Télécharger et installer"
-        AppLanguage.GERMAN -> "Herunterladen & installieren"
-        AppLanguage.RUSSIAN -> "Скачать и установить"
-        AppLanguage.JAPANESE -> "ダウンロードしてインストール"
-        AppLanguage.KOREAN -> "다운로드 및 설치"
+        AppLanguage.CHINESE -> "下载"
+        AppLanguage.ENGLISH -> "Download"
+        AppLanguage.ARABIC -> "تنزيل"
+        AppLanguage.PORTUGUESE -> "Baixar"
+        AppLanguage.SPANISH -> "Descargar"
+        AppLanguage.FRENCH -> "Télécharger"
+        AppLanguage.GERMAN -> "Herunterladen"
+        AppLanguage.RUSSIAN -> "Скачать"
+        AppLanguage.JAPANESE -> "ダウンロード"
+        AppLanguage.KOREAN -> "다운로드"
     }
     val updateDownloadStarted: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "已开始下载，完成后将提示安装"
@@ -13356,6 +13365,102 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Загрузка начата; по завершении вам будет предложено установить"
         AppLanguage.JAPANESE -> "ダウンロードを開始しました。完了時にインストールを促されます"
         AppLanguage.KOREAN -> "다운로드가 시작되었습니다. 완료되면 설치하라는 메시지가 표시됩니다"
+    }
+    val updateInstallReady: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "安装包已就绪"
+        AppLanguage.ENGLISH -> "Update package ready"
+        AppLanguage.ARABIC -> "حزمة التحديث جاهزة"
+        AppLanguage.PORTUGUESE -> "Pacote de atualização pronto"
+        AppLanguage.SPANISH -> "Paquete de actualización listo"
+        AppLanguage.FRENCH -> "Mise à jour prête"
+        AppLanguage.GERMAN -> "Update-Paket bereit"
+        AppLanguage.RUSSIAN -> "Пакет обновления готов"
+        AppLanguage.JAPANESE -> "更新パッケージの準備ができました"
+        AppLanguage.KOREAN -> "업데이트 패키지 준비됨"
+    }
+    val updateDownloading: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "正在下载…"
+        AppLanguage.ENGLISH -> "Downloading…"
+        AppLanguage.ARABIC -> "جاري التنزيل…"
+        AppLanguage.PORTUGUESE -> "Baixando…"
+        AppLanguage.SPANISH -> "Descargando…"
+        AppLanguage.FRENCH -> "Téléchargement…"
+        AppLanguage.GERMAN -> "Wird heruntergeladen…"
+        AppLanguage.RUSSIAN -> "Загрузка…"
+        AppLanguage.JAPANESE -> "ダウンロード中…"
+        AppLanguage.KOREAN -> "다운로드 중…"
+    }
+    val updateVerifying: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "正在校验…"
+        AppLanguage.ENGLISH -> "Verifying…"
+        AppLanguage.ARABIC -> "جاري التحقق…"
+        AppLanguage.PORTUGUESE -> "Verificando…"
+        AppLanguage.SPANISH -> "Verificando…"
+        AppLanguage.FRENCH -> "Vérification…"
+        AppLanguage.GERMAN -> "Wird verifiziert…"
+        AppLanguage.RUSSIAN -> "Проверка…"
+        AppLanguage.JAPANESE -> "検証中…"
+        AppLanguage.KOREAN -> "검증 중…"
+    }
+    val updateCancelDownload: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "取消下载"
+        AppLanguage.ENGLISH -> "Cancel download"
+        AppLanguage.ARABIC -> "إلغاء التنزيل"
+        AppLanguage.PORTUGUESE -> "Cancelar download"
+        AppLanguage.SPANISH -> "Cancelar descarga"
+        AppLanguage.FRENCH -> "Annuler le téléchargement"
+        AppLanguage.GERMAN -> "Download abbrechen"
+        AppLanguage.RUSSIAN -> "Отменить загрузку"
+        AppLanguage.JAPANESE -> "ダウンロードをキャンセル"
+        AppLanguage.KOREAN -> "다운로드 취소"
+    }
+    val updateRetry: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "重试"
+        AppLanguage.ENGLISH -> "Retry"
+        AppLanguage.ARABIC -> "إعادة المحاولة"
+        AppLanguage.PORTUGUESE -> "Tentar novamente"
+        AppLanguage.SPANISH -> "Reintentar"
+        AppLanguage.FRENCH -> "Réessayer"
+        AppLanguage.GERMAN -> "Erneut versuchen"
+        AppLanguage.RUSSIAN -> "Повторить"
+        AppLanguage.JAPANESE -> "再試行"
+        AppLanguage.KOREAN -> "재시도"
+    }
+    val updateDownloadFailed: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "下载失败"
+        AppLanguage.ENGLISH -> "Download failed"
+        AppLanguage.ARABIC -> "فشل التنزيل"
+        AppLanguage.PORTUGUESE -> "Falha no download"
+        AppLanguage.SPANISH -> "Error en la descarga"
+        AppLanguage.FRENCH -> "Échec du téléchargement"
+        AppLanguage.GERMAN -> "Download fehlgeschlagen"
+        AppLanguage.RUSSIAN -> "Ошибка загрузки"
+        AppLanguage.JAPANESE -> "ダウンロードに失敗しました"
+        AppLanguage.KOREAN -> "다운로드 실패"
+    }
+    val updateReadyHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "下载完成，点击安装"
+        AppLanguage.ENGLISH -> "Downloaded. Tap install to continue."
+        AppLanguage.ARABIC -> "تم التنزيل. اضغط تثبيت للمتابعة."
+        AppLanguage.PORTUGUESE -> "Baixado. Toque em instalar para continuar."
+        AppLanguage.SPANISH -> "Descargado. Toca instalar para continuar."
+        AppLanguage.FRENCH -> "Téléchargé. Appuyez sur installer pour continuer."
+        AppLanguage.GERMAN -> "Heruntergeladen. Zum Fortfahren auf Installieren tippen."
+        AppLanguage.RUSSIAN -> "Загружено. Нажмите «Установить», чтобы продолжить."
+        AppLanguage.JAPANESE -> "ダウンロード完了。インストールをタップして続行してください。"
+        AppLanguage.KOREAN -> "다운로드 완료. 계속하려면 설치를 탭하세요."
+    }
+    val updatePerSec: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "/秒"
+        AppLanguage.ENGLISH -> "/s"
+        AppLanguage.ARABIC -> "/ث"
+        AppLanguage.PORTUGUESE -> "/s"
+        AppLanguage.SPANISH -> "/s"
+        AppLanguage.FRENCH -> "/s"
+        AppLanguage.GERMAN -> "/s"
+        AppLanguage.RUSSIAN -> "/с"
+        AppLanguage.JAPANESE -> "/秒"
+        AppLanguage.KOREAN -> "/초"
     }
     val updateReleaseNotesLabel: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "更新说明"
@@ -61754,6 +61859,18 @@ object StringsE {
         AppLanguage.RUSSIAN -> "Клоны приложений"
         AppLanguage.JAPANESE -> "アプリクローン"
         AppLanguage.KOREAN -> "앱 복제"
+    }
+    val fileManagerSectionUpdateApks: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "更新安装包"
+        AppLanguage.ENGLISH -> "Update Packages"
+        AppLanguage.ARABIC -> "حزم التحديث"
+        AppLanguage.PORTUGUESE -> "Pacotes de Atualização"
+        AppLanguage.SPANISH -> "Paquetes de Actualización"
+        AppLanguage.FRENCH -> "Mises à jour"
+        AppLanguage.GERMAN -> "Update-Pakete"
+        AppLanguage.RUSSIAN -> "Пакеты обновлений"
+        AppLanguage.JAPANESE -> "更新パッケージ"
+        AppLanguage.KOREAN -> "업데이트 패키지"
     }
     val fileManagerSectionLogs: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "构建日志"

--- a/app/src/main/java/com/webtoapp/core/update/ApkUpdateInstaller.kt
+++ b/app/src/main/java/com/webtoapp/core/update/ApkUpdateInstaller.kt
@@ -1,108 +1,165 @@
 package com.webtoapp.core.update
 
-import android.app.DownloadManager
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
-import android.database.Cursor
-import android.net.Uri
-import android.os.Environment
-import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
 import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.core.network.NetworkModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.Request
 import java.io.File
 import java.security.MessageDigest
+
+/**
+ * States emitted by [download]. The UI renders a deterministic view per state.
+ *
+ * [DownloadProgress.totalBytes] is -1 when the server does not advertise Content-Length.
+ */
+sealed interface UpdateDownloadState {
+    data object Idle : UpdateDownloadState
+    data class Downloading(
+        val downloadedBytes: Long,
+        val totalBytes: Long,
+        val speedBytesPerSec: Long
+    ) : UpdateDownloadState
+    data object Verifying : UpdateDownloadState
+    data class Done(val file: File) : UpdateDownloadState
+    data class Failed(val message: String) : UpdateDownloadState
+}
 
 object ApkUpdateInstaller {
 
     private const val TAG = "ApkUpdateInstaller"
 
+    /** Directory under app-private external storage that the file manager scans. */
+    const val UPDATE_APK_DIR = "update_apks"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Last started download so a second "download" tap cancels / no-ops the previous. */
+    @Volatile
+    private var activeJob: Job? = null
+
+    /** Resolved on first use; reused across calls. */
+    private fun targetDir(context: android.content.Context): File {
+        val base = context.getExternalFilesDir(null)
+            ?: File(context.filesDir, "external").apply { mkdirs() }
+        return File(base, UPDATE_APK_DIR).apply { mkdirs() }
+    }
+
+    /**
+     * Streams [url] into `update_apks/web-to-app-<version>.apk` via OkHttp, emitting progress
+     * roughly once per second. On completion the file is SHA-256 verified against [expectedSha256]
+     * (if provided); on mismatch the file is deleted and [UpdateDownloadState.Failed] is emitted.
+     *
+     * The APK is **not** auto-installed; the caller decides when to launch the system installer
+     * (see `ApkBuilder.installApk`). This keeps the user in control and matches Android's rule
+     * that apps cannot silently install packages.
+     *
+     * @return the [Job] backing the download; cancel it to abort.
+     */
     fun download(
-        context: Context,
+        context: android.content.Context,
         url: String,
         version: String,
         expectedSha256: String? = null,
-        onStarted: (() -> Unit)? = null,
-        onVerificationFailed: (() -> Unit)? = null
-    ) {
-        try {
-            val appContext = context.applicationContext
-            val fileName = "web-to-app-$version.apk"
-
-            val targetDir = appContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
-            File(targetDir, fileName).takeIf { it.exists() }?.delete()
-
-            val request = DownloadManager.Request(Uri.parse(url)).apply {
-                setTitle("WebToApp $version")
-                setMimeType("application/vnd.android.package-archive")
-                setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                setDestinationInExternalFilesDir(appContext, Environment.DIRECTORY_DOWNLOADS, fileName)
-                setAllowedNetworkTypes(
-                    DownloadManager.Request.NETWORK_WIFI or DownloadManager.Request.NETWORK_MOBILE
-                )
-            }
-
-            val dm = appContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-            val downloadId = dm.enqueue(request)
-            registerCompletionReceiver(appContext, dm, downloadId, expectedSha256, onVerificationFailed)
-            onStarted?.invoke()
-        } catch (e: Exception) {
-            AppLogger.e(TAG, "Failed to enqueue update download", e)
-        }
-    }
-
-    private fun registerCompletionReceiver(
-        context: Context,
-        dm: DownloadManager,
-        downloadId: Long,
-        expectedSha256: String?,
-        onVerificationFailed: (() -> Unit)?
-    ) {
-        val receiver = object : BroadcastReceiver() {
-            override fun onReceive(ctx: Context?, intent: Intent?) {
-                val id = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1L) ?: -1L
-                if (id != downloadId) return
-                try {
-                    context.unregisterReceiver(this)
-                } catch (_: Exception) {
-                }
-                val localUri = resolveLocalUri(dm, downloadId) ?: return
-                val file = localUri.path?.let { File(it) }
-                if (expectedSha256 != null && file != null && file.exists()) {
+        onState: (UpdateDownloadState) -> Unit
+    ): Job {
+        activeJob?.cancel()
+        val appContext = context.applicationContext
+        val job = scope.launch {
+            try {
+                onState(UpdateDownloadState.Downloading(0L, -1L, 0L))
+                val file = streamToFile(appContext, url, version, onState)
+                if (expectedSha256 != null) {
+                    onState(UpdateDownloadState.Verifying)
                     val actual = sha256Of(file)
-                    if (actual != null && !actual.equals(expectedSha256, ignoreCase = true)) {
-                        AppLogger.e(TAG, "APK integrity check failed: expected=$expectedSha256 actual=$actual")
+                    if (actual == null || !actual.equals(expectedSha256, ignoreCase = true)) {
+                        AppLogger.e(
+                            TAG,
+                            "APK integrity check failed: expected=$expectedSha256 actual=$actual"
+                        )
                         file.delete()
-                        onVerificationFailed?.invoke()
-                        return
+                        onState(UpdateDownloadState.Failed("sha256-mismatch"))
+                        return@launch
                     }
                     AppLogger.i(TAG, "APK integrity verified (sha256 match)")
                 }
-                installApk(context, localUri)
+                onState(UpdateDownloadState.Done(file))
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "Update download failed", e)
+                onState(UpdateDownloadState.Failed(e.message ?: e.javaClass.simpleName))
             }
         }
-        ContextCompat.registerReceiver(
-            context,
-            receiver,
-            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-            ContextCompat.RECEIVER_EXPORTED
-        )
+        activeJob = job
+        return job
     }
 
-    private fun resolveLocalUri(dm: DownloadManager, downloadId: Long): Uri? {
-        val query = DownloadManager.Query().setFilterById(downloadId)
-        val cursor: Cursor? = dm.query(query)
-        cursor?.use {
-            if (it.moveToFirst()) {
-                val statusIndex = it.getColumnIndex(DownloadManager.COLUMN_STATUS)
-                val uriIndex = it.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
-                if (statusIndex >= 0 && it.getInt(statusIndex) == DownloadManager.STATUS_SUCCESSFUL && uriIndex >= 0) {
-                    return it.getString(uriIndex)?.let { s -> Uri.parse(s) }
+    fun cancel() {
+        activeJob?.cancel()
+        activeJob = null
+    }
+
+    private suspend fun streamToFile(
+        context: android.content.Context,
+        url: String,
+        version: String,
+        onState: (UpdateDownloadState) -> Unit
+    ): File {
+        val dir = targetDir(context)
+        val fileName = "web-to-app-$version.apk"
+        // Wipe stale copies of the same name so a partial previous download never resumes silently.
+        File(dir, fileName).takeIf { it.exists() }?.delete()
+        val target = File(dir, fileName)
+
+        val response = NetworkModule.downloadClient.newCall(Request.Builder().url(url).build()).execute()
+        if (!response.isSuccessful) {
+            response.close()
+            throw IllegalStateException("HTTP ${response.code}")
+        }
+        val body = response.body ?: throw IllegalStateException("empty response body")
+        val total = body.contentLength()
+
+        body.byteStream().use { input ->
+            target.outputStream().buffered().use { output ->
+                val buffer = ByteArray(64 * 1024)
+                var downloaded = 0L
+                var windowStartBytes = 0L
+                var windowStartTime = System.currentTimeMillis()
+                var lastEmit = 0L
+                while (true) {
+                    // ensureActive so cancel() propagates promptly.
+                    kotlinx.coroutines.coroutineScope { ensureActive() }
+                    val read = input.read(buffer)
+                    if (read == -1) break
+                    output.write(buffer, 0, read)
+                    downloaded += read
+
+                    val now = System.currentTimeMillis()
+                    val elapsed = now - windowStartTime
+                    if (now - lastEmit >= 1000L || (total > 0 && downloaded == total)) {
+                        val speed = if (elapsed > 0) {
+                            (downloaded - windowStartBytes) * 1000L / elapsed
+                        } else 0L
+                        onState(UpdateDownloadState.Downloading(downloaded, total, speed))
+                        lastEmit = now
+                        // reset sampling window so speed reflects the recent second, not whole run.
+                        windowStartBytes = downloaded
+                        windowStartTime = now
+                    }
                 }
+                output.flush()
+                // final emit so the bar reaches 100% with exact totals.
+                onState(UpdateDownloadState.Downloading(downloaded, total.coerceAtLeast(downloaded), 0L))
             }
         }
-        return null
+        return target
     }
 
     private fun sha256Of(file: File): String? {
@@ -119,25 +176,6 @@ object ApkUpdateInstaller {
         } catch (e: Exception) {
             AppLogger.w(TAG, "Failed to compute sha256: ${e.message}")
             null
-        }
-    }
-
-    private fun installApk(context: Context, localUri: Uri) {
-        try {
-            val installUri = if (localUri.scheme == "file") {
-                val file = File(localUri.path ?: return)
-                FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
-            } else {
-                localUri
-            }
-            val intent = Intent(Intent.ACTION_VIEW).apply {
-                setDataAndType(installUri, "application/vnd.android.package-archive")
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }
-            context.startActivity(intent)
-        } catch (e: Exception) {
-            AppLogger.e(TAG, "Failed to launch APK installer", e)
         }
     }
 }

--- a/app/src/main/java/com/webtoapp/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AboutScreen.kt
@@ -132,26 +132,43 @@ private fun AuthorHeroCard(
     }
     var isCheckingUpdate by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     var showUpdateDialog by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+    var downloadState by androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateOf<com.webtoapp.core.update.UpdateDownloadState>(
+            com.webtoapp.core.update.UpdateDownloadState.Idle
+        )
+    }
+    val apkBuilder = remember(context) { com.webtoapp.core.apkbuilder.ApkBuilder(context.applicationContext) }
 
     if (showUpdateDialog) {
         UpdateCheckDialog(
             isChecking = isCheckingUpdate,
             result = updateResult,
             currentVersionName = versionName,
+            downloadState = downloadState,
             onDownload = { info ->
                 com.webtoapp.core.update.ApkUpdateInstaller.download(
                     context = context,
                     url = info.downloadUrl,
                     version = info.version,
                     expectedSha256 = info.sha256,
-                    onVerificationFailed = {
-                        Toast.makeText(context, Strings.updateVerificationFailed, Toast.LENGTH_LONG).show()
-                    }
+                    onState = { state -> downloadState = state }
                 )
-                Toast.makeText(context, Strings.updateDownloadStarted, Toast.LENGTH_LONG).show()
-                showUpdateDialog = false
             },
-            onDismiss = { showUpdateDialog = false }
+            onCancelDownload = {
+                com.webtoapp.core.update.ApkUpdateInstaller.cancel()
+                downloadState = com.webtoapp.core.update.UpdateDownloadState.Idle
+            },
+            onInstall = { file ->
+                val started = apkBuilder.installApk(file)
+                if (!started) {
+                    Toast.makeText(context, Strings.fileManagerInstallFailed, Toast.LENGTH_SHORT).show()
+                }
+            },
+            onDismiss = {
+                com.webtoapp.core.update.ApkUpdateInstaller.cancel()
+                showUpdateDialog = false
+                downloadState = com.webtoapp.core.update.UpdateDownloadState.Idle
+            }
         )
     }
 
@@ -527,11 +544,21 @@ private fun UpdateCheckDialog(
     isChecking: Boolean,
     result: com.webtoapp.core.update.UpdateChecker.Result?,
     currentVersionName: String,
+    downloadState: com.webtoapp.core.update.UpdateDownloadState,
     onDownload: (com.webtoapp.core.update.UpdateChecker.ReleaseInfo) -> Unit,
+    onCancelDownload: () -> Unit,
+    onInstall: (java.io.File) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val available = result as? com.webtoapp.core.update.UpdateChecker.Result.UpdateAvailable
+    val downloading = downloadState is com.webtoapp.core.update.UpdateDownloadState.Downloading ||
+        downloadState is com.webtoapp.core.update.UpdateDownloadState.Verifying
+
     androidx.compose.material3.AlertDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            // Block dismiss via outside touch while a download is in flight.
+            if (!downloading) onDismiss()
+        },
         icon = {
             Icon(Icons.Outlined.Sync, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
         },
@@ -549,44 +576,12 @@ private fun UpdateCheckDialog(
                             Text(Strings.updateChecking, style = MaterialTheme.typography.bodyMedium)
                         }
                     }
-                    result is com.webtoapp.core.update.UpdateChecker.Result.UpdateAvailable -> {
-                        val info = result.info
-                        Text(
-                            Strings.updateAvailableTitle,
-                            style = MaterialTheme.typography.titleSmall,
-                            color = MaterialTheme.colorScheme.primary
+                    available != null -> {
+                        UpdateAvailableContent(
+                            info = available.info,
+                            currentVersion = available.currentVersion,
+                            downloadState = downloadState
                         )
-                        Spacer(Modifier.height(8.dp))
-                        Text(
-                            "${Strings.updateNewVersionLabel}: v${info.version}",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Text(
-                            "${Strings.updateCurrentVersionLabel}: v${result.currentVersion}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        if (info.sizeBytes > 0) {
-                            Text(
-                                "${Strings.updateSizeLabel}: ${formatBytes(info.sizeBytes)}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        if (info.releaseNotes.isNotBlank()) {
-                            Spacer(Modifier.height(12.dp))
-                            Text(
-                                Strings.updateReleaseNotesLabel,
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                info.releaseNotes,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                        }
                     }
                     result is com.webtoapp.core.update.UpdateChecker.Result.UpToDate -> {
                         Text(Strings.updateUpToDate, style = MaterialTheme.typography.bodyMedium)
@@ -612,27 +607,169 @@ private fun UpdateCheckDialog(
             }
         },
         confirmButton = {
-            val available = result as? com.webtoapp.core.update.UpdateChecker.Result.UpdateAvailable
-            if (available != null) {
-                androidx.compose.material3.TextButton(
-                    onClick = { onDownload(available.info) }
-                ) {
-                    Text(Strings.updateDownloadButton)
+            when {
+                // Download finished: show Install.
+                downloadState is com.webtoapp.core.update.UpdateDownloadState.Done -> {
+                    androidx.compose.material3.TextButton(onClick = {
+                        onInstall(downloadState.file)
+                    }) {
+                        Text(Strings.install)
+                    }
                 }
-            } else {
-                androidx.compose.material3.TextButton(onClick = onDismiss) {
-                    Text(Strings.close)
+                // Download failed: Retry.
+                downloadState is com.webtoapp.core.update.UpdateDownloadState.Failed && available != null -> {
+                    androidx.compose.material3.TextButton(onClick = { onDownload(available.info) }) {
+                        Text(Strings.updateRetry)
+                    }
+                }
+                // Downloading / verifying: Cancel.
+                downloading -> {
+                    androidx.compose.material3.TextButton(onClick = onCancelDownload) {
+                        Text(Strings.updateCancelDownload)
+                    }
+                }
+                // Update available, idle: Download.
+                available != null -> {
+                    androidx.compose.material3.TextButton(onClick = { onDownload(available.info) }) {
+                        Text(Strings.updateDownloadButton)
+                    }
+                }
+                else -> {
+                    androidx.compose.material3.TextButton(onClick = onDismiss) {
+                        Text(Strings.close)
+                    }
                 }
             }
         },
         dismissButton = {
-            val available = result as? com.webtoapp.core.update.UpdateChecker.Result.UpdateAvailable
-            if (available != null) {
-                androidx.compose.material3.TextButton(onClick = onDismiss) {
-                    Text(Strings.close)
-                }
+            androidx.compose.material3.TextButton(onClick = onDismiss) {
+                Text(Strings.close)
             }
         }
+    )
+}
+
+@Composable
+private fun UpdateAvailableContent(
+    info: com.webtoapp.core.update.UpdateChecker.ReleaseInfo,
+    currentVersion: String,
+    downloadState: com.webtoapp.core.update.UpdateDownloadState
+) {
+    Text(
+        Strings.updateAvailableTitle,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.primary
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+        "${Strings.updateNewVersionLabel}: v${info.version}",
+        style = MaterialTheme.typography.bodyMedium
+    )
+    Text(
+        "${Strings.updateCurrentVersionLabel}: v$currentVersion",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+    if (info.sizeBytes > 0) {
+        Text(
+            "${Strings.updateSizeLabel}: ${formatBytes(info.sizeBytes)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    Spacer(Modifier.height(12.dp))
+
+    when (downloadState) {
+        is com.webtoapp.core.update.UpdateDownloadState.Downloading -> {
+            DownloadProgressRow(
+                downloaded = downloadState.downloadedBytes,
+                total = downloadState.totalBytes,
+                speed = downloadState.speedBytesPerSec
+            )
+        }
+        com.webtoapp.core.update.UpdateDownloadState.Verifying -> {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                androidx.compose.material3.CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(Strings.updateVerifying, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        is com.webtoapp.core.update.UpdateDownloadState.Done -> {
+            Text(
+                Strings.updateInstallReady,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                Strings.updateReadyHint,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        is com.webtoapp.core.update.UpdateDownloadState.Failed -> {
+            Text(
+                Strings.updateDownloadFailed,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.error
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                downloadState.message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        com.webtoapp.core.update.UpdateDownloadState.Idle -> {
+            if (info.releaseNotes.isNotBlank()) {
+                Text(
+                    Strings.updateReleaseNotesLabel,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    info.releaseNotes,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadProgressRow(downloaded: Long, total: Long, speed: Long) {
+    val percent = if (total > 0) {
+        (downloaded.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+    } else {
+        // indeterminate when Content-Length unknown
+        -1f
+    }
+    Text(Strings.updateDownloading, style = MaterialTheme.typography.labelMedium)
+    Spacer(Modifier.height(6.dp))
+    if (percent >= 0f) {
+        androidx.compose.material3.LinearProgressIndicator(
+            progress = { percent },
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    } else {
+        androidx.compose.material3.LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+    Spacer(Modifier.height(6.dp))
+    val percentText = if (percent >= 0f) "${(percent * 100).toInt()}% · " else ""
+    val totalText = if (total > 0) "${formatBytes(downloaded)} / ${formatBytes(total)}" else formatBytes(downloaded)
+    Text(
+        "$percentText$totalText · ${formatBytes(speed)}${Strings.updatePerSec}",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
     )
 }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/FileManagerScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/FileManagerScreen.kt
@@ -100,12 +100,13 @@ private enum class FileSection(val dirName: String) {
     APK("built_apks"),
     AAB("built_aabs"),
     CLONED("cloned_apks"),
+    UPDATE_APKS("update_apks"),
     LOGS("build_logs"),
     USER_PROJECTS("");
 
     val isLogs: Boolean get() = this == LOGS
     val isUserProjects: Boolean get() = this == USER_PROJECTS
-    val canInstall: Boolean get() = this == APK || this == CLONED
+    val canInstall: Boolean get() = this == APK || this == CLONED || this == UPDATE_APKS
     val canShare: Boolean get() = this != USER_PROJECTS
     val canOpen: Boolean get() = this == AAB || this == LOGS
 }
@@ -964,6 +965,7 @@ private fun sectionLabel(section: FileSection): String = when (section) {
     FileSection.APK -> Strings.fileManagerSectionApk
     FileSection.AAB -> Strings.fileManagerSectionAab
     FileSection.CLONED -> Strings.fileManagerSectionCloned
+    FileSection.UPDATE_APKS -> Strings.fileManagerSectionUpdateApks
     FileSection.LOGS -> Strings.fileManagerSectionLogs
     FileSection.USER_PROJECTS -> Strings.fileManagerSectionUserFiles
 }
@@ -972,6 +974,7 @@ private fun sectionIcon(section: FileSection): ImageVector = when {
     section.isLogs -> Icons.AutoMirrored.Outlined.Article
     section.isUserProjects -> Icons.Outlined.FolderShared
     section == FileSection.APK || section == FileSection.CLONED -> Icons.Outlined.Android
+    section == FileSection.UPDATE_APKS -> Icons.Outlined.GetApp
     else -> Icons.Outlined.Folder
 }
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -201,7 +201,7 @@ entry mirrors the module manifest plus a `path` (folder name) and a
 
 `minAppVersion` lets you ship a module that needs APIs only present from a
 specific WebToApp `versionCode` onwards — older clients hide the entry.
-The current `versionCode` is **51** (`v2.4.0`); set this only if you
+The current `versionCode` is **52** (`v2.4.1`); set this only if you
 genuinely depend on a newer build.
 
 `iconUrl` is optional. Either a relative path (`"icon.png"`, `"icon.svg"`,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 51
-        versionName = "2.4.0"
+        versionCode = 52
+        versionName = "2.4.1"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
Closes #474

## Summary

Reworks the About → Check-for-updates download flow end to end, plus a version bump to 2.4.1.

## Changes

**Self-managed download (replaces system DownloadManager)**
- `ApkUpdateInstaller` rewritten to stream via `NetworkModule.downloadClient` (OkHttp). Emits a `UpdateDownloadState` sealed callback: `Idle / Downloading(downloaded, total, speed) / Verifying / Done(file) / Failed(msg)`. Progress throttled to ~1s with a rolling speed window; `cancel()` aborts promptly; SHA-256 mismatch deletes the file.
- No longer auto-launches the system installer — `Done(file)` only; the UI decides when to install.
- Download target moved from system Downloads to `getExternalFilesDir(null)/update_apks/` so the File Manager can see it.

**About dialog (`UpdateCheckDialog`)**
- Rewritten as a state machine: checking → update available (Download) → downloading (live progress bar + speed + downloaded/total) → verifying → done (Install button) → failed (Retry).
- Button relabelled **"Download"** (was "Download & install"). A separate **Install** button appears only after a verified download; tapping it launches the system installer via `ApkBuilder.installApk`.
- Download-in-flight blocks outside-touch dismissal to prevent accidental cancellation.

**File Manager**
- New `UPDATE_APKS("update_apks")` section ("Update Packages", 10 languages) with `canInstall` / `canShare`. Scanned automatically by the existing `scanAllSections` logic — the downloaded APK is immediately visible, installable, shareable, and deletable, consistent with the built-APK section.

**i18n** (all 10 languages, parity-test verified)
- `updateDownloadButton`: "Download & install" → "Download".
- New: `updateInstallReady`, `updateDownloading`, `updateVerifying`, `updateCancelDownload`, `updateRetry`, `updateDownloadFailed`, `updateReadyHint`, `updatePerSec`, `fileManagerSectionUpdateApks`.

**Version bump**
- `versionCode` 51 → 52, `versionName` 2.4.0 → 2.4.1 in `app` + `shell`. Synced in `CONTRIBUTING.md` (EN + ZH) and `modules/README.md`.

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] `:app:testDebugUnitTest --tests com.webtoapp.core.i18n.* --tests com.webtoapp.core.update.*` — all pass (parity + update)
- [x] No system `DownloadManager` / `BroadcastReceiver` residue in the update package
- [x] New strings cover all 10 languages (enforced by `StringsKtTranslationParityTest`)

## Impact / risk

- Low. Download now runs in an IO coroutine scoped to the installer singleton; progress is throttled. File Manager section is additive. No new dependencies (OkHttp + `formatFileSize` already in-tree). The dialog dismiss guard only affects the update dialog.