### PR TITLE
Fix #471: Lift bottom action bars above system navigation bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 .vscode/
 .claude/
 .zcode/
+.workbuddy/
 local.properties
 gradle/config.properties
 gradle/gradle-daemon-jvm.properties

--- a/app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt
@@ -12,19 +12,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -1103,6 +1091,7 @@ private fun AppModifyBottomBar(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .navigationBarsPadding()
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {

--- a/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt
@@ -10,20 +10,8 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -374,6 +362,7 @@ private fun BuildApkContent(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .navigationBarsPadding()
                             .padding(horizontal = 16.dp, vertical = 12.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -450,6 +439,7 @@ private fun BuildApkContent(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .navigationBarsPadding()
                             .padding(vertical = 12.dp),
                         contentAlignment = Alignment.Center
                     ) {

--- a/app/src/main/java/com/webtoapp/ui/screens/FileManagerScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/FileManagerScreen.kt
@@ -10,19 +10,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -344,6 +332,7 @@ fun FileManagerScreen(onBack: () -> Unit) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .navigationBarsPadding()
                             .padding(horizontal = 16.dp, vertical = 10.dp),
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                         verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
## Summary

Add `navigationBarsPadding()` to bottom bar containers so action buttons are not overlapped by the 3-button system navigation bar.

## Fixes

**Fixes #471**

## What changed

Pattern-matched `CreateAppBottomBar` in [CreateAppScreen.kt](app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt) which already applied the correct inset handling. Applied the same pattern to 3 screens that were missing it:

1. **[BuildApkScreen.kt](app/src/main/java/com/webtoapp/ui/screens/BuildApkScreen.kt)**
   - Idle-state bottom bar (AAB / Cancel / Build buttons) — added `navigationBarsPadding()` before content padding
   - In-progress bottom bar (CircularProgressIndicator) — same fix

2. **[FileManagerScreen.kt](app/src/main/java/com/webtoapp/ui/screens/FileManagerScreen.kt)**
   - Multi-selection action bar (Share / Delete buttons) — added `navigationBarsPadding()`

3. **[AppModifierScreen.kt](app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt)**
   - `AppModifyBottomBar` Column container — added `navigationBarsPadding()` before content padding

Also collapsed per-name `androidx.compose.foundation.layout.*` imports to wildcard in the three files to match the shorter style used elsewhere in the codebase.

## Why

The host activity uses `enableEdgeToEdge()` + `WindowCompat.setDecorFitsSystemWindows(window, false)` so the app renders under the transparent system navigation bar. This means every bottom bar must opt in to `navigationBarsPadding()`; otherwise the last ~48dp of the bar (including the button tap targets) sits under the system nav keys.

Gesture-nav devices are unaffected since `navigationBarsPadding()` returns 0 there; only 3-button-nav devices show the difference.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin -x syncCloneHostDex --no-configuration-cache` → BUILD SUCCESSFUL
- [ ] Launch app on a device with 3-button navigation (Settings → System → Navigation mode → 3-button navigation)
- [ ] Open Build APK screen, confirm AAB / Cancel / Build buttons are fully visible above the nav bar
- [ ] Start a build, confirm in-progress loading circle is fully visible
- [ ] Open FileManager screen, long-press a file to enter multi-select mode, confirm Share/Delete actions are above nav bar
- [ ] Open App Modifier screen, scroll to bottom, confirm Clone/Shortcut/Back buttons are above nav bar
- [ ] Repeat with gesture navigation enabled, confirm no extra blank space is introduced