### PR TITLE
fix(activation): enforce device-bound codes via remote verifier + honest local labeling (#448)

### DIFF
--- a/.github/docs/remote-activation.md
+++ b/.github/docs/remote-activation.md
@@ -40,7 +40,8 @@ Accept: application/json
   "deviceId": "f3a9…",
   "packageName": "com.example.app",
   "nonce": "Base64-random-24-bytes",
-  "ts": 1733270400000
+  "ts": 1733270400000,
+  "deviceBound": false
 }
 ```
 
@@ -49,6 +50,14 @@ Accept: application/json
 - `nonce` is fresh per request — you **must** echo it back unchanged (replay
   protection).
 - `ts` is the client clock in epoch milliseconds.
+- `deviceBound` is `true` when the entered code is a **device-bound** code. For
+  such codes your server should enforce per-device binding: record the first
+  `deviceId` that activates a given `code`, and reject the same `code` from any
+  different `deviceId` (return `{ "ok": false }`). This is the only way to
+  truly restrict a device-bound code to one device — the app itself has no
+  shared state between devices, so a purely local device-bound code can only
+  prevent re-activation on the same device after a local reset or hardware
+  change.
 
 ## Response (your server → app)
 

--- a/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
@@ -95,7 +95,8 @@ class ActivationManager(private val context: Context) {
         offlinePolicy: com.webtoapp.data.model.RemoteActivationOfflinePolicy,
         deliverUrl: Boolean = false,
         encryptUrl: Boolean = false,
-        aesKeyBase64: String = ""
+        aesKeyBase64: String = "",
+        deviceBound: Boolean = false
     ): RemoteActivationVerifier.RemoteRequest {
         return RemoteActivationVerifier.RemoteRequest(
             verifyUrl = verifyUrl,
@@ -106,7 +107,8 @@ class ActivationManager(private val context: Context) {
             packageName = context.packageName,
             deliverUrl = deliverUrl,
             encryptUrl = encryptUrl,
-            aesKeyBase64 = aesKeyBase64
+            aesKeyBase64 = aesKeyBase64,
+            deviceBound = deviceBound
         )
     }
 

--- a/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
@@ -46,7 +46,12 @@ class RemoteActivationVerifier(private val context: Context) {
         val packageName: String,
         val deliverUrl: Boolean = false,
         val encryptUrl: Boolean = false,
-        val aesKeyBase64: String = ""
+        val aesKeyBase64: String = "",
+        // True when the entered code is a DEVICE_BOUND code: tells the verifier
+        // endpoint this activation must be enforced per deviceId (the server
+        // rejects the same code from any other device). Pure-local mode cannot
+        // enforce cross-device binding because there is no shared state.
+        val deviceBound: Boolean = false
     )
 
     private val secureRandom = SecureRandom()
@@ -171,6 +176,7 @@ class RemoteActivationVerifier(private val context: Context) {
         obj.addProperty("packageName", request.packageName)
         obj.addProperty("nonce", nonce)
         obj.addProperty("ts", timestamp)
+        obj.addProperty("deviceBound", request.deviceBound)
         return obj.toString()
     }
 

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -848,6 +848,7 @@ object Strings {
     val expireTime: String get() = StringsA.expireTime
     val remainingUsage: String get() = StringsA.remainingUsage
     val deviceBound: String get() = StringsA.deviceBound
+    val deviceBoundRemoteTip: String get() = StringsA.deviceBoundRemoteTip
     val invalidActivationCode: String get() = StringsA.invalidActivationCode
     val remoteActivationTitle: String get() = StringsA.remoteActivationTitle
     val activationSectionRemoteEnabled: (String) -> String get() = StringsA.activationSectionRemoteEnabled
@@ -15621,6 +15622,18 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Привязан к устройству: Включено"
         AppLanguage.JAPANESE -> "デバイス紐付け: 有効"
         AppLanguage.KOREAN -> "기기 연결: 활성화됨"
+    }
+    val deviceBoundRemoteTip: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "提示：设备绑定在本机生效（防止本机重激活/硬件变更后旧码复用）。跨设备限制需要在应用中配置远程激活验证服务，由服务器按设备 ID 拒绝其他设备。"
+        AppLanguage.ENGLISH -> "Note: device binding is enforced on this device only (prevents re-activation after a local reset or hardware change). Cross-device restriction requires configuring the remote activation verifier in the app, so the server can reject other devices by device ID."
+        AppLanguage.ARABIC -> "ملاحظة: ربط الجهاز يُطبَّق على هذا الجهاز فقط (يمنع إعادة التفعيل بعد إعادة الضبط المحلية أو تغيير العتاد). التقييد عبر الأجهزة يتطلب إعداد خدمة التحقق عن بُعد في التطبيق، بحيث يرفض الخادم الأجهزة الأخرى حسب معرّف الجهاز."
+        AppLanguage.PORTUGUESE -> "Observação: a vinculação ao dispositivo vale apenas neste aparelho (impede reativação após redefinição local ou troca de hardware). A restrição entre dispositivos exige configurar o verificador remoto no aplicativo, para o servidor rejeitar outros dispositivos pelo ID."
+        AppLanguage.SPANISH -> "Nota: la vinculación al dispositivo solo se aplica en este equipo (evita reactivar tras un restablecimiento local o cambio de hardware). La restricción entre dispositivos requiere configurar el verificador remoto en la app, para que el servidor rechace otros dispositivos por ID."
+        AppLanguage.FRENCH -> "Remarque : la liaison à l'appareil ne s'applique qu'à cet appareil (empêche la réactivation après une réinitialisation locale ou un changement de matériel). La restriction multi-appareils nécessite de configurer le vérificateur distant dans l'application, pour que le serveur rejette les autres appareils par ID."
+        AppLanguage.GERMAN -> "Hinweis: Die Gerätebindung gilt nur für dieses Gerät (verhindert Reaktivierung nach lokalem Reset oder Hardwarewechsel). Geräteübergreifende Einschränkung erfordert die Konfiguration des Remote-Verifizierers in der App, damit der Server andere Geräte per ID ablehnt."
+        AppLanguage.RUSSIAN -> "Примечание: привязка к устройству действует только на этом устройстве (предотвращает повторную активацию после локального сброса или замены железа). Ограничение между устройствами требует настройки удалённого проверяющего в приложении, чтобы сервер отклонял другие устройства по ID."
+        AppLanguage.JAPANESE -> "注意: デバイス紐付けはこの端末のみで有効です（ローカルリセットやハードウェア変更後の再アクティベーションを防ぎます）。端末間の制限には、アプリでリモート検証サービスを設定し、サーバーがデバイス ID で他の端末を拒否する必要があります。"
+        AppLanguage.KOREAN -> "참고: 기기 연결은 이 기기에서만 적용됩니다(로컬 초기화 또는 하드웨어 변경 후 재활성화 방지). 기기 간 제한은 앱에서 원격 인증 서비스를 구성하여 서버가 기기 ID로 다른 기기를 거부하도록 해야 합니다."
     }
 
     val invalidActivationCode: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -1171,6 +1171,18 @@ private fun EnhancedActivationCodeItem(
                     }
                 }
             }
+
+            if (code.type == ActivationCodeType.DEVICE_BOUND) {
+                Text(
+                    text = Strings.deviceBoundRemoteTip,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                    fontSize = 11.sp,
+                    modifier = Modifier
+                        .padding(top = 4.dp)
+                        .fillMaxWidth()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -42,6 +42,12 @@ fun ShellActivationDialog(
             activationError = null
             scope?.launch {
                 val result = if (config.activationRemoteEnabled) {
+                    val deviceBound = config.activationCodes.any { raw ->
+                        val parsed = com.webtoapp.core.activation.ActivationCode.fromJson(raw)
+                            ?: com.webtoapp.core.activation.ActivationCode.fromLegacyString(raw)
+                        parsed.code == code &&
+                            parsed.type == com.webtoapp.core.activation.ActivationCodeType.DEVICE_BOUND
+                    }
                     activation.verifyRemoteActivation(
                         -1L,
                         code,
@@ -51,7 +57,8 @@ fun ShellActivationDialog(
                             offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
                             deliverUrl = config.activationRemoteDeliverUrl,
                             encryptUrl = config.activationRemoteEncryptUrl,
-                            aesKeyBase64 = config.activationRemoteAesKey
+                            aesKeyBase64 = config.activationRemoteAesKey,
+                            deviceBound = deviceBound
                         )
                     )
                 } else {


### PR DESCRIPTION
Fixes #448: DEVICE_BOUND codes could activate on any device. See the issue comments for the full root-cause analysis.

## What changed

- **RemoteRequest now carries a `deviceBound` flag** — true when the entered code is a DEVICE_BOUND code (matched against the packaged code list). Your verification server can now enforce real cross-device binding for these codes: record the first `deviceId` per code and reject the same code from any other `deviceId`.
- **`buildRemoteRequest` gains a `deviceBound` parameter**; the shell activation dialog computes it from the packaged codes (parsed via `ActivationCode.fromJson` / `fromLegacyString`).
- **Honest local labeling**: without a remote verifier, a DEVICE_BOUND code only prevents re-activation on the same device (local reset / hardware change) — a fresh device has no shared record to compare against. The editor's code card now shows a note (new 10-language string) explaining this.
- **Docs**: `remote-activation.md` documents the new `deviceBound` field and the recommended server-side binding logic.

## Why not the built-in shared service (Option 3)

Pure-local cross-device binding is architecturally impossible without a shared store. The app is a pure client with no backend; self-hosting a binding database (code → deviceId) would make the project an authorization service, and third-party free stores (Gist/Firebase) would embed credentials in every APK and store users' device IDs elsewhere. The enforceable path is the user-provided endpoint (Option 2), now properly wired.

## Verification

- `:app:compileDebugKotlin` passes (host + shell).
- Shell template rebuilt; dex contains `deviceBound`.

Closes #448