### PR TITLE
fix(extensions): harden store download and make uBO Lite DNR filtering work (#462)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/DeclarativeNetRequestEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/DeclarativeNetRequestEngine.kt
@@ -43,6 +43,7 @@ object DeclarativeNetRequestEngine {
         val excludedResourceTypes: Set<ResourceType>,
         val domains: Set<String>,
         val excludedDomains: Set<String>,
+        val requestDomains: Set<String> = emptySet(),
         val requestMethods: Set<String>,
         val excludedRequestMethods: Set<String>,
         val requestHeaders: List<HeaderOp> = emptyList(),
@@ -71,6 +72,19 @@ object DeclarativeNetRequestEngine {
     private val dynamicRules = ConcurrentHashMap<String, MutableList<DnrRule>>()
     private val sessionRules = ConcurrentHashMap<String, MutableList<DnrRule>>()
 
+    /**
+     * Immutable candidate index over all currently active rules, keyed by
+     * hostname buckets. Rebuilt whenever any ruleset changes; read lock-free
+     * (volatile snapshot) from the WebView request thread.
+     */
+    private data class RuleIndex(
+        val domainBuckets: Map<String, List<DnrRule>>,
+        val genericRules: List<DnrRule>
+    )
+
+    @Volatile
+    private var ruleIndex: RuleIndex = RuleIndex(emptyMap(), emptyList())
+
     @Volatile
     var matchedCount: Long = 0
         private set
@@ -90,6 +104,108 @@ object DeclarativeNetRequestEngine {
             }
         }
         modifyHeaderRuleCount = count
+        rebuildIndex()
+    }
+
+    /** Rebuilds the immutable domain candidate index from all active rules. */
+    private fun rebuildIndex() {
+        val buckets = HashMap<String, MutableList<DnrRule>>()
+        val generic = mutableListOf<DnrRule>()
+
+        fun addRule(rule: DnrRule) {
+            val keys = indexKeysFor(rule)
+            if (keys.isEmpty()) {
+                generic.add(rule)
+                return
+            }
+            for (key in keys) {
+                buckets.getOrPut(key) { mutableListOf() }.add(rule)
+            }
+        }
+
+        for ((_, rules) in sessionRules) rules.forEach(::addRule)
+        for ((_, rules) in dynamicRules) rules.forEach(::addRule)
+        for ((_, rulesets) in staticRulesets) {
+            rulesets.values.filter { it.enabled }.forEach { rs -> rs.rules.forEach(::addRule) }
+        }
+
+        ruleIndex = RuleIndex(
+            domainBuckets = buckets.mapValues { it.value.toList() },
+            genericRules = generic.toList()
+        )
+    }
+
+    /**
+     * Extracts the hostname bucket keys a rule should be indexed under.
+     * `requestDomains` matches the request URL host (or subdomains), so each
+     * entry becomes a key. Otherwise a stable host is extracted from the
+     * urlFilter; rules that cannot be reliably keyed go to the generic pool.
+     */
+    private fun indexKeysFor(rule: DnrRule): Set<String> {
+        if (rule.requestDomains.isNotEmpty()) {
+            return rule.requestDomains
+        }
+        val filter = rule.urlFilter ?: return emptySet()
+        return extractHostFromFilter(filter.pattern())?.let { setOf(it) } ?: emptySet()
+    }
+
+    private fun extractHostFromFilter(filter: String): String? {
+        val cleaned = filter
+            .replace("||", "")
+            .replace("|", "")
+            .replace("*", "")
+            .replace("^", "")
+            .replace("http://", "")
+            .replace("https://", "")
+            .replace("ws://", "")
+            .replace("wss://", "")
+            .trimStart('/')
+            .substringBefore("/")
+            .substringBefore("?")
+            .substringBefore("#")
+            .trim()
+        if (cleaned.isEmpty()) return null
+        if (!cleaned.contains(".")) return null
+        if (cleaned.any { !it.isLetterOrDigit() && it != '.' && it != '-' }) return null
+        return cleaned
+    }
+
+    /** Returns [host] and each parent domain, e.g. "a.b.example.com" → [a.b.example.com, b.example.com, example.com, com]. */
+    private fun parentDomains(host: String): List<String> {
+        if (host.isEmpty()) return emptyList()
+        val parts = host.split(".")
+        if (parts.size <= 1) return listOf(host)
+        return (0 until parts.size).map { i -> parts.drop(i).joinToString(".") }
+    }
+
+    private fun matchesRequestDomain(requestHost: String, domains: Set<String>): Boolean {
+        if (domains.isEmpty()) return true
+        if (requestHost.isEmpty()) return false
+        return domains.any { d -> requestHost == d || requestHost.endsWith(".$d") }
+    }
+
+    /** Candidate rules for a request: generic pool + hostname-bucket hits (host + parent domains). */
+    private fun buildCandidates(index: RuleIndex, requestHost: String): List<DnrRule> {
+        if (index.genericRules.isEmpty() && index.domainBuckets.isEmpty()) return emptyList()
+        val buckets = index.domainBuckets
+        val matched = ArrayList<DnrRule>(index.genericRules.size + 16)
+        if (index.genericRules.isNotEmpty()) {
+            matched.addAll(index.genericRules)
+        }
+        if (requestHost.isNotEmpty() && buckets.isNotEmpty()) {
+            for (domain in parentDomains(requestHost)) {
+                buckets[domain]?.let { matched.addAll(it) }
+            }
+        }
+        return matched
+    }
+
+    private fun extractHost(url: String): String {
+        return try {
+            android.net.Uri.parse(url).host ?: ""
+        } catch (_: Exception) {
+            ""
+        }
     }
 
     fun loadStaticRules(
@@ -231,28 +347,19 @@ object DeclarativeNetRequestEngine {
         initiatorDomain: String = "",
         method: String = "GET"
     ): EvalResult? {
-        val allRuleSets = mutableListOf<List<DnrRule>>()
-
-        for ((_, rules) in sessionRules) allRuleSets.add(rules)
-        for ((_, rules) in dynamicRules) allRuleSets.add(rules)
-        for ((_, rulesets) in staticRulesets) {
-            rulesets.values
-                .filter { it.enabled }
-                .forEach { allRuleSets.add(it.rules) }
-        }
-
-        if (allRuleSets.all { it.isEmpty() }) return null
-
         val resType = ResourceType.fromString(resourceType)
+        val requestHost = extractHost(url)
+        val index = ruleIndex
+        val candidates = buildCandidates(index, requestHost)
+        if (candidates.isEmpty()) return null
+
         var bestMatch: Pair<DnrRule, Int>? = null
 
-        for (ruleSet in allRuleSets) {
-            for (rule in ruleSet) {
-                if (!matchesRule(rule, url, resType, initiatorDomain, method)) continue
-                val effectivePriority = rule.priority
-                if (bestMatch == null || effectivePriority > bestMatch.second) {
-                    bestMatch = rule to effectivePriority
-                }
+        for (rule in candidates) {
+            if (!matchesRule(rule, url, resType, initiatorDomain, method, requestHost)) continue
+            val effectivePriority = rule.priority
+            if (bestMatch == null || effectivePriority > bestMatch.second) {
+                bestMatch = rule to effectivePriority
             }
         }
 
@@ -285,24 +392,19 @@ object DeclarativeNetRequestEngine {
         if (modifyHeaderRuleCount == 0) return null
 
         val resType = ResourceType.fromString(resourceType)
-        val allRuleSets = mutableListOf<List<DnrRule>>()
-        for ((_, rules) in sessionRules) allRuleSets.add(rules)
-        for ((_, rules) in dynamicRules) allRuleSets.add(rules)
-        for ((_, rulesets) in staticRulesets) {
-            rulesets.values.filter { it.enabled }.forEach { allRuleSets.add(it.rules) }
-        }
+        val requestHost = extractHost(url)
+        val index = ruleIndex
+        val candidates = buildCandidates(index, requestHost)
 
         var maxAllowPriority = 0
         val matchedHeaderRules = mutableListOf<DnrRule>()
-        for (ruleSet in allRuleSets) {
-            for (rule in ruleSet) {
-                if (!matchesRule(rule, url, resType, initiatorDomain, method)) continue
-                when (rule.action) {
-                    ActionType.ALLOW, ActionType.ALLOW_ALL_REQUESTS ->
-                        if (rule.priority > maxAllowPriority) maxAllowPriority = rule.priority
-                    ActionType.MODIFY_HEADERS -> matchedHeaderRules.add(rule)
-                    else -> {}
-                }
+        for (rule in candidates) {
+            if (!matchesRule(rule, url, resType, initiatorDomain, method, requestHost)) continue
+            when (rule.action) {
+                ActionType.ALLOW, ActionType.ALLOW_ALL_REQUESTS ->
+                    if (rule.priority > maxAllowPriority) maxAllowPriority = rule.priority
+                ActionType.MODIFY_HEADERS -> matchedHeaderRules.add(rule)
+                else -> {}
             }
         }
 
@@ -339,7 +441,8 @@ object DeclarativeNetRequestEngine {
         url: String,
         resType: ResourceType?,
         initiatorDomain: String,
-        method: String
+        method: String,
+        requestHost: String
     ): Boolean {
         val urlMatched = when {
             rule.urlFilter != null -> rule.urlFilter.matcher(url).find()
@@ -352,6 +455,9 @@ object DeclarativeNetRequestEngine {
             if (rule.resourceTypes.isNotEmpty() && resType !in rule.resourceTypes) return false
             if (resType in rule.excludedResourceTypes) return false
         }
+
+        // requestDomains constrains the *request URL's* host (uBO filter lists rely on it).
+        if (rule.requestDomains.isNotEmpty() && !matchesRequestDomain(requestHost, rule.requestDomains)) return false
 
         if (initiatorDomain.isNotEmpty()) {
             if (rule.domains.isNotEmpty() && !matchesDomain(initiatorDomain, rule.domains)) return false
@@ -425,6 +531,8 @@ object DeclarativeNetRequestEngine {
             ?: condition?.optJSONArray("domains"))
         val excludedDomains = parseStringSet(condition?.optJSONArray("excludedInitiatorDomains")
             ?: condition?.optJSONArray("excludedDomains"))
+        // requestDomains matches the *request URL's* host (uBO filter lists rely on this).
+        val requestDomains = parseStringSet(condition?.optJSONArray("requestDomains"))
         val requestMethods = parseStringSet(condition?.optJSONArray("requestMethods")).map { it.uppercase() }.toSet()
         val excludedRequestMethods = parseStringSet(condition?.optJSONArray("excludedRequestMethods")).map { it.uppercase() }.toSet()
 
@@ -444,6 +552,7 @@ object DeclarativeNetRequestEngine {
             excludedResourceTypes = excludedResourceTypes,
             domains = domains,
             excludedDomains = excludedDomains,
+            requestDomains = requestDomains,
             requestMethods = requestMethods,
             excludedRequestMethods = excludedRequestMethods,
             requestHeaders = requestHeaderOps,

--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionFileManager.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionFileManager.kt
@@ -140,8 +140,9 @@ class ExtensionFileManager(private val context: Context) {
         }
         val crxFile = File(tempDir, "store_${cleanId}_${System.currentTimeMillis()}.crx")
         try {
-            if (!downloadCrxFromStore(cleanId, crxFile, onProgress)) {
-                return@withContext ImportResult.Error("Failed to download extension from store")
+            val downloadError = downloadCrxFromStore(cleanId, crxFile, onProgress)
+            if (downloadError != null) {
+                return@withContext ImportResult.Error(downloadError)
             }
             importChromeExtensionFromFile(crxFile, cleanId)
         } catch (e: Exception) {
@@ -152,12 +153,17 @@ class ExtensionFileManager(private val context: Context) {
         }
     }
 
+    /**
+     * Downloads a CRX from the Chrome Web Store update endpoint.
+     *
+     * @return null on success, or a user-actionable error message on failure.
+     */
     private fun downloadCrxFromStore(
         storeId: String,
         dest: File,
         onProgress: (DownloadProgress) -> Unit
-    ): Boolean {
-        val prodVersions = listOf("132.0.0.0", "120.0.0.0", "124.0.0.0", "138.0.0.0")
+    ): String? {
+        val prodVersions = listOf("132.0.0.0", "138.0.0.0", "124.0.0.0")
         for (pv in prodVersions) {
             try {
                 val url = "https://clients2.google.com/service/update2/crx" +
@@ -167,8 +173,11 @@ class ExtensionFileManager(private val context: Context) {
                     .url(url)
                     .header("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/$pv Safari/537.36")
                     .build()
-                httpClient.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) return@use
+                NetworkModule.downloadClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        AppLogger.w(TAG, "CRX download HTTP ${response.code} for $storeId (prodversion=$pv)")
+                        return@use
+                    }
                     val body = response.body ?: return@use
                     val reportedTotal = body.contentLength().coerceAtLeast(0L)
                     dest.outputStream().use { out ->
@@ -184,7 +193,7 @@ class ExtensionFileManager(private val context: Context) {
                                 total += read
                                 if (total > MAX_EXTENSION_SIZE) {
                                     AppLogger.w(TAG, "CRX exceeds max size, aborting: $storeId")
-                                    return false
+                                    return "Extension too large (max 50MB)"
                                 }
                                 out.write(buffer, 0, read)
                                 val now = System.currentTimeMillis()
@@ -207,13 +216,20 @@ class ExtensionFileManager(private val context: Context) {
                 }
                 if (dest.exists() && dest.length() > 0 && ChromeExtensionParser.isCrxFile(dest)) {
                     AppLogger.i(TAG, "Downloaded CRX for $storeId (${dest.length() / 1024} KB, prodversion=$pv)")
-                    return true
+                    return null
                 }
             } catch (e: Exception) {
                 AppLogger.w(TAG, "CRX download attempt failed (prodversion=$pv): $storeId", e)
             }
         }
-        return false
+        return if (dest.exists() && dest.length() > 0 && !ChromeExtensionParser.isCrxFile(dest)) {
+            "Downloaded file is not a valid Chrome extension (CRX). " +
+                "The store may have restricted this extension, or the download was interrupted."
+        } else {
+            "Failed to download extension from the Chrome Web Store. " +
+                "The store is not reachable from your network — check your connection or proxy, " +
+                "then try again. (extension id: $storeId)"
+        }
     }
 
     fun downloadIconForExtension(iconUrl: String, targetDir: File): File? {

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -3742,6 +3742,7 @@ object Strings {
     val cwsDlModule: String get() = StringsE.cwsDlModule
     val cwsDlIcon: String get() = StringsE.cwsDlIcon
     val cwsDlTags: String get() = StringsE.cwsDlTags
+    val cwsAdBlockTip: String get() = StringsE.cwsAdBlockTip
     val cwsTagAdBlocking: String get() = StringsE.cwsTagAdBlocking
     val cwsTagTranslate: String get() = StringsE.cwsTagTranslate
     val cwsTagDarkMode: String get() = StringsE.cwsTagDarkMode
@@ -51580,10 +51581,22 @@ object StringsE {
         AppLanguage.PORTUGUESE -> "Gerando etiquetas de recursos"
         AppLanguage.SPANISH -> "Generando etiquetas de funciones"
         AppLanguage.FRENCH -> "Génération des étiquettes de fonctionnalités"
-        AppLanguage.GERMAN -> "Funktions-Tags werden erstellt"
-        AppLanguage.RUSSIAN -> "Создание тегов функций"
+        AppLanguage.GERMAN -> "Funktions-Tags werden generiert"
+        AppLanguage.RUSSIAN -> "Генерация тегов функций"
         AppLanguage.JAPANESE -> "機能タグを生成中"
         AppLanguage.KOREAN -> "기능 태그 생성 중"
+    }
+    val cwsAdBlockTip: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "需要广告拦截？试试内置广告过滤（hosts 规则 + 20 个过滤列表），无需安装扩展"
+        AppLanguage.ENGLISH -> "Need ad blocking? Try the built-in ad blocker (hosts rules + 20 filter lists) instead of an extension"
+        AppLanguage.ARABIC -> "تحتاج إلى حظر الإعلانات؟ جرّب مانع الإعلانات المدمج (قواعد hosts + 20 قائمة تصفية) بدلاً من الإضافة"
+        AppLanguage.PORTUGUESE -> "Precisa bloquear anúncios? Experimente o bloqueador de anúncios integrado (regras hosts + 20 listas de filtros) em vez de uma extensão"
+        AppLanguage.SPANISH -> "¿Necesitas bloquear anuncios? Prueba el bloqueador integrado (reglas hosts + 20 listas de filtros) en lugar de una extensión"
+        AppLanguage.FRENCH -> "Besoin de bloquer les pubs ? Essayez le bloqueur intégré (règles hosts + 20 listes de filtres) au lieu d'une extension"
+        AppLanguage.GERMAN -> "Werbeblocker nötig? Probieren Sie den integrierten Blocker (hosts-Regeln + 20 Filterlisten) statt einer Erweiterung"
+        AppLanguage.RUSSIAN -> "Нужна блокировка рекламы? Попробуйте встроенный блокировщик (правила hosts + 20 списков фильтров) вместо расширения"
+        AppLanguage.JAPANESE -> "広告ブロックが必要ですか？拡張機能の代わりに内蔵ブロッカー（hosts ルール + 20 のフィルターリスト）をお試しください"
+        AppLanguage.KOREAN -> "광고 차단이 필요하신가요? 확장 프로그램 대신 내장 광고 차단기(hosts 규칙 + 필터 목록 20개)를 사용해 보세요"
     }
     val cwsTagAdBlocking: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "广告拦截"

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -3698,7 +3698,12 @@ class WebViewManager(
                 )
                 runtime.initialize(webView)
                 extensionRuntimes[extId] = runtime
-                loadDeclarativeNetRequestRules(extId, primaryModule.manifestJson)
+                // Load static DNR rulesets (uBO filter lists can be several MB with
+                // ~100k rules) off the main thread so activating an extension never
+                // blocks the WebView setup.
+                kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+                    loadDeclarativeNetRequestRules(extId, primaryModule.manifestJson)
+                }
                 AppLogger.d("WebViewManager", "Created background runtime for extension: $extId")
             }
 

--- a/app/src/main/java/com/webtoapp/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/webtoapp/ui/navigation/AppNavigation.kt
@@ -760,7 +760,8 @@ fun AppNavigation() {
                 val initialTab = rawTab.toIntOrNull() ?: 0
                 ModuleMarketScreen(
                     onNavigateBack = { navController.popBackStack() },
-                    initialTab = initialTab
+                    initialTab = initialTab,
+                    onOpenHostsAdBlock = { navController.navigate(Routes.HOSTS_ADBLOCK) }
                 )
             }
 

--- a/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
@@ -129,6 +129,7 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.VolunteerActivism
 import kotlinx.coroutines.flow.collectLatest
@@ -140,7 +141,8 @@ import java.time.format.DateTimeParseException
 @Composable
 fun ModuleMarketScreen(
     onNavigateBack: () -> Unit,
-    initialTab: Int = 0
+    initialTab: Int = 0,
+    onOpenHostsAdBlock: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -514,7 +516,35 @@ fun ModuleMarketScreen(
                         listState = listState
                     )
                 } else if (selectedTab == 1) {
-                    CwsSearchContent(
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        Surface(
+                            onClick = { onOpenHostsAdBlock() },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 6.dp),
+                            shape = MaterialTheme.shapes.medium,
+                            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Block,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Text(
+                                    text = Strings.cwsAdBlockTip,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                        }
+                        CwsSearchContent(
                         query = searchQuery.trim(),
                         results = cwsViews,
                         isSearching = cwsSearching,
@@ -560,7 +590,8 @@ fun ModuleMarketScreen(
                             }
                         },
                         listState = listState
-                    )
+                        )
+                    }
                 } else {
                     when (val s = state) {
                         is MarketState.Idle, is MarketState.Loading -> {


### PR DESCRIPTION
## Summary

Fixes #462: some extensions (notably uBlock Origin Lite) could not be downloaded from the in-app Chrome Web Store, and uBO Lite could not actually block anything once installed. Also improves discoverability of the built-in ad blocker.

## Download fixes

- **Removed the obsolete `prodversion=120` fallback** — the store answers 204 (empty) for it, so it always wasted one of the download attempts.
- **CRX downloads now use `NetworkModule.downloadClient`** (extended timeouts) instead of the short-lived default client.
- **Actionable error messages** on failure: distinguishes store rejection / non-CRX payload / store unreachable from the user's network (with a connection/proxy hint). Root cause of the original report: `clients2.google.com` is unreachable from mainland networks, and the old code silently reported a generic failure.

## DNR engine fixes (make uBO Lite actually block)

Audited uBO Lite (MV3, 56 static rulesets, ~5 MB / ~100k rules, module service worker):

- **`condition.requestDomains` was never parsed** — the field uBO filter lists rely on to scope rules to the request URL host; without it most EasyList-style rules never matched. Now parsed and enforced in `matchesRule` against the request host.
- **Static rulesets were loaded synchronously on the main thread** (~100k rules would freeze WebView setup). Now loaded off the main thread.
- **Rule matching was a linear scan over every rule per request**. Added a hostname-bucket index (`requestDomains` + stable `urlFilter` hosts); `evaluate()` now scans only the generic pool + host-bucket candidates.
- **`userScripts` cosmetic filtering is not implemented**; uBO Lite detects this (`supportsUserScripts()` → false) and degrades gracefully to network-level blocking without crashing. This is the main ad-blocking path and now works.

## Built-in ad blocker discoverability

Added a hint banner in the Chrome Web Store tab of the extension market that links to the built-in hosts ad blocker (10-language string), guiding users to the built-in filter lists when they don't need a full extension.

## Verification

- `:app:compileDebugKotlin` passes.
- Shell template rebuilt; dex contains the new code (`requestDomains` / new strings).
- Store endpoint verified directly: correct uBO Lite id returns a valid 9.9 MB CRX3 with prodversion 132/138.

Closes #462
