### PR TITLE
feat(media): polyfill MediaMetadata and call-state stubs in the Media Session bridge

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
@@ -651,6 +651,36 @@ class MediaSessionBridge(
 
               const mediaSession = navigator.mediaSession || null;
 
+              // WebView has no native MediaMetadata constructor; sites that do
+              // `navigator.mediaSession.metadata = new MediaMetadata({...})`
+              // would throw ReferenceError. Provide a compatible constructor —
+              // metadata is read as plain properties by sendMetadata() below.
+              if (typeof window.MediaMetadata === "undefined") {
+                window.MediaMetadata = class MediaMetadata {
+                  constructor(options = {}) {
+                    this.title = options.title || "";
+                    this.artist = options.artist || "";
+                    this.album = options.album || "";
+                    this.artwork = Array.isArray(options.artwork)
+                      ? options.artwork.map(art => ({
+                          src: (art && art.src) || "",
+                          sizes: (art && art.sizes) || "",
+                          type: (art && art.type) || ""
+                        }))
+                      : [];
+                  }
+                };
+              }
+
+              // Call/camera state APIs (edge case): keep them callable so sites
+              // using them do not crash; state is not surfaced to the system UI.
+              if (mediaSession && typeof mediaSession.setMicrophoneActive !== "function") {
+                mediaSession.setMicrophoneActive = function() {};
+              }
+              if (mediaSession && typeof mediaSession.setCameraActive !== "function") {
+                mediaSession.setCameraActive = function() {};
+              }
+
               function absoluteUrl(value) {
                 if (!value) return "";
 


### PR DESCRIPTION
Completes the WebView Media Session polyfill edge cases identified in the #473 follow-up analysis.

## Changes (`MediaSessionBridge.kt` injection script)

- **`window.MediaMetadata` constructor** — WebView has no native MediaMetadata class, so sites using `navigator.mediaSession.metadata = new MediaMetadata({...})` (YouTube-style players, music sites) threw ReferenceError and lost artwork. The script now installs a compatible class (title/artist/album/artwork with the standard artwork entry shape) when missing; the existing sync path reads plain properties, so no bridge changes were needed.
- **`setMicrophoneActive` / `setCameraActive` no-op stubs** — installed when absent so call/telecom sites don't crash.
- Extended actions (`hangup` / `toggleMicrophone` / `toggleCamera`) already flow through the generic registered-handler command channel — registration and dispatch need no further code.

## Verification

- `:app:compileDebugKotlin` passes; shell template rebuilt (dex contains the new `MediaMetadata` string).