### PR TITLE
feat(runtime): configurable port-conflict policy for all runtime apps + fix preview-switch leak

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -4110,12 +4110,14 @@ private fun WebApp.buildWordpressBlock(): WordpressBlock = WordpressBlock(
     siteLanguage = wordpressConfig?.siteLanguage ?: "zh_CN",
     autoInstall = wordpressConfig?.autoInstall ?: true,
     phpPort = wordpressConfig?.phpPort ?: 0,
+    portConflictMode = wordpressConfig?.portConflictMode?.name ?: "AUTO_KILL",
     customPhpExtensions = wordpressConfig?.customPhpExtensions ?: emptyList()
 )
 
 private fun WebApp.buildNodejsBlock(): NodejsBlock = NodejsBlock(
     mode = nodejsConfig?.buildMode?.name ?: "STATIC",
     port = nodejsConfig?.serverPort ?: 0,
+    portConflictMode = nodejsConfig?.portConflictMode?.name ?: "AUTO_KILL",
     entryFile = nodejsConfig?.entryFile ?: "",
     envVars = nodejsConfig?.envVars ?: emptyMap(),
     customNodeExtensions = nodejsConfig?.customNodeExtensions ?: emptyList()
@@ -4126,6 +4128,7 @@ private fun WebApp.buildPhpAppBlock(): PhpAppBlock = PhpAppBlock(
     documentRoot = phpAppConfig?.documentRoot ?: "",
     entryFile = phpAppConfig?.entryFile ?: "index.php",
     port = phpAppConfig?.phpPort ?: 0,
+    portConflictMode = phpAppConfig?.portConflictMode?.name ?: "AUTO_KILL",
     envVars = phpAppConfig?.envVars ?: emptyMap(),
     phpExtensions = phpAppConfig?.phpExtensions ?: emptyMap(),
     customPhpExtensions = phpAppConfig?.customPhpExtensions ?: emptyList()
@@ -4137,6 +4140,7 @@ private fun WebApp.buildPythonAppBlock(): PythonAppBlock = PythonAppBlock(
     entryModule = pythonAppConfig?.entryModule ?: "",
     serverType = pythonAppConfig?.serverType ?: "builtin",
     port = pythonAppConfig?.serverPort ?: 0,
+    portConflictMode = pythonAppConfig?.portConflictMode?.name ?: "AUTO_KILL",
     envVars = pythonAppConfig?.envVars ?: emptyMap(),
     customPythonExtensions = pythonAppConfig?.customPythonExtensions ?: emptyList()
 )
@@ -4146,6 +4150,7 @@ private fun WebApp.buildGoAppBlock(): GoAppBlock = GoAppBlock(
     binaryName = goAppConfig?.binaryName ?: "",
     targetArch = goAppConfig?.targetArch ?: "arm64-v8a",
     port = goAppConfig?.serverPort ?: 0,
+    portConflictMode = goAppConfig?.portConflictMode?.name ?: "AUTO_KILL",
     staticDir = goAppConfig?.staticDir ?: "",
     envVars = goAppConfig?.envVars ?: emptyMap()
 )

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -798,12 +798,14 @@ data class WordpressBlock(
     val siteLanguage: String = "zh_CN",
     val autoInstall: Boolean = true,
     val phpPort: Int = 0,
+    val portConflictMode: String = "AUTO_KILL",
     val customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()
 )
 
 data class NodejsBlock(
     val mode: String = "STATIC",
     val port: Int = 0,
+    val portConflictMode: String = "AUTO_KILL",
     val entryFile: String = "",
     val envVars: Map<String, String> = emptyMap(),
     val customNodeExtensions: List<com.webtoapp.data.model.CustomNodeExtension> = emptyList()
@@ -814,6 +816,7 @@ data class PhpAppBlock(
     val documentRoot: String = "",
     val entryFile: String = "index.php",
     val port: Int = 0,
+    val portConflictMode: String = "AUTO_KILL",
     val envVars: Map<String, String> = emptyMap(),
     val phpExtensions: Map<String, Boolean> = emptyMap(),
     val customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()
@@ -825,6 +828,7 @@ data class PythonAppBlock(
     val entryModule: String = "",
     val serverType: String = "builtin",
     val port: Int = 0,
+    val portConflictMode: String = "AUTO_KILL",
     val envVars: Map<String, String> = emptyMap(),
     val customPythonExtensions: List<com.webtoapp.data.model.CustomPythonExtension> = emptyList()
 )
@@ -834,8 +838,9 @@ data class GoAppBlock(
     val binaryName: String = "",
     val targetArch: String = "arm64-v8a",
     val port: Int = 0,
+    val portConflictMode: String = "AUTO_KILL",
     val staticDir: String = "",
-    val envVars: Map<String, String> = emptyMap(),
+    val envVars: Map<String, String> = emptyMap()
 )
 
 data class MultiWebBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -497,12 +497,14 @@ internal object ApkConfigJsonFactory {
         "siteLanguage" to wordpress.siteLanguage,
         "autoInstall" to wordpress.autoInstall,
         "phpPort" to wordpress.phpPort,
+        "portConflictMode" to wordpress.portConflictMode,
         "customPhpExtensions" to wordpress.customPhpExtensions
     )
 
     private fun ApkConfig.nodejsConfigPayload(): Map<String, Any?> = linkedMapOf(
         "mode" to nodejs.mode,
         "port" to nodejs.port,
+        "portConflictMode" to nodejs.portConflictMode,
         "entryFile" to nodejs.entryFile,
         "envVars" to nodejs.envVars,
         "customNodeExtensions" to nodejs.customNodeExtensions
@@ -513,6 +515,7 @@ internal object ApkConfigJsonFactory {
         "documentRoot" to phpApp.documentRoot,
         "entryFile" to phpApp.entryFile,
         "port" to phpApp.port,
+        "portConflictMode" to phpApp.portConflictMode,
         "envVars" to phpApp.envVars,
         "phpExtensions" to phpApp.phpExtensions,
         "customPhpExtensions" to phpApp.customPhpExtensions
@@ -524,6 +527,7 @@ internal object ApkConfigJsonFactory {
         "entryModule" to pythonApp.entryModule,
         "serverType" to pythonApp.serverType,
         "port" to pythonApp.port,
+        "portConflictMode" to pythonApp.portConflictMode,
         "envVars" to pythonApp.envVars,
         "customPythonExtensions" to pythonApp.customPythonExtensions
     )
@@ -533,6 +537,7 @@ internal object ApkConfigJsonFactory {
         "binaryName" to goApp.binaryName,
         "targetArch" to goApp.targetArch,
         "port" to goApp.port,
+        "portConflictMode" to goApp.portConflictMode,
         "staticDir" to goApp.staticDir,
         "envVars" to goApp.envVars
     )

--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -80,6 +80,7 @@ class GoRuntime(private val context: Context) {
         projectDir: String,
         binaryName: String,
         port: Int = 0,
+        portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL,
         envVars: Map<String, String> = emptyMap()
     ): Int = withContext(Dispatchers.IO) {
         try {
@@ -100,7 +101,12 @@ class GoRuntime(private val context: Context) {
             }
 
             val projectId = projDir.name
-            val serverPort = PortManager.allocateForGo(projectId, port, conflictPolicy = if (port > 0) PortManager.ConflictPolicy.AUTO_KILL else PortManager.ConflictPolicy.REASSIGN)
+            val conflictPolicy = if (port > 0) {
+                PortManager.ConflictPolicy.fromName(portConflictMode.name)
+            } else {
+                PortManager.ConflictPolicy.REASSIGN
+            }
+            val serverPort = PortManager.allocateForGo(projectId, port, conflictPolicy = conflictPolicy)
             if (serverPort < 0) {
                 _serverState.value = ServerState.Error("无法分配端口")
                 return@withContext -1

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeRuntime.kt
@@ -41,6 +41,7 @@ class NodeRuntime(private val context: Context) {
         projectDir: String,
         entryFile: String = "index.js",
         port: Int = 0,
+        portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL,
         envVars: Map<String, String> = emptyMap(),
         customNodeExtensions: List<com.webtoapp.data.model.CustomNodeExtension> = emptyList()
     ): Int = withContext(Dispatchers.IO) {
@@ -68,6 +69,7 @@ class NodeRuntime(private val context: Context) {
                 projectDir = projectDir,
                 entryFile = entryFile,
                 portPref = port,
+                portConflictMode = portConflictMode.name,
                 envVars = effectiveEnvVars
             )
 
@@ -81,6 +83,7 @@ class NodeRuntime(private val context: Context) {
                     projectDir = projectDir,
                     entryFile = entryFile,
                     portPref = port,
+                    portConflictMode = portConflictMode.name,
                     envVars = envVars
                 )
             } else {

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -117,6 +117,7 @@ class NodeService : Service() {
         val projectDir = data.getString(NodeServiceProtocol.Keys.PROJECT_DIR).orEmpty()
         val entryFile = data.getString(NodeServiceProtocol.Keys.ENTRY_FILE) ?: "index.js"
         val portPref = data.getInt(NodeServiceProtocol.Keys.PORT_PREF, 0)
+        val portConflictModeName = data.getString(NodeServiceProtocol.Keys.PORT_CONFLICT_MODE) ?: "AUTO_KILL"
         val envBundle = data.getBundle(NodeServiceProtocol.Keys.ENV_VARS) ?: Bundle()
         val envVars = envBundle.keySet().associateWith { envBundle.getString(it).orEmpty() }
 
@@ -181,10 +182,15 @@ class NodeService : Service() {
             }
 
             val projectId = File(projectDir).name
+            val conflictPolicy = if (portPref > 0) {
+                PortManager.ConflictPolicy.fromName(portConflictModeName)
+            } else {
+                PortManager.ConflictPolicy.REASSIGN
+            }
             val serverPort = PortManager.allocateForNodeJs(
                 projectId,
                 portPref,
-                conflictPolicy = if (portPref > 0) PortManager.ConflictPolicy.AUTO_KILL else PortManager.ConflictPolicy.REASSIGN
+                conflictPolicy = conflictPolicy
             )
             if (serverPort == PortManager.PORT_CONFLICT) {
                 replyFailed(replyTo, requestId, "端口被占用: $portPref")

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeServiceClient.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeServiceClient.kt
@@ -94,6 +94,7 @@ object NodeServiceClient {
         projectDir: String,
         entryFile: String,
         portPref: Int,
+        portConflictMode: String = "AUTO_KILL",
         envVars: Map<String, String>
     ): StartResult = withContext(Dispatchers.IO) {
         ensureBound(context)
@@ -112,6 +113,7 @@ object NodeServiceClient {
             putString(NodeServiceProtocol.Keys.PROJECT_DIR, projectDir)
             putString(NodeServiceProtocol.Keys.ENTRY_FILE, entryFile)
             putInt(NodeServiceProtocol.Keys.PORT_PREF, portPref)
+            putString(NodeServiceProtocol.Keys.PORT_CONFLICT_MODE, portConflictMode)
             val envBundle = Bundle()
             envVars.forEach { (k, v) -> envBundle.putString(k, v) }
             putBundle(NodeServiceProtocol.Keys.ENV_VARS, envBundle)

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeServiceProtocol.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeServiceProtocol.kt
@@ -23,6 +23,7 @@ object NodeServiceProtocol {
         const val PROJECT_DIR = "projectDir"
         const val ENTRY_FILE = "entryFile"
         const val PORT_PREF = "portPref"
+        const val PORT_CONFLICT_MODE = "portConflictMode"
         const val ENV_VARS = "envVars"
         const val REQUEST_ID = "requestId"
 

--- a/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
@@ -69,6 +69,7 @@ class PhpAppRuntime(private val context: Context) {
         documentRoot: String = "",
         entryFile: String = "index.php",
         port: Int = 0,
+        portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL,
         envVars: Map<String, String> = emptyMap(),
         phpExtensions: Map<String, Boolean> = emptyMap(),
         customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()
@@ -109,7 +110,12 @@ class PhpAppRuntime(private val context: Context) {
             }
 
             val projectId = File(projectDir).name
-            val serverPort = PortManager.allocateForPhp(projectId, port, conflictPolicy = if (port > 0) PortManager.ConflictPolicy.AUTO_KILL else PortManager.ConflictPolicy.REASSIGN)
+            val conflictPolicy = if (port > 0) {
+                PortManager.ConflictPolicy.fromName(portConflictMode.name)
+            } else {
+                PortManager.ConflictPolicy.REASSIGN
+            }
+            val serverPort = PortManager.allocateForPhp(projectId, port, conflictPolicy = conflictPolicy)
             if (serverPort < 0) {
                 _serverState.value = ServerState.Error("无法分配端口")
                 return@withContext -1

--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -61,6 +61,7 @@ class PythonRuntime(private val context: Context) {
         entryFile: String = "app.py",
         framework: String = "raw",
         port: Int = 0,
+        portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL,
         envVars: Map<String, String> = emptyMap(),
         installDeps: Boolean = true,
         customPythonExtensions: List<com.webtoapp.data.model.CustomPythonExtension> = emptyList()
@@ -141,7 +142,12 @@ class PythonRuntime(private val context: Context) {
             }
 
             val projectId = projDir.name
-            val serverPort = PortManager.allocateForPython(projectId, port, conflictPolicy = if (port > 0) PortManager.ConflictPolicy.AUTO_KILL else PortManager.ConflictPolicy.REASSIGN)
+            val conflictPolicy = if (port > 0) {
+                PortManager.ConflictPolicy.fromName(portConflictMode.name)
+            } else {
+                PortManager.ConflictPolicy.REASSIGN
+            }
+            val serverPort = PortManager.allocateForPython(projectId, port, conflictPolicy = conflictPolicy)
             if (serverPort < 0) {
                 _serverState.value = ServerState.Error("无法分配端口")
                 return@withContext -1

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -796,6 +796,9 @@ data class WordPressShellConfig(
     @SerializedName("phpPort")
     val phpPort: Int = 0,
 
+    @SerializedName("portConflictMode")
+    val portConflictMode: String = "AUTO_KILL",
+
     @SerializedName("customPhpExtensions")
     val customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()
 )
@@ -806,6 +809,9 @@ data class NodeJsShellConfig(
 
     @SerializedName("port")
     val port: Int = 0,
+
+    @SerializedName("portConflictMode")
+    val portConflictMode: String = "AUTO_KILL",
 
     @SerializedName("entryFile")
     val entryFile: String = "",
@@ -829,6 +835,9 @@ data class PhpAppShellConfig(
 
     @SerializedName("port")
     val port: Int = 0,
+
+    @SerializedName("portConflictMode")
+    val portConflictMode: String = "AUTO_KILL",
 
     @SerializedName("envVars")
     val envVars: Map<String, String> = emptyMap(),
@@ -856,6 +865,9 @@ data class PythonAppShellConfig(
     @SerializedName("port")
     val port: Int = 0,
 
+    @SerializedName("portConflictMode")
+    val portConflictMode: String = "AUTO_KILL",
+
     @SerializedName("envVars")
     val envVars: Map<String, String> = emptyMap(),
 
@@ -875,6 +887,9 @@ data class GoAppShellConfig(
 
     @SerializedName("port")
     val port: Int = 0,
+
+    @SerializedName("portConflictMode")
+    val portConflictMode: String = "AUTO_KILL",
 
     @SerializedName("staticDir")
     val staticDir: String = "",

--- a/app/src/main/java/com/webtoapp/core/shell/ShellServerLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellServerLauncher.kt
@@ -15,6 +15,13 @@ object ShellServerLauncher {
 
     private const val TAG = "ShellServerLauncher"
 
+    /** Safely parse a stored port-conflict-mode string (from ShellConfig JSON) into the enum. */
+    private fun resolvePortConflictMode(name: String?): com.webtoapp.data.model.PortConflictMode {
+        return runCatching {
+            com.webtoapp.data.model.PortConflictMode.valueOf(name ?: "AUTO_KILL")
+        }.getOrDefault(com.webtoapp.data.model.PortConflictMode.AUTO_KILL)
+    }
+
     fun interface RuntimeStopper {
         fun stop()
     }
@@ -66,6 +73,7 @@ object ShellServerLauncher {
                 documentRoot = config.phpAppConfig.documentRoot,
                 entryFile = entryFile,
                 port = config.phpAppConfig.port,
+                portConflictMode = resolvePortConflictMode(config.phpAppConfig.portConflictMode),
                 envVars = config.phpAppConfig.envVars,
                 phpExtensions = config.phpAppConfig.phpExtensions,
                 customPhpExtensions = config.phpAppConfig.customPhpExtensions
@@ -119,6 +127,7 @@ object ShellServerLauncher {
                 entryFile = entryFile,
                 framework = framework,
                 port = pyConfig.port,
+                portConflictMode = resolvePortConflictMode(pyConfig.portConflictMode),
                 envVars = pyConfig.envVars,
                 installDeps = true,
                 customPythonExtensions = pyConfig.customPythonExtensions
@@ -178,6 +187,7 @@ object ShellServerLauncher {
                 projectDir = projectDir.absolutePath,
                 binaryName = binaryName,
                 port = goConfig.port,
+                portConflictMode = resolvePortConflictMode(goConfig.portConflictMode),
                 envVars = goConfig.envVars
             )
             if (port > 0) {
@@ -236,6 +246,7 @@ object ShellServerLauncher {
                 projectDir = projectDir.absolutePath,
                 entryFile = entryFile,
                 port = config.nodejsConfig.port,
+                portConflictMode = resolvePortConflictMode(config.nodejsConfig.portConflictMode),
                 envVars = envVars,
                 customNodeExtensions = config.nodejsConfig.customNodeExtensions
             )
@@ -276,6 +287,7 @@ object ShellServerLauncher {
             val port = runtime.startServer(
                 wpDir.absolutePath,
                 config.wordpressConfig.phpPort,
+                resolvePortConflictMode(config.wordpressConfig.portConflictMode),
                 config.wordpressConfig.customPhpExtensions
             )
             if (port <= 0) {

--- a/app/src/main/java/com/webtoapp/core/stats/LivePreviewServerLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/stats/LivePreviewServerLauncher.kt
@@ -192,9 +192,10 @@ object LivePreviewServerLauncher {
 
         val runtime = WordPressPhpRuntime(context)
         val port = runtime.startServer(
-            projectDir.absolutePath,
-            config.phpPort,
-            config.customPhpExtensions
+            documentRoot = projectDir.absolutePath,
+            port = config.phpPort,
+            portConflictMode = config.portConflictMode,
+            customPhpExtensions = config.customPhpExtensions
         )
         if (port <= 0) return null
 

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
@@ -54,7 +54,7 @@ class WordPressPhpRuntime(private val context: Context) {
         return WordPressDependencyManager.isPhpReady(context)
     }
 
-    suspend fun startServer(documentRoot: String, port: Int = 0, customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()): Int = withContext(Dispatchers.IO) {
+    suspend fun startServer(documentRoot: String, port: Int = 0, portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL, customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()): Int = withContext(Dispatchers.IO) {
         try {
 
             if (!isPhpAvailable()) {
@@ -75,7 +75,12 @@ class WordPressPhpRuntime(private val context: Context) {
             _serverState.value = ServerState.Starting
 
             val projectId = File(documentRoot).name
-            val serverPort = PortManager.allocateForPhp("wp:$projectId", port, conflictPolicy = if (port > 0) PortManager.ConflictPolicy.AUTO_KILL else PortManager.ConflictPolicy.REASSIGN)
+            val conflictPolicy = if (port > 0) {
+                PortManager.ConflictPolicy.fromName(portConflictMode.name)
+            } else {
+                PortManager.ConflictPolicy.REASSIGN
+            }
+            val serverPort = PortManager.allocateForPhp("wp:$projectId", port, conflictPolicy = conflictPolicy)
             if (serverPort < 0) {
                 _serverState.value = ServerState.Error("无法分配端口")
                 return@withContext -1

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -705,6 +705,7 @@ data class NodeJsConfig(
     val buildMode: NodeJsBuildMode = NodeJsBuildMode.API_BACKEND,
     val entryFile: String = "index.js",
     val serverPort: Int = 0,
+    val portConflictMode: PortConflictMode = PortConflictMode.AUTO_KILL,
     val envVars: Map<String, String> = emptyMap(),
     val hasNodeModules: Boolean = false,
     val nodeVersion: String = "",
@@ -727,6 +728,7 @@ data class WordPressConfig(
     val sourceType: String = "BLANK",
     val sourceProjectId: String = "",
     val phpPort: Int = 0,
+    val portConflictMode: PortConflictMode = PortConflictMode.AUTO_KILL,
     val customPhpExtensions: List<CustomPhpExtension> = emptyList()
 )
 
@@ -737,6 +739,7 @@ data class PhpAppConfig(
     val documentRoot: String = "",
     val entryFile: String = "index.php",
     val phpPort: Int = 0,
+    val portConflictMode: PortConflictMode = PortConflictMode.AUTO_KILL,
     val envVars: Map<String, String> = emptyMap(),
     val hasComposerJson: Boolean = false,
     val phpExtensions: Map<String, Boolean> = emptyMap(),
@@ -786,6 +789,7 @@ data class PythonAppConfig(
     val entryModule: String = "",
     val serverType: String = "builtin",
     val serverPort: Int = 0,
+    val portConflictMode: PortConflictMode = PortConflictMode.AUTO_KILL,
     val envVars: Map<String, String> = emptyMap(),
     val pythonVersion: String = "",
     val requirementsFile: String = "requirements.txt",
@@ -800,6 +804,7 @@ data class GoAppConfig(
     val binaryName: String = "",
     val targetArch: String = "arm64",
     val serverPort: Int = 0,
+    val portConflictMode: PortConflictMode = PortConflictMode.AUTO_KILL,
     val envVars: Map<String, String> = emptyMap(),
     val staticDir: String = ""
 )

--- a/app/src/main/java/com/webtoapp/ui/components/RuntimePortConfigSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/RuntimePortConfigSection.kt
@@ -1,0 +1,259 @@
+package com.webtoapp.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.webtoapp.core.i18n.Strings
+import com.webtoapp.data.model.PortConflictMode
+import com.webtoapp.ui.design.WtaSwitch
+
+/**
+ * Shared "local server port + conflict policy" configuration section for runtime-backed apps
+ * (Node.js / PHP / Python / Go / WordPress). Mirrors the section already used by HTML apps so
+ * every runtime type exposes the same controls.
+ *
+ * Semantics (matching HTML):
+ * - [port] == 0  → "auto-assign": the runtime asks PortManager for a free port (REASSIGN); the
+ *   conflict-mode radio is then irrelevant because a free port never conflicts.
+ * - [port] > 0   → fixed port: the conflict mode decides what happens if it is occupied.
+ *
+ * Defaults passed by callers: port = 0, portConflictMode = AUTO_KILL — the safest combination,
+ * since auto-assign never collides and never kills another process.
+ *
+ * @param title     section heading, e.g. Strings.portConflictTitle or a runtime-specific label.
+ * @param showTitle whether to render the heading row (some screens already group under a card).
+ */
+@Composable
+fun RuntimePortConfigSection(
+    port: Int,
+    portConflictMode: PortConflictMode,
+    onPortChange: (Int) -> Unit,
+    onPortConflictModeChange: (PortConflictMode) -> Unit,
+    modifier: Modifier = Modifier,
+    title: String = Strings.portConflictTitle,
+    showTitle: Boolean = true
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        if (showTitle) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.height(8.dp))
+        }
+
+        // Auto-assign toggle
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = Strings.portAutoAssign,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = Strings.portAutoAssignHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            WtaSwitch(
+                checked = port == 0,
+                onCheckedChange = { auto -> onPortChange(if (auto) 0 else 8080) }
+            )
+        }
+
+        // Fixed-port input (only visible when auto-assign is off)
+        AnimatedVisibility(visible = port > 0) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = Strings.portDefaultLabel,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                Surface(
+                    shape = RoundedCornerShape(10.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    modifier = Modifier.width(100.dp)
+                ) {
+                    BasicTextField(
+                        value = if (port > 0) port.toString() else "",
+                        onValueChange = { text ->
+                            val num = text.toIntOrNull()
+                            onPortChange(
+                                when {
+                                    num != null && num in 1024..65535 -> num
+                                    text.isEmpty() -> 0
+                                    else -> port
+                                }
+                            )
+                        },
+                        singleLine = true,
+                        textStyle = MaterialTheme.typography.bodyMedium.copy(
+                            textAlign = TextAlign.Center
+                        ),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider()
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = Strings.portConflictTitle,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(4.dp))
+
+        // AUTO_KILL
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = Strings.portConflictAutoKill,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = Strings.portConflictAutoKillHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            RadioButton(
+                selected = portConflictMode == PortConflictMode.AUTO_KILL,
+                onClick = { onPortConflictModeChange(PortConflictMode.AUTO_KILL) }
+            )
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        // ALERT
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = Strings.portConflictAlert,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = Strings.portConflictAlertHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            RadioButton(
+                selected = portConflictMode == PortConflictMode.ALERT,
+                onClick = { onPortConflictModeChange(PortConflictMode.ALERT) }
+            )
+        }
+    }
+}
+
+/**
+ * Conflict-policy selector only (no port input), for screens that already render their own
+ * port field (e.g. CreateNodeJsAppScreen's NodeJsPortCard) but still want the shared
+ * AUTO_KILL / ALERT radio section.
+ */
+@Composable
+fun RuntimePortConflictSelector(
+    portConflictMode: PortConflictMode,
+    onPortConflictModeChange: (PortConflictMode) -> Unit,
+    modifier: Modifier = Modifier,
+    accentColor: Color = MaterialTheme.colorScheme.primary
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = Strings.portConflictTitle,
+            style = MaterialTheme.typography.labelLarge,
+            color = accentColor
+        )
+        Spacer(Modifier.height(4.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = Strings.portConflictAutoKill,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = Strings.portConflictAutoKillHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            RadioButton(
+                selected = portConflictMode == PortConflictMode.AUTO_KILL,
+                onClick = { onPortConflictModeChange(PortConflictMode.AUTO_KILL) }
+            )
+        }
+
+        Spacer(Modifier.height(4.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = Strings.portConflictAlert,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = Strings.portConflictAlertHint,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            RadioButton(
+                selected = portConflictMode == PortConflictMode.ALERT,
+                onClick = { onPortConflictModeChange(PortConflictMode.ALERT) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
@@ -60,6 +60,8 @@ fun CreateGoAppScreen(
 
     var binaryName by remember { mutableStateOf("") }
     var staticDir by remember { mutableStateOf("") }
+    var serverPort by remember { mutableStateOf(0) }
+    var portConflictMode by remember { mutableStateOf(com.webtoapp.data.model.PortConflictMode.AUTO_KILL) }
     var envVars by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var newEnvKey by remember { mutableStateOf("") }
     var newEnvValue by remember { mutableStateOf("") }
@@ -110,6 +112,8 @@ fun CreateGoAppScreen(
                 app.goAppConfig?.let { config ->
                     binaryName = config.binaryName
                     staticDir = config.staticDir
+                    serverPort = config.serverPort
+                    portConflictMode = config.portConflictMode
                     envVars = config.envVars.toMutableMap()
                     detectedFramework = config.framework
                     projectId = config.projectId
@@ -258,7 +262,8 @@ fun CreateGoAppScreen(
                                 framework = detectedFramework ?: "raw",
                                 binaryName = binaryName,
                                 targetArch = targetArch,
-                                serverPort = 0,
+                                serverPort = serverPort,
+                                portConflictMode = portConflictMode,
                                 envVars = envVars,
                                 staticDir = staticDir,
                             ),
@@ -493,6 +498,14 @@ fun CreateGoAppScreen(
                         }
                     },
                     onRemove = { key -> envVars = envVars.toMutableMap().apply { remove(key) } }
+                )
+
+                Spacer(Modifier.height(12.dp))
+                com.webtoapp.ui.components.RuntimePortConfigSection(
+                    port = serverPort,
+                    portConflictMode = portConflictMode,
+                    onPortChange = { serverPort = it },
+                    onPortConflictModeChange = { portConflictMode = it }
                 )
             }
             }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateNodeJsAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateNodeJsAppScreen.kt
@@ -98,6 +98,7 @@ fun CreateNodeJsAppScreen(
 
     var detectedPort by remember { mutableStateOf<Int?>(null) }
     var customPort by remember { mutableStateOf("") }
+    var portConflictMode by remember { mutableStateOf(com.webtoapp.data.model.PortConflictMode.AUTO_KILL) }
 
     var nodeEngineVersion by remember { mutableStateOf<String?>(null) }
 
@@ -122,6 +123,7 @@ fun CreateNodeJsAppScreen(
                     projectId = config.projectId
                     selectedProjectDir = config.projectName
                     packageName = config.projectName
+                    portConflictMode = config.portConflictMode
                     if (config.serverPort > 0) {
                         detectedPort = config.serverPort
                         customPort = config.serverPort.toString()
@@ -337,6 +339,7 @@ fun CreateNodeJsAppScreen(
             buildMode = buildMode,
             entryFile = entryFile,
             serverPort = finalPort,
+            portConflictMode = portConflictMode,
             envVars = envVars,
             hasNodeModules = dependencies.isNotEmpty(),
             nodeVersion = nodeEngineVersion ?: "",
@@ -771,6 +774,13 @@ fun CreateNodeJsAppScreen(
                         detectedPort = detectedPort,
                         customPort = customPort,
                         onCustomPortChange = { customPort = it },
+                        accentColor = accentColor
+                    )
+
+                    Spacer(Modifier.height(8.dp))
+                    com.webtoapp.ui.components.RuntimePortConflictSelector(
+                        portConflictMode = portConflictMode,
+                        onPortConflictModeChange = { portConflictMode = it },
                         accentColor = accentColor
                     )
                 }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePhpAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePhpAppScreen.kt
@@ -67,6 +67,8 @@ fun CreatePhpAppScreen(
 
     var documentRoot by remember { mutableStateOf("") }
     var entryFile by remember { mutableStateOf("index.php") }
+    var phpPort by remember { mutableStateOf(0) }
+    var portConflictMode by remember { mutableStateOf(com.webtoapp.data.model.PortConflictMode.AUTO_KILL) }
     var envVars by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var newEnvKey by remember { mutableStateOf("") }
     var newEnvValue by remember { mutableStateOf("") }
@@ -117,6 +119,8 @@ fun CreatePhpAppScreen(
                 app.phpAppConfig?.let { config ->
                     documentRoot = config.documentRoot
                     entryFile = config.entryFile
+                    phpPort = config.phpPort
+                    portConflictMode = config.portConflictMode
                     envVars = config.envVars.toMutableMap()
                     detectedFramework = config.framework
                     projectId = config.projectId
@@ -365,6 +369,8 @@ fun CreatePhpAppScreen(
                                 framework = detectedFramework ?: "raw",
                                 documentRoot = documentRoot,
                                 entryFile = entryFile,
+                                phpPort = phpPort,
+                                portConflictMode = portConflictMode,
                                 envVars = envVars,
                                 hasComposerJson = localProjectDir?.let { File(it, "composer.json").exists() } ?: false,
                                 phpExtensions = phpExtensions,
@@ -591,6 +597,14 @@ fun CreatePhpAppScreen(
                         }
                     },
                     onRemove = { key -> envVars = envVars.toMutableMap().apply { remove(key) } }
+                )
+
+                Spacer(Modifier.height(12.dp))
+                com.webtoapp.ui.components.RuntimePortConfigSection(
+                    port = phpPort,
+                    portConflictMode = portConflictMode,
+                    onPortChange = { phpPort = it },
+                    onPortConflictModeChange = { portConflictMode = it }
                 )
             }
             }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
@@ -65,6 +65,8 @@ fun CreatePythonAppScreen(
     var entryFile by remember { mutableStateOf("app.py") }
     var entryModule by remember { mutableStateOf("") }
     var serverType by remember { mutableStateOf("builtin") }
+    var serverPort by remember { mutableStateOf(0) }
+    var portConflictMode by remember { mutableStateOf(com.webtoapp.data.model.PortConflictMode.AUTO_KILL) }
     var envVars by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var newEnvKey by remember { mutableStateOf("") }
     var newEnvValue by remember { mutableStateOf("") }
@@ -108,6 +110,8 @@ fun CreatePythonAppScreen(
                     entryFile = config.entryFile
                     entryModule = config.entryModule
                     serverType = config.serverType
+                    serverPort = config.serverPort
+                    portConflictMode = config.portConflictMode
                     envVars = config.envVars.toMutableMap()
                     customPythonExtensions = config.customPythonExtensions
                     detectedFramework = config.framework
@@ -351,6 +355,8 @@ fun CreatePythonAppScreen(
                                 entryFile = entryFile,
                                 entryModule = entryModule,
                                 serverType = serverType,
+                                serverPort = serverPort,
+                                portConflictMode = portConflictMode,
                                 envVars = envVars,
                                 requirementsFile = if (localProjectDir?.let { File(it, "requirements.txt").exists() } == true) "requirements.txt" else "",
                                 hasPipDeps = localProjectDir?.let { File(it, "requirements.txt").exists() } ?: false,
@@ -601,6 +607,14 @@ fun CreatePythonAppScreen(
                         }
                     },
                     onRemove = { key -> envVars = envVars.toMutableMap().apply { remove(key) } }
+                )
+
+                Spacer(Modifier.height(12.dp))
+                com.webtoapp.ui.components.RuntimePortConfigSection(
+                    port = serverPort,
+                    portConflictMode = portConflictMode,
+                    onPortChange = { serverPort = it },
+                    onPortConflictModeChange = { portConflictMode = it }
                 )
 
                 PythonExtensionsCard(

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateWordPressAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateWordPressAppScreen.kt
@@ -75,6 +75,9 @@ fun CreateWordPressAppScreen(
 
     var permalink by remember { mutableStateOf("postname") }
 
+    var phpPort by remember { mutableStateOf(0) }
+    var portConflictMode by remember { mutableStateOf(com.webtoapp.data.model.PortConflictMode.AUTO_KILL) }
+
     var siteLanguage by remember { mutableStateOf(Strings.wpDefaultSiteLanguageCode) }
 
     var detectedThemes by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -224,6 +227,8 @@ fun CreateWordPressAppScreen(
                                 siteLanguage = siteLanguage,
                                 autoInstall = true,
                                 sourceType = sourceType,
+                                phpPort = phpPort,
+                                portConflictMode = portConflictMode,
                                 customPhpExtensions = customPhpExtensions
                             ),
                             appIcon,
@@ -490,6 +495,14 @@ fun CreateWordPressAppScreen(
                 )
 
                 WpDbInfoCard(accentColor = accentColor)
+
+                Spacer(Modifier.height(12.dp))
+                com.webtoapp.ui.components.RuntimePortConfigSection(
+                    port = phpPort,
+                    portConflictMode = portConflictMode,
+                    onPortChange = { phpPort = it },
+                    onPortConflictModeChange = { portConflictMode = it }
+                )
             }
             }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -1058,28 +1058,28 @@ fun WebViewScreen(
     var statusBarBackgroundAlphaDark by remember { mutableFloatStateOf(1.0f) }
 
     var wordPressPreviewState by remember { mutableStateOf<WordPressPreviewState>(WordPressPreviewState.Idle) }
-    val phpRuntime = remember { WordPressPhpRuntime(context) }
+    val phpRuntime = remember(webApp?.id) { WordPressPhpRuntime(context) }
     val wpDownloadState by WordPressDependencyManager.downloadState.collectAsStateWithLifecycle()
     var wpRetryTrigger by remember { mutableIntStateOf(0) }
 
     var phpAppPreviewState by remember { mutableStateOf<PhpAppPreviewState>(PhpAppPreviewState.Idle) }
-    val phpAppRuntime = remember { PhpAppRuntime(context) }
+    val phpAppRuntime = remember(webApp?.id) { PhpAppRuntime(context) }
     val phpAppDownloadState by WordPressDependencyManager.downloadState.collectAsStateWithLifecycle()
     var phpAppRetryTrigger by remember { mutableIntStateOf(0) }
 
     var pythonAppPreviewState by remember { mutableStateOf<PythonAppPreviewState>(PythonAppPreviewState.Idle) }
-    val pythonRuntime = remember { com.webtoapp.core.python.PythonRuntime(context) }
-    val pythonHttpServer = remember { com.webtoapp.core.webview.LocalHttpServer(context) }
+    val pythonRuntime = remember(webApp?.id) { com.webtoapp.core.python.PythonRuntime(context) }
+    val pythonHttpServer = remember(webApp?.id) { com.webtoapp.core.webview.LocalHttpServer(context) }
     var pythonAppRetryTrigger by remember { mutableIntStateOf(0) }
 
     var nodeJsAppPreviewState by remember { mutableStateOf<NodeJsAppPreviewState>(NodeJsAppPreviewState.Idle) }
-    val nodeRuntime = remember { com.webtoapp.core.nodejs.NodeRuntime(context) }
-    val nodeHttpServer = remember { com.webtoapp.core.webview.LocalHttpServer(context) }
+    val nodeRuntime = remember(webApp?.id) { com.webtoapp.core.nodejs.NodeRuntime(context) }
+    val nodeHttpServer = remember(webApp?.id) { com.webtoapp.core.webview.LocalHttpServer(context) }
     var nodeJsAppRetryTrigger by remember { mutableIntStateOf(0) }
 
     var goAppPreviewState by remember { mutableStateOf<GoAppPreviewState>(GoAppPreviewState.Idle) }
-    val goRuntime = remember { com.webtoapp.core.golang.GoRuntime(context) }
-    val goHttpServer = remember { com.webtoapp.core.webview.LocalHttpServer(context) }
+    val goRuntime = remember(webApp?.id) { com.webtoapp.core.golang.GoRuntime(context) }
+    val goHttpServer = remember(webApp?.id) { com.webtoapp.core.webview.LocalHttpServer(context) }
     var goAppRetryTrigger by remember { mutableIntStateOf(0) }
 
     var autoRefreshController by remember { mutableStateOf<com.webtoapp.core.webview.AutoRefreshController?>(null) }
@@ -1519,7 +1519,7 @@ fun WebViewScreen(
             return@LaunchedEffect
         }
         WordPressManager.ensureDbPhpExists(context, wpDir)
-        val port = phpRuntime.startServer(wpDir.absolutePath, app.wordpressConfig?.phpPort ?: 0)
+        val port = phpRuntime.startServer(wpDir.absolutePath, app.wordpressConfig?.phpPort ?: 0, app.wordpressConfig?.portConflictMode ?: com.webtoapp.data.model.PortConflictMode.AUTO_KILL)
 
         if (port > 0) {
             val url = "http://127.0.0.1:$port/"
@@ -1639,6 +1639,7 @@ fun WebViewScreen(
             documentRoot = actualDocRoot,
             entryFile = actualEntryFile,
             port = config.phpPort,
+            portConflictMode = config.portConflictMode,
             envVars = config.envVars,
             phpExtensions = config.phpExtensions
         )
@@ -1796,6 +1797,7 @@ fun WebViewScreen(
                     entryFile = actualEntryFile,
                     framework = actualFramework,
                     port = config.serverPort,
+                    portConflictMode = config.portConflictMode,
                     envVars = config.envVars,
                     installDeps = config.hasPipDeps
                 )
@@ -1965,6 +1967,7 @@ fun WebViewScreen(
                     projectDir = projectDir.absolutePath,
                     entryFile = config.entryFile.ifBlank { "index.js" },
                     port = config.serverPort,
+                    portConflictMode = config.portConflictMode,
                     envVars = config.envVars,
                 )
 
@@ -2033,6 +2036,12 @@ fun WebViewScreen(
     DisposableEffect(nodeHttpServer) {
         onDispose {
             nodeHttpServer.stop()
+        }
+    }
+
+    DisposableEffect(nodeRuntime) {
+        onDispose {
+            nodeRuntime.stopServer()
         }
     }
 
@@ -2130,6 +2139,7 @@ fun WebViewScreen(
                         projectDir = projectDir.absolutePath,
                         binaryName = config.binaryName,
                         port = config.serverPort,
+                        portConflictMode = config.portConflictMode,
                         envVars = config.envVars
                     )
 


### PR DESCRIPTION
Closes #478

## Summary

Two fixes in one: a preview-switching bug where the wrong app's content loaded, plus making the port-conflict policy a universal, configurable setting for all 5 runtime-backed app types (matching what HTML apps already had).

## 1. Bug fix — preview switching loaded the wrong app

The 5 runtime objects in `WebViewActivity` (`nodeRuntime`/`phpRuntime`/`pythonRuntime`/`goRuntime`/`phpAppRuntime`) were created with `remember { }` **without a key**. Switching apps didn't dispose the previous runtime, so its server kept running and leaked into the next preview. `nodeRuntime` additionally lacked a `DisposableEffect { onDispose { stopServer() } }`, so its server was never stopped.

**Fix**: key all 5 `remember` calls by `webApp?.id` (switching apps disposes the old runtime → `stopServer` → clean start), and add the missing `DisposableEffect(nodeRuntime)`.

## 2. Feature — port-conflict policy as a universal setting

`port` + `portConflictMode` previously existed only on `HtmlConfig`. The 5 runtime configs had a `port` field but no `portConflictMode`; the start path hardcoded `if (port > 0) AUTO_KILL else REASSIGN`, invisible to the user.

**This threads `portConflictMode` through the full chain**, mirroring HtmlConfig, defaulting to the safest combination: `port = 0` (auto-assign) → always REASSIGN (free port, never kills another process).

| Layer | Change |
|-------|--------|
| Model (`WebApp.kt`) | `portConflictMode` added to 5 runtime configs |
| Export (`ApkConfig`/`ShellModeManager`/`ApkConfigJsonFactory`/`ApkBuilder`) | 5 blocks synced; `checkConfigFieldDrift` passes |
| Runtime (5 `startServer` + Node IPC) | accept `portConflictMode`, replace hardcoded policy; `port=0` still forces REASSIGN |
| Launchers (`ShellServerLauncher` + preview) | pass configured mode through |
| UI (5 `CreateXxxAppScreen`) | new shared `RuntimePortConfigSection` / `RuntimePortConflictSelector`; reuses HTML i18n strings (no new strings) |

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] `:shell:compileReleaseKotlin` — shell sync OK, app/shell consistent
- [x] `:app:testDebugUnitTest --tests com.webtoapp.core.port.*` — passes
- [x] `:app:checkConfigFieldDrift` — no drift
- [x] WebViewConfig coverage tests unaffected (WebViewConfig untouched)

## Impact / risk

Medium scope (22 files) but each change is mechanical and mirrors the existing HtmlConfig pattern. The bug fix is standard Compose keying. `startServer` params default to `AUTO_KILL` for backward compatibility. Default user-facing behavior (`port=0`) is strictly safer than before (always REASSIGN).