### PR TITLE
fix(delete): clean up orphaned source project dir when deleting an app

### DIFF
--- a/app/src/main/java/com/webtoapp/core/app/ProjectDirCleaner.kt
+++ b/app/src/main/java/com/webtoapp/core/app/ProjectDirCleaner.kt
@@ -1,0 +1,112 @@
+package com.webtoapp.core.app
+
+import android.content.Context
+import com.webtoapp.core.golang.GoRuntime
+import com.webtoapp.core.nodejs.NodeRuntime
+import com.webtoapp.core.php.PhpAppRuntime
+import com.webtoapp.core.python.PythonRuntime
+import com.webtoapp.core.wordpress.WordPressManager
+import com.webtoapp.data.model.AppType
+import com.webtoapp.data.model.WebApp
+import com.webtoapp.core.logging.AppLogger
+import java.io.File
+
+/**
+ * Deletes the on-disk project directory owned by a [WebApp] when the app is removed.
+ *
+ * Each runtime-backed app type stores its source files under `filesDir/<root>/<projectId>`
+ * (e.g. `wordpress_projects/<id>`, `nodejs_projects/<id>`). [MainViewModel.deleteApp] previously
+ * only dropped the database row, leaving these directories as orphans that accumulated storage
+ * (notably the WordPress SQLite DB + wp-content). This resolves the orphaned-project bug reported
+ * when deleting a WordPress app left its files behind.
+ *
+ * Exported artifacts (built_apks/, built_aabs/) are intentionally NOT touched — those are the
+ * user's deliverables and independent of the source project.
+ *
+ * Safe by design: it only deletes directories it resolves through the canonical runtime helpers
+ * (or, for HTML, the stored projectId / absolute projectDir), and only when they actually live
+ * under the app's private filesDir. It never follows an arbitrary absolute path outside the
+ * sandbox, so a corrupted projectDir field cannot cause data loss elsewhere.
+ */
+object ProjectDirCleaner {
+
+    private const val TAG = "ProjectDirCleaner"
+
+    /** Returns the list of directories that were deleted (empty if nothing applied). */
+    fun deleteForApp(context: Context, app: WebApp): List<File> {
+        val appContext = context.applicationContext
+        val sandboxRoot = appContext.filesDir.canonicalFile
+        val deleted = mutableListOf<File>()
+
+        fun deleteIfSandboxed(dir: File) {
+            try {
+                if (!dir.exists()) return
+                val canonical = dir.canonicalFile
+                // Guard: only delete inside our own filesDir. A tampered/absolute projectDir must
+                // never let us wipe an arbitrary location.
+                if (!canonical.path.startsWith(sandboxRoot.path)) {
+                    AppLogger.w(TAG, "Refusing to delete dir outside filesDir: $canonical")
+                    return
+                }
+                if (dir.deleteRecursively()) {
+                    deleted += canonical
+                    AppLogger.i(TAG, "Deleted project dir: $canonical")
+                } else {
+                    AppLogger.w(TAG, "Failed to delete project dir: $canonical")
+                }
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "Error deleting project dir $dir", e)
+            }
+        }
+
+        when (app.appType) {
+            AppType.WORDPRESS -> {
+                app.wordpressConfig?.projectId?.takeIf { it.isNotBlank() }?.let { pid ->
+                    deleteIfSandboxed(WordPressManager.getProjectDir(appContext, pid))
+                }
+            }
+            AppType.NODEJS_APP -> {
+                app.nodejsConfig?.projectId?.takeIf { it.isNotBlank() }?.let { pid ->
+                    deleteIfSandboxed(NodeRuntime(appContext).getProjectDir(pid))
+                }
+            }
+            AppType.PHP_APP -> {
+                app.phpAppConfig?.projectId?.takeIf { it.isNotBlank() }?.let { pid ->
+                    deleteIfSandboxed(PhpAppRuntime(appContext).getProjectDir(pid))
+                }
+            }
+            AppType.PYTHON_APP -> {
+                app.pythonAppConfig?.projectId?.takeIf { it.isNotBlank() }?.let { pid ->
+                    deleteIfSandboxed(PythonRuntime(appContext).getProjectDir(pid))
+                }
+            }
+            AppType.GO_APP -> {
+                app.goAppConfig?.projectId?.takeIf { it.isNotBlank() }?.let { pid ->
+                    deleteIfSandboxed(GoRuntime(appContext).getProjectDir(pid))
+                }
+            }
+            AppType.FRONTEND -> {
+                // Frontend projects live under frontend_builds/<projectId>.
+                app.htmlConfig?.projectId?.takeIf { it.isNotBlank() }?.let { pid ->
+                    deleteIfSandboxed(File(appContext.filesDir, "frontend_builds/$pid"))
+                }
+            }
+            AppType.HTML, AppType.MULTI_WEB -> {
+                // HTML projects: prefer the stored absolute projectDir (imported HTML), fall back
+                // to html_projects/<projectId>. MULTI_WEB reuses the html_projects storage.
+                val cfg = app.htmlConfig
+                val pid = cfg?.projectId?.takeIf { it.isNotBlank() }
+                val importedDir = cfg?.projectDir?.takeIf { it.isNotBlank() }?.let(::File)
+                if (importedDir != null) {
+                    deleteIfSandboxed(importedDir)
+                } else if (pid != null) {
+                    deleteIfSandboxed(File(appContext.filesDir, "html_projects/$pid"))
+                }
+            }
+            // WEB / IMAGE / VIDEO / GALLERY have no source project directory on disk.
+            AppType.WEB, AppType.IMAGE, AppType.VIDEO, AppType.GALLERY -> { }
+        }
+
+        return deleted
+    }
+}

--- a/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/viewmodel/MainViewModel.kt
@@ -131,11 +131,17 @@ class MainViewModel(
     fun deleteAppById(id: Long) {
         viewModelScope.launch {
             try {
+                // Fetch the full WebApp before deleting the DB row so we can resolve the project
+                // directory and clean it up (otherwise wordpress_projects/<id> etc. are orphaned).
+                val webApp = repository.getWebApp(id)
                 repository.deleteWebAppById(id)
                 withContext(Dispatchers.IO) {
                     com.webtoapp.core.script.UserScriptStorage.deleteScriptsForApp(
                         getApplication(), id
                     )
+                    if (webApp != null) {
+                        com.webtoapp.core.app.ProjectDirCleaner.deleteForApp(getApplication(), webApp)
+                    }
                 }
                 _uiState.value = UiState.Success(Strings.appDeleted)
             } catch (e: Exception) {
@@ -460,6 +466,9 @@ class MainViewModel(
                     com.webtoapp.core.script.UserScriptStorage.deleteScriptsForApp(
                         getApplication(), webApp.id
                     )
+                    // Remove the on-disk project directory (e.g. wordpress_projects/<id>) so the
+                    // source files — including the WordPress SQLite DB — don't linger as orphans.
+                    com.webtoapp.core.app.ProjectDirCleaner.deleteForApp(getApplication(), webApp)
                 }
                 _uiState.value = UiState.Success(Strings.appDeleted)
             } catch (e: Exception) {


### PR DESCRIPTION
Closes #476

## Summary

Deleting a runtime-backed app left its source project directory orphaned on disk. This adds a `ProjectDirCleaner` that resolves and deletes the project dir for all 8 runtime-backed app types, wired into both delete paths.

## Root cause

`MainViewModel.deleteApp()` / `deleteAppById()` dropped the DB row and userscripts but never resolved the app's `projectId` from its config, so `filesDir/<root>/<projectId>` (e.g. `wordpress_projects/<id>`) stayed behind forever — including, for WordPress, the SQLite DB and `wp-content/`.

## Changes

- **New `core/app/ProjectDirCleaner.kt`** — given a `WebApp`, resolves its project directory via the existing per-runtime helpers and deletes it:
  - WordPress → `WordPressManager.getProjectDir`
  - Node.js / PHP / Python / Go → `NodeRuntime` / `PhpAppRuntime` / `PythonRuntime` / `GoRuntime` `.getProjectDir`
  - Frontend → `frontend_builds/<projectId>`
  - HTML / Multi-Web → `HtmlConfig.projectDir` (imported absolute path) or `html_projects/<projectId>` (Multi-Web reuses the html_projects storage)
  - WEB / IMAGE / VIDEO / GALLERY → no project dir, skipped
- **Safety guard**: only deletes inside `filesDir` (canonical-path check). A tampered/corrupted `HtmlConfig.projectDir` absolute path can never trigger deletion outside the app sandbox.
- **Preserves exported artifacts** (`built_apks/`, `built_aabs/`) — those are the user's deliverables, independent of the source project.
- **`MainViewModel`**: wired into both `deleteApp(webApp)` and `deleteAppById(id)`. The latter now fetches the `WebApp` first (via `repository.getWebApp`) so it can resolve the project id before the row is dropped. `deleteCategory` is unchanged — it only unassigns apps (`clearCategoryId`), does not delete them.

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] Changes are host-only (`ui/viewmodel` + `core/app` are not shell-synced); no template rebuild needed.

## Impact / risk

Low. Pure addition to the delete path; the canonical-path guard prevents data loss outside the sandbox. Existing delete-by-id callers now do one extra DB read (`getWebApp`) before delete, which is negligible.