### PR TITLE
fix(apkbuilder): invalidate build cache on host upgrade via hostVersionCode

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
@@ -108,6 +108,7 @@ class ApkBuildCache(private val context: Context) {
         galleryItems: List<com.webtoapp.data.model.GalleryItem>,
         errorPageMediaPath: String?,
         nativeLibsFingerprint: String? = null,
+        hostVersionCode: Int = 0,
         forceFullRebuild: Boolean
     ): IncrementalPlan {
         val shellId = shellTemplateId(templateApk)
@@ -117,7 +118,8 @@ class ApkBuildCache(private val context: Context) {
             encryptionEnabled = encryptionEnabled,
             abiFilters = abiFilters,
             iconPath = webApp.iconPath,
-            nativeLibsFingerprint = nativeLibsFingerprint
+            nativeLibsFingerprint = nativeLibsFingerprint,
+            hostVersionCode = hostVersionCode
         )
         val content = contentFingerprint(
             config = config,
@@ -333,13 +335,21 @@ class ApkBuildCache(private val context: Context) {
         encryptionEnabled: Boolean,
         abiFilters: List<String>,
         iconPath: String?,
-        nativeLibsFingerprint: String? = null
+        nativeLibsFingerprint: String? = null,
+        hostVersionCode: Int = 0
     ): String {
         val parts = mutableListOf<String>()
         parts += "shell=$shellTemplateId"
         parts += "pkg=${config.packageName}"
         parts += "vc=${config.versionCode}"
         parts += "vn=${config.versionName}"
+        // Host app versionCode participates so a host upgrade (which may ship improved
+        // packaging/alignment/export logic) invalidates every cached unsigned APK, forcing a
+        // FULL rebuild that re-applies the latest logic. Without this, a user who built a
+        // NODEJS_APP on an older host and upgrades without re-downloading libnode.so would
+        // keep hitting REUSE_UNSIGNED and serving a stale APK (e.g. one with an unaligned
+        // libnode.so that dlopen rejects on Android 15+/16KB-page devices).
+        parts += "hostVc=$hostVersionCode"
         parts += "name=${config.appName}"
         parts += "type=${config.appType}"
         parts += "engine=${config.engineType}"

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -600,6 +600,7 @@ class ApkBuilder(private val context: Context) {
                 ?.let { File(context.filesDir, "html_projects/$it") }
 
             logger.section("Incremental Build Plan")
+            val hostVersionCode = rememberHostVersionCode()
             val incrementalPlan = buildCache.plan(
                 webApp = webApp,
                 packageName = packageName,
@@ -629,6 +630,7 @@ class ApkBuilder(private val context: Context) {
                 } else {
                     null
                 },
+                hostVersionCode = hostVersionCode,
                 forceFullRebuild = forceFullRebuild
             )
             logger.logKeyValue("incrementalMode", incrementalPlan.mode.name)
@@ -1987,6 +1989,33 @@ class ApkBuilder(private val context: Context) {
      * Returns null for non-Node.js apps (no native lib injection), which is treated as
      * "not applicable" by the cache and does not affect other app types' cache keys.
      */
+
+    @Volatile
+    private var cachedHostVersionCode: Int? = null
+
+    /**
+     * The host app's own versionCode, cached after first lookup. Fed into the incremental
+     * build cache's identity fingerprint so a host upgrade invalidates every cached unsigned
+     * APK (forcing FULL rebuild + re-alignment), even when the source libs and app config are
+     * unchanged.
+     */
+    private fun rememberHostVersionCode(): Int {
+        cachedHostVersionCode?.let { return it }
+        val code = try {
+            val info = context.packageManager.getPackageInfo(context.packageName, 0)
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                info.longVersionCode.toInt()
+            } else {
+                @Suppress("DEPRECATION")
+                info.versionCode
+            }
+        } catch (_: Exception) {
+            0
+        }
+        cachedHostVersionCode = code
+        return code
+    }
+
     private fun nativeLibsFingerprint(): String? {
         val nativeDir = File(context.applicationInfo.nativeLibraryDir)
         val bridge = File(nativeDir, "libnode_bridge.so")

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuildCacheTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/ApkBuildCacheTest.kt
@@ -289,4 +289,85 @@ class ApkBuildCacheTest {
         )
         assertThat(nullPlan.identityFingerprint).isNotEqualTo(withLibsPlan.identityFingerprint)
     }
+
+    @Test
+    fun `host versionCode change forces full rebuild instead of reuse`() {
+        val context = RuntimeEnvironment.getApplication()
+        val cache = ApkBuildCache(context)
+        cache.clearAll()
+
+        val webApp = com.webtoapp.data.model.WebApp(
+            id = 21,
+            name = "HostVcApp",
+            url = "https://example.com"
+        )
+        val template = File(context.cacheDir, "shell_hostvc.apk").apply {
+            writeBytes(ByteArray(16) { 9 })
+        }
+        val config = ApkConfig(
+            meta = MetaBlock(
+                appName = "HostVcApp",
+                packageName = "com.demo.hostvc",
+                targetUrl = "https://example.com",
+                versionCode = 1,
+                versionName = "1.0",
+                appType = "WEB"
+            )
+        )
+
+        // Build #1 with host versionCode 50 → cache miss → FULL; cache the unsigned APK.
+        val plan1 = cache.plan(
+            webApp = webApp,
+            packageName = "com.demo.hostvc",
+            config = config,
+            templateApk = template,
+            encryptionEnabled = false,
+            abiFilters = emptyList(),
+            projectDirs = emptyList(),
+            mediaContentPath = null,
+            splashMediaPath = null,
+            bgmPlaylistPaths = emptyList(),
+            htmlFiles = emptyList(),
+            galleryItems = emptyList(),
+            errorPageMediaPath = null,
+            hostVersionCode = 50,
+            forceFullRebuild = false
+        )
+        assertThat(plan1.mode).isEqualTo(IncrementalBuildMode.FULL)
+
+        val unsigned = File(context.cacheDir, "hostvc_unsigned.apk").apply {
+            writeBytes(ByteArray(64) { 1 })
+        }
+        cache.saveUnsigned(
+            webApp = webApp,
+            packageName = "com.demo.hostvc",
+            unsignedApk = unsigned,
+            identityFingerprint = plan1.identityFingerprint,
+            contentFingerprint = plan1.contentFingerprint,
+            shellTemplateId = plan1.shellTemplateId
+        )
+
+        // Same app + config + template, but the host just upgraded (versionCode 50 -> 51).
+        // The cache MUST NOT reuse the stale unsigned APK — a FULL rebuild is required so the
+        // latest export/packaging/alignment logic is re-applied.
+        val plan2 = cache.plan(
+            webApp = webApp,
+            packageName = "com.demo.hostvc",
+            config = config,
+            templateApk = template,
+            encryptionEnabled = false,
+            abiFilters = emptyList(),
+            projectDirs = emptyList(),
+            mediaContentPath = null,
+            splashMediaPath = null,
+            bgmPlaylistPaths = emptyList(),
+            htmlFiles = emptyList(),
+            galleryItems = emptyList(),
+            errorPageMediaPath = null,
+            hostVersionCode = 51,
+            forceFullRebuild = false
+        )
+        assertThat(plan2.mode).isEqualTo(IncrementalBuildMode.FULL)
+        assertThat(plan2.identityFingerprint).isNotEqualTo(plan1.identityFingerprint)
+    }
 }


### PR DESCRIPTION
Closes #480

## Summary

Closes the remaining blind spot from #470: a host upgrade did not invalidate the APK build cache when the source libs were unchanged, so a stale unaligned `libnode.so` could still be served to Android 15+ (16KB-page) devices.

## Root cause

`identityFingerprint` did not include the **host** app's versionCode — only the generated app's. When the host upgraded (improved `ElfAligner16k` / packaging) but the user did not re-download `libnode.so`, `nativeLibsFingerprint` (#470) was unchanged → fingerprint matched → `REUSE_UNSIGNED` served the stale cached APK.

`#470` caught *source-lib* changes; it did not catch *host-logic* changes when the source lib was identical.

## Fix

Include the host app's versionCode in `identityFingerprint` (`hostVc=...`). Every host upgrade invalidates all cached unsigned APKs → forces FULL rebuild → the latest alignment/packaging/export logic is re-applied.

| File | Change |
|------|--------|
| `ApkBuildCache.kt` | `identityFingerprint()` + `plan()` take `hostVersionCode` (default 0) |
| `ApkBuilder.kt` | `rememberHostVersionCode()` reads via PackageManager once (cached), passed to `plan()` |
| `ApkBuildCacheTest.kt` | new test: host versionCode 50→51 forces FULL, fingerprints differ |

Backwards compatible: default `0`; old cache meta without the field deserialises as `0` ≠ new host value → triggers FULL (the desired post-upgrade behaviour).

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] `:app:testDebugUnitTest --tests com.webtoapp.core.apkbuilder.*` — all pass (existing + new)
- [x] Host-only change (`apkbuilder` is not shell-synced); no template rebuild needed.

## Impact / risk

Low. One additional input to the identity fingerprint. The only behavioural change: after a host upgrade, the first build of each app is a FULL rebuild (slightly slower) — which is exactly what should happen to guarantee the latest pipeline logic is applied.