### PR TITLE
fix(webview): restore FORCE_DARK for follow-system-dark-mode and react to uiMode changes (#485)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -228,6 +228,69 @@ class WebViewManager(
             browsingDataClearGeneration++
         }
 
+        /**
+         * (Re-)applies the "follow system dark mode" state to a single WebView, derived from
+         * the CURRENT system uiMode. Safe to call at setup time and again whenever the system
+         * theme changes (e.g. Activity.onConfigurationChanged), which is required because:
+         *
+         *  - Both the host builder and generated APKs are targetSdk 28 (<=32). On such apps the
+         *    WebView only applies algorithmic darkening when FORCE_DARK is ON — the modern
+         *    setAlgorithmicDarkeningAllowed(true) API is a no-op. FORCE_DARK must therefore be
+         *    preferred (regression from #342, reported as #485).
+         *  - FORCE_DARK is a static switch: it does not track system theme changes by itself,
+         *    so the hosting activity must re-derive ON/OFF from the uiMode on every change
+         *    (#301 / #341).
+         *
+         * DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING keeps pages that ship their
+         * own prefers-color-scheme: dark theme using their own theme, while pages without one
+         * still get algorithmically darkened — so both categories follow the system.
+         */
+        @JvmStatic
+        fun refreshSystemDarkMode(webView: WebView?, followSystemDarkMode: Boolean) {
+            if (webView == null) return
+            try {
+                val systemInDarkMode = (webView.context.resources.configuration.uiMode and
+                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                    android.content.res.Configuration.UI_MODE_NIGHT_YES
+                if (followSystemDarkMode) {
+                    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                        @Suppress("DEPRECATION")
+                        WebSettingsCompat.setForceDark(
+                            webView.settings,
+                            if (systemInDarkMode) WebSettingsCompat.FORCE_DARK_ON else WebSettingsCompat.FORCE_DARK_OFF
+                        )
+                        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
+                            @Suppress("DEPRECATION")
+                            WebSettingsCompat.setForceDarkStrategy(
+                                webView.settings,
+                                WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING
+                            )
+                        }
+                        AppLogger.d(
+                            "WebViewManager",
+                            "Follow system dark mode: FORCE_DARK ${if (systemInDarkMode) "ON" else "OFF"}"
+                        )
+                    } else if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+                        // Fallback for very old WebViews without FORCE_DARK.
+                        WebSettingsCompat.setAlgorithmicDarkeningAllowed(webView.settings, true)
+                        AppLogger.d("WebViewManager", "Follow system dark mode: algorithmic darkening allowed")
+                    }
+                } else {
+                    // Explicitly off: reset both mechanisms so a previously dark WebView
+                    // stops being darkened even after the system theme changed.
+                    if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                        @Suppress("DEPRECATION")
+                        WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_OFF)
+                    }
+                    if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+                        WebSettingsCompat.setAlgorithmicDarkeningAllowed(webView.settings, false)
+                    }
+                }
+            } catch (e: Exception) {
+                AppLogger.w("WebViewManager", "refreshSystemDarkMode failed", e)
+            }
+        }
+
         @Suppress("DEPRECATION")
         fun clearBrowsingData(context: Context, webView: WebView?) {
             try {
@@ -1422,35 +1485,12 @@ class WebViewManager(
                 allowFileAccessFromFileURLs = config.allowFileAccessFromFileURLs
                 allowUniversalAccessFromFileURLs = config.allowUniversalAccessFromFileURLs
 
-                if (config.followSystemDarkMode) {
-                    if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-                        // Modern WebView (API 33+): algorithmic darkening follows the system dark
-                        // mode automatically and respects the page's own prefers-color-scheme theme,
-                        // so it keeps responding to system theme changes at runtime.
-                        WebSettingsCompat.setAlgorithmicDarkeningAllowed(this, true)
-                        AppLogger.d("WebViewManager", "Follow system dark mode: algorithmic darkening allowed")
-                    } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-                        // Legacy WebView: FORCE_DARK is a fixed setting, so derive it from the
-                        // current system state (on these older devices the activity is recreated on
-                        // a uiMode change, which re-applies it).
-                        val systemInDarkMode = (context.resources.configuration.uiMode and
-                            android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-                            android.content.res.Configuration.UI_MODE_NIGHT_YES
-                        @Suppress("DEPRECATION")
-                        WebSettingsCompat.setForceDark(
-                            this,
-                            if (systemInDarkMode) WebSettingsCompat.FORCE_DARK_ON else WebSettingsCompat.FORCE_DARK_OFF
-                        )
-                        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
-                            @Suppress("DEPRECATION")
-                            WebSettingsCompat.setForceDarkStrategy(
-                                this,
-                                WebSettingsCompat.DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING
-                            )
-                        }
-                        AppLogger.d("WebViewManager", "Follow system dark mode: FORCE_DARK ${if (systemInDarkMode) "ON" else "OFF"}")
-                    }
-                }
+                // Follow system dark mode. Both the host builder and generated APKs are
+                // targetSdk 28 (<=32): on such apps the WebView only performs algorithmic
+                // darkening via FORCE_DARK (setAlgorithmicDarkeningAllowed is a no-op), so
+                // FORCE_DARK must be preferred and re-applied whenever the system uiMode
+                // changes (ShellActivity.onConfigurationChanged calls refreshSystemDarkMode).
+                WebViewManager.refreshSystemDarkMode(webView, config.followSystemDarkMode)
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -244,6 +244,27 @@ class ShellActivity : AppCompatActivity() {
         browserSurface?.reload() ?: webView?.reload()
     }
 
+    override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // The shell manifest declares configChanges including uiMode, so switching the system
+        // dark/light theme does NOT recreate this activity. Compose recomposition already
+        // refreshes the chrome (status bar etc.), but the WebView's dark-mode switch
+        // (FORCE_DARK, static, targetSdk 28) must be re-derived from the new uiMode
+        // explicitly — see WebViewManager.refreshSystemDarkMode (#301 / #341 / #485).
+        try {
+            val config = WebToAppApplication.shellMode.getConfig()
+            val wv = webView
+            if (wv != null && config?.webViewConfig != null) {
+                com.webtoapp.core.webview.WebViewManager.refreshSystemDarkMode(
+                    wv,
+                    config.webViewConfig.followSystemDarkMode
+                )
+            }
+        } catch (e: Exception) {
+            com.webtoapp.core.shell.ShellLogger.w("ShellActivity", "onConfigurationChanged: refresh dark mode failed", e)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
 
         ShellActivityInit.initLogger(this)


### PR DESCRIPTION
## Summary

Fix #485: "Follow System Dark Mode" completely stopped working in v2.4.0+ on modern devices (Pixel 5 / Android 14). This is a regression introduced by #342, which preferred `setAlgorithmicDarkeningAllowed(true)` over `FORCE_DARK`.

## Root cause

Both the host builder and generated APKs are **targetSdk 28 (<=32)** (deliberate, for fork+exec native runtimes). Per the Android docs, on apps targeting API <= 32 the WebView only applies algorithmic darkening **via `FORCE_DARK`** — `setAlgorithmicDarkeningAllowed(true)` is a no-op there. `WebViewFeature.isFeatureSupported(ALGORITHMIC_DARKENING)` only reports that the WebView *build* supports the API, not that it is effective for the current app configuration, which is why #342 looked correct but broke dark mode entirely.

Additionally, `FORCE_DARK` is a static switch that does not track system theme changes. Because the shell manifest declares `android:configChanges` including `uiMode`, switching the system dark/light theme never recreates the activity — so the switch was never re-derived and page content did not follow the system theme (#301 / #341).

## Changes

- **`WebViewManager.kt`** — new re-entrant `companion @JvmStatic refreshSystemDarkMode(webView, follow)`:
  - `FORCE_DARK` preferred (derived from the *current* uiMode), keeping `DARK_STRATEGY_PREFER_WEB_THEME_OVER_USER_AGENT_DARKENING` so pages with their own `prefers-color-scheme: dark` theme use their theme while others get UA darkening;
  - `ALGORITHMIC_DARKENING` only as a fallback for very old WebViews without `FORCE_DARK`;
  - explicit OFF cleanup of both mechanisms when the toggle is disabled.
  - `configureWebView` now calls it at setup time.
- **`ShellActivity.kt`** — refresh the WebView dark mode in `onConfigurationChanged` so the static `FORCE_DARK` switch is re-applied whenever the system uiMode changes.

## Verification

- `:app:compileDebugKotlin` passes.
- Shell runtime sync verified (app ↔ shell sources byte-identical); `webview_shell.apk` template rebuilt and confirmed to contain the new code (strings present in dex).

## Notes

- Background issues: #301 (exported APK does not follow system theme changes) and #341 (the analysis that motivated #342) are addressed by the `onConfigurationChanged` refresh; #342's approach was kept only as a legacy fallback rather than being blindly reverted, so the two conflicting requirements (reliable darkening on targetSdk 28 + live system-theme tracking) are both met.
