### PR TITLE
style(runtime): match port-config UI to the app's design system

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/RuntimePortConfigSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/RuntimePortConfigSection.kt
@@ -9,104 +9,88 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Lan
+import androidx.compose.material.icons.outlined.Shield
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Surface
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.PortConflictMode
 import com.webtoapp.ui.design.WtaSwitch
 
 /**
- * Shared "local server port + conflict policy" configuration section for runtime-backed apps
- * (Node.js / PHP / Python / Go / WordPress). Mirrors the section already used by HTML apps so
- * every runtime type exposes the same controls.
+ * Shared "local server + port + conflict policy" card for runtime-backed apps
+ * (Node.js / PHP / Python / Go / WordPress). Mirrors the controls HTML apps already have,
+ * wrapped in the project's standard [EnhancedElevatedCard] + [RuntimeSectionHeader] style so it
+ * blends with the neighbouring cards ([RuntimeEnvVarsCard], [PhpExtensionsCard], …).
  *
  * Semantics (matching HTML):
- * - [port] == 0  → "auto-assign": the runtime asks PortManager for a free port (REASSIGN); the
- *   conflict-mode radio is then irrelevant because a free port never conflicts.
+ * - [port] == 0  → auto-assign: the runtime asks PortManager for a free port (REASSIGN); the
+ *   conflict-policy segmented control is then irrelevant because a free port never conflicts.
  * - [port] > 0   → fixed port: the conflict mode decides what happens if it is occupied.
  *
- * Defaults passed by callers: port = 0, portConflictMode = AUTO_KILL — the safest combination,
- * since auto-assign never collides and never kills another process.
- *
- * @param title     section heading, e.g. Strings.portConflictTitle or a runtime-specific label.
- * @param showTitle whether to render the heading row (some screens already group under a card).
+ * Callers pass the safest defaults — port = 0, portConflictMode = AUTO_KILL — because
+ * auto-assign never collides and never kills another process.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RuntimePortConfigSection(
     port: Int,
     portConflictMode: PortConflictMode,
     onPortChange: (Int) -> Unit,
     onPortConflictModeChange: (PortConflictMode) -> Unit,
-    modifier: Modifier = Modifier,
-    title: String = Strings.portConflictTitle,
-    showTitle: Boolean = true
+    modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        if (showTitle) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary
+    EnhancedElevatedCard(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            RuntimeSectionHeader(
+                icon = Icons.Outlined.Lan,
+                title = Strings.portConfigTitle
             )
-            Spacer(Modifier.height(8.dp))
-        }
+            Spacer(Modifier.height(16.dp))
 
-        // Auto-assign toggle
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = Strings.portAutoAssign,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = Strings.portAutoAssignHint,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            WtaSwitch(
-                checked = port == 0,
-                onCheckedChange = { auto -> onPortChange(if (auto) 0 else 8080) }
-            )
-        }
-
-        // Fixed-port input (only visible when auto-assign is off)
-        AnimatedVisibility(visible = port > 0) {
+            // Auto-assign toggle
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = Strings.portDefaultLabel,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.weight(1f)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = Strings.portAutoAssign,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = Strings.portAutoAssignHint,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                WtaSwitch(
+                    checked = port == 0,
+                    onCheckedChange = { auto -> onPortChange(if (auto) 0 else 8080) }
                 )
-                Surface(
-                    shape = RoundedCornerShape(10.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerLow,
-                    modifier = Modifier.width(100.dp)
-                ) {
-                    BasicTextField(
+            }
+
+            // Fixed-port input (only visible when auto-assign is off)
+            AnimatedVisibility(visible = port > 0) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
                         value = if (port > 0) port.toString() else "",
                         onValueChange = { text ->
                             val num = text.toIntOrNull()
@@ -118,142 +102,88 @@ fun RuntimePortConfigSection(
                                 }
                             )
                         },
+                        label = { Text(Strings.portDefaultLabel) },
                         singleLine = true,
-                        textStyle = MaterialTheme.typography.bodyMedium.copy(
-                            textAlign = TextAlign.Center
-                        ),
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
             }
-        }
 
-        Spacer(Modifier.height(12.dp))
-        HorizontalDivider()
-        Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(16.dp))
 
-        Text(
-            text = Strings.portConflictTitle,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.primary
-        )
-        Spacer(Modifier.height(4.dp))
-
-        // AUTO_KILL
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = Strings.portConflictAutoKill,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = Strings.portConflictAutoKillHint,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            RadioButton(
-                selected = portConflictMode == PortConflictMode.AUTO_KILL,
-                onClick = { onPortConflictModeChange(PortConflictMode.AUTO_KILL) }
+            // Conflict-policy segmented control (only meaningful for a fixed port)
+            Text(
+                text = Strings.portConflictTitle,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
             )
-        }
-
-        Spacer(Modifier.height(4.dp))
-
-        // ALERT
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = Strings.portConflictAlert,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = Strings.portConflictAlertHint,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            RadioButton(
-                selected = portConflictMode == PortConflictMode.ALERT,
-                onClick = { onPortConflictModeChange(PortConflictMode.ALERT) }
+            Spacer(Modifier.height(8.dp))
+            PortConflictSegmentedRow(
+                mode = portConflictMode,
+                onModeChange = onPortConflictModeChange,
+                enabled = port > 0
             )
         }
     }
 }
 
 /**
- * Conflict-policy selector only (no port input), for screens that already render their own
- * port field (e.g. CreateNodeJsAppScreen's NodeJsPortCard) but still want the shared
- * AUTO_KILL / ALERT radio section.
+ * Conflict-policy selector card only (no port input), for screens that already render their own
+ * port field (e.g. CreateNodeJsAppScreen's NodeJsPortCard) but still want the shared policy
+ * control in the matching card style.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RuntimePortConflictSelector(
     portConflictMode: PortConflictMode,
     onPortConflictModeChange: (PortConflictMode) -> Unit,
     modifier: Modifier = Modifier,
-    accentColor: Color = MaterialTheme.colorScheme.primary
+    @Suppress("UNUSED_PARAMETER") accentColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.primary
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = Strings.portConflictTitle,
-            style = MaterialTheme.typography.labelLarge,
-            color = accentColor
-        )
-        Spacer(Modifier.height(4.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = Strings.portConflictAutoKill,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = Strings.portConflictAutoKillHint,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            RadioButton(
-                selected = portConflictMode == PortConflictMode.AUTO_KILL,
-                onClick = { onPortConflictModeChange(PortConflictMode.AUTO_KILL) }
+    EnhancedElevatedCard(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            RuntimeSectionHeader(
+                icon = Icons.Outlined.Shield,
+                title = Strings.portConflictTitle
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = Strings.portConflictAutoKillHint,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(12.dp))
+            PortConflictSegmentedRow(
+                mode = portConflictMode,
+                onModeChange = onPortConflictModeChange,
+                enabled = true
             )
         }
+    }
+}
 
-        Spacer(Modifier.height(4.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = Strings.portConflictAlert,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = Strings.portConflictAlertHint,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PortConflictSegmentedRow(
+    mode: PortConflictMode,
+    onModeChange: (PortConflictMode) -> Unit,
+    enabled: Boolean
+) {
+    val options = listOf(
+        PortConflictMode.AUTO_KILL to Strings.portConflictAutoKill,
+        PortConflictMode.ALERT to Strings.portConflictAlert
+    )
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, (value, label) ->
+            SegmentedButton(
+                selected = mode == value,
+                onClick = { onModeChange(value) },
+                enabled = enabled,
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size)
+            ) {
+                Text(label)
             }
-            RadioButton(
-                selected = portConflictMode == PortConflictMode.ALERT,
-                onClick = { onPortConflictModeChange(PortConflictMode.ALERT) }
-            )
         }
     }
 }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateGoAppScreen.kt
@@ -500,7 +500,6 @@ fun CreateGoAppScreen(
                     onRemove = { key -> envVars = envVars.toMutableMap().apply { remove(key) } }
                 )
 
-                Spacer(Modifier.height(12.dp))
                 com.webtoapp.ui.components.RuntimePortConfigSection(
                     port = serverPort,
                     portConflictMode = portConflictMode,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateNodeJsAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateNodeJsAppScreen.kt
@@ -777,7 +777,6 @@ fun CreateNodeJsAppScreen(
                         accentColor = accentColor
                     )
 
-                    Spacer(Modifier.height(8.dp))
                     com.webtoapp.ui.components.RuntimePortConflictSelector(
                         portConflictMode = portConflictMode,
                         onPortConflictModeChange = { portConflictMode = it },

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePhpAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePhpAppScreen.kt
@@ -599,7 +599,6 @@ fun CreatePhpAppScreen(
                     onRemove = { key -> envVars = envVars.toMutableMap().apply { remove(key) } }
                 )
 
-                Spacer(Modifier.height(12.dp))
                 com.webtoapp.ui.components.RuntimePortConfigSection(
                     port = phpPort,
                     portConflictMode = portConflictMode,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
@@ -609,7 +609,6 @@ fun CreatePythonAppScreen(
                     onRemove = { key -> envVars = envVars.toMutableMap().apply { remove(key) } }
                 )
 
-                Spacer(Modifier.height(12.dp))
                 com.webtoapp.ui.components.RuntimePortConfigSection(
                     port = serverPort,
                     portConflictMode = portConflictMode,

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateWordPressAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateWordPressAppScreen.kt
@@ -496,7 +496,6 @@ fun CreateWordPressAppScreen(
 
                 WpDbInfoCard(accentColor = accentColor)
 
-                Spacer(Modifier.height(12.dp))
                 com.webtoapp.ui.components.RuntimePortConfigSection(
                     port = phpPort,
                     portConflictMode = portConflictMode,


### PR DESCRIPTION
Closes #482

## Summary

Fixes the two UI issues in the port-config cards added in #479: they rendered as bare `Text`/`Row`/`RadioButton` with no card container (clashing with every neighbouring card), and the local-service card and the conflict-policy card shared the same `Lan` icon.

## Changes

| Component | Before | After |
|-----------|--------|-------|
| Container | bare `Column`, no background | `EnhancedElevatedCard` (matches `RuntimeEnvVarsCard`, `PhpExtensionsCard`) |
| Header | bare `Text` | `RuntimeSectionHeader(icon, title)` — `Icons.Outlined.Lan` for local service, distinct `Icons.Outlined.Shield` for conflict policy |
| Conflict policy | two bare `RadioButton` rows | `SingleChoiceSegmentedButtonRow` (Material 3 segmented control, already used by `PhpExtensionsCard`) |
| Fixed-port input | hand-rolled `Surface` + `BasicTextField` | standard `OutlinedTextField` |
| Spacing | manual `Spacer(12.dp)` fighting `spacedBy(CardGap)` | removed; the 5 create screens rely on `WtaCreateFlowSection`'s `spacedBy(CardGap = 10.dp)` |

No functional changes — same state, callbacks, and semantics as #479; purely presentation. No new i18n strings (reuses `portConfigTitle` / `portAutoAssign*` / `portDefaultLabel` / `portConflict*`).

## Verification

- [x] `:app:compileDebugKotlin` — passes
- [x] Host-only UI change; no shell sync / template rebuild needed.

## Impact / risk

None functional. Visual only — the port-config section now looks like the rest of the create screens.