### PR TITLE
feat(splash): make the top-right countdown toggleable (default on)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3957,7 +3957,8 @@ private fun WebApp.buildSplashBlock(): SplashBlock = SplashBlock(
     videoEndMs = splashConfig?.videoEndMs ?: 5000L,
     landscape = splashConfig?.orientation == com.webtoapp.data.model.SplashOrientation.LANDSCAPE,
     fillScreen = splashConfig?.fillScreen ?: true,
-    enableAudio = splashConfig?.enableAudio ?: false
+    enableAudio = splashConfig?.enableAudio ?: false,
+    showCountdown = splashConfig?.showCountdown ?: true
 )
 
 private fun WebApp.buildMediaBlock(): MediaBlock = MediaBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -696,7 +696,8 @@ data class SplashBlock(
     val landscape: Boolean = false,
     val fillScreen: Boolean = true,
     val enableAudio: Boolean = false,
-    val mediaPath: String? = null
+    val mediaPath: String? = null,
+    val showCountdown: Boolean = true
 )
 
 data class MediaBlock(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -78,6 +78,7 @@ internal object ApkConfigJsonFactory {
         "splashType" to splash.type,
         "splashDuration" to splash.duration,
         "splashClickToSkip" to splash.clickToSkip,
+        "splashShowCountdown" to splash.showCountdown,
         "splashVideoStartMs" to splash.videoStartMs,
         "splashVideoEndMs" to splash.videoEndMs,
         "splashLandscape" to splash.landscape,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2303,6 +2303,8 @@ object Strings {
     val configFontSize: String get() = StringsC.configFontSize
     val allowSkip: String get() = StringsC.allowSkip
     val allowSkipHint: String get() = StringsC.allowSkipHint
+    val splashShowCountdownLabel: String get() = StringsC.splashShowCountdownLabel
+    val splashShowCountdownHint: String get() = StringsC.splashShowCountdownHint
     val showTranslateButton: String get() = StringsC.showTranslateButton
     val showTranslateButtonHint: String get() = StringsC.showTranslateButtonHint
     val translateEngine: String get() = StringsC.translateEngine
@@ -33671,6 +33673,32 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Разрешить пропуск"
         AppLanguage.JAPANESE -> "スキップを許可"
         AppLanguage.KOREAN -> "건너뛰기 허용"
+    }
+
+    val splashShowCountdownLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "显示倒计时"
+        AppLanguage.ENGLISH -> "Show countdown"
+        AppLanguage.ARABIC -> "إظهار العد التنازلي"
+        AppLanguage.PORTUGUESE -> "Mostrar contagem regressiva"
+        AppLanguage.SPANISH -> "Mostrar cuenta atrás"
+        AppLanguage.FRENCH -> "Afficher le compte à rebours"
+        AppLanguage.GERMAN -> "Countdown anzeigen"
+        AppLanguage.RUSSIAN -> "Показывать обратный отсчёт"
+        AppLanguage.JAPANESE -> "カウントダウンを表示"
+        AppLanguage.KOREAN -> "카운트다운 표시"
+    }
+
+    val splashShowCountdownHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "在启动画面右上角显示剩余秒数"
+        AppLanguage.ENGLISH -> "Show remaining seconds in the top-right corner of the splash screen"
+        AppLanguage.ARABIC -> "عرض الثواني المتبقية في الزاوية العلوية اليمنى لشاشة البداية"
+        AppLanguage.PORTUGUESE -> "Mostrar segundos restantes no canto superior direito da tela inicial"
+        AppLanguage.SPANISH -> "Mostrar los segundos restantes en la esquina superior derecha de la pantalla de inicio"
+        AppLanguage.FRENCH -> "Afficher les secondes restantes en haut à droite de l'écran de démarrage"
+        AppLanguage.GERMAN -> "Verbleibende Sekunden oben rechts auf dem Startbildschirm anzeigen"
+        AppLanguage.RUSSIAN -> "Показывать оставшиеся секунды в правом верхнем углу заставки"
+        AppLanguage.JAPANESE -> "スプラッシュ画面の右上に残り秒数を表示"
+        AppLanguage.KOREAN -> "시작 화면 오른쪽 상단에 남은 초 표시"
     }
 
     val allowSkipHint: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -301,6 +301,9 @@ data class ShellConfig(
     @SerializedName("splashClickToSkip")
     val splashClickToSkip: Boolean = true,
 
+    @SerializedName("splashShowCountdown")
+    val splashShowCountdown: Boolean = true,
+
     @SerializedName("splashVideoStartMs")
     val splashVideoStartMs: Long = 0,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -533,7 +533,9 @@ data class SplashConfig(
     val enableAudio: Boolean = false,
     val videoStartMs: Long = 0,
     val videoEndMs: Long = 5000,
-    val videoDurationMs: Long = 0
+    val videoDurationMs: Long = 0,
+    // Show the Ns countdown in the top-right corner of the splash screen.
+    val showCountdown: Boolean = true
 )
 
 enum class SplashType {

--- a/app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AppModifierScreen.kt
@@ -773,6 +773,9 @@ private fun AppModifyContent(
                 onClickToSkipChange = { skip ->
                     update { copy(splashConfig = splashConfig.copy(clickToSkip = skip)) }
                 },
+                onShowCountdownChange = { show ->
+                    update { copy(splashConfig = splashConfig.copy(showCountdown = show)) }
+                },
                 onOrientationChange = { orientation ->
                     update { copy(splashConfig = splashConfig.copy(orientation = orientation)) }
                 },

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppScreen.kt
@@ -379,6 +379,11 @@ fun CreateAppScreen(
                             copy(splashConfig = splashConfig.copy(clickToSkip = it))
                         }
                     },
+                    onShowCountdownChange = {
+                        viewModel.updateEditState {
+                            copy(splashConfig = splashConfig.copy(showCountdown = it))
+                        }
+                    },
                     onOrientationChange = {
                         viewModel.updateEditState {
                             copy(splashConfig = splashConfig.copy(orientation = it))

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppSplashCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppSplashCard.kt
@@ -54,6 +54,7 @@ fun SplashScreenCard(
     onSelectVideo: () -> Unit,
     onDurationChange: (Int) -> Unit,
     onClickToSkipChange: (Boolean) -> Unit,
+    onShowCountdownChange: (Boolean) -> Unit,
     onOrientationChange: (SplashOrientation) -> Unit,
     onFillScreenChange: (Boolean) -> Unit,
     onEnableAudioChange: (Boolean) -> Unit,
@@ -70,6 +71,7 @@ fun SplashScreenCard(
         onSelectVideo = onSelectVideo,
         onDurationChange = onDurationChange,
         onClickToSkipChange = onClickToSkipChange,
+        onShowCountdownChange = onShowCountdownChange,
         onOrientationChange = onOrientationChange,
         onFillScreenChange = onFillScreenChange,
         onEnableAudioChange = onEnableAudioChange,
@@ -89,6 +91,7 @@ fun SplashScreenCard(
     onSelectVideo: () -> Unit,
     onDurationChange: (Int) -> Unit,
     onClickToSkipChange: (Boolean) -> Unit,
+    onShowCountdownChange: (Boolean) -> Unit,
     onOrientationChange: (SplashOrientation) -> Unit,
     onFillScreenChange: (Boolean) -> Unit,
     onEnableAudioChange: (Boolean) -> Unit,
@@ -271,6 +274,14 @@ fun SplashScreenCard(
                         icon = Icons.Outlined.TouchApp,
                         checked = splashConfig.clickToSkip,
                         onCheckedChange = onClickToSkipChange
+                    )
+
+                    WtaToggleRow(
+                        title = Strings.splashShowCountdownLabel,
+                        subtitle = Strings.splashShowCountdownHint,
+                        icon = Icons.Outlined.Timer,
+                        checked = splashConfig.showCountdown,
+                        onCheckedChange = onShowCountdownChange
                     )
 
                     WtaToggleRow(

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -29,6 +29,7 @@ fun ShellSplashOverlay(
     fillScreen: Boolean = true,
     enableAudio: Boolean = false,
     mediaPath: String? = null,
+    showCountdown: Boolean = true,
     onSkip: (() -> Unit)?,
     onComplete: (() -> Unit)? = null
 ) {
@@ -233,7 +234,8 @@ fun ShellSplashOverlay(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (displayTime > 0) {
+                val showNumber = showCountdown && displayTime > 0
+                if (showNumber) {
                     Text(
                         text = "${displayTime}s",
                         color = Color.White,
@@ -241,7 +243,7 @@ fun ShellSplashOverlay(
                     )
                 }
                 if (onSkip != null) {
-                    if (displayTime > 0) {
+                    if (showNumber) {
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = "|",

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -468,6 +468,7 @@ fun ShellScreen(
             fillScreen = config.splashFillScreen,
             enableAudio = config.splashEnableAudio,
             mediaPath = config.splashMediaPath,
+            showCountdown = config.splashShowCountdown,
 
             onSkip = if (config.splashClickToSkip) { closeSplash } else null,
 

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -243,6 +243,7 @@ fun SplashLauncherScreen(
                 videoEndMs = videoEndMs,
                 fillScreen = fillScreen,
                 enableAudio = enableAudio,
+                showCountdown = splashConfig.showCountdown,
                 onSkip = {
                     showSplash = false
                     onLaunchTarget()
@@ -427,6 +428,7 @@ fun SplashContent(
     videoEndMs: Long,
     fillScreen: Boolean,
     enableAudio: Boolean = false,
+    showCountdown: Boolean = true,
     onSkip: () -> Unit
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewSplashOverlay.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewSplashOverlay.kt
@@ -169,7 +169,8 @@ fun SplashOverlay(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (displayTime > 0) {
+                val showNumber = splashConfig.showCountdown && displayTime > 0
+                if (showNumber) {
                     Text(
                         text = "${displayTime}s",
                         color = Color.White,
@@ -177,7 +178,7 @@ fun SplashOverlay(
                     )
                 }
                 if (onSkip != null) {
-                    if (displayTime > 0) {
+                    if (showNumber) {
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = "|",


### PR DESCRIPTION
## What

Per user feedback, the `Ns` countdown in the top-right corner of the splash screen looks odd for some apps. It is now a per-app switch in the splash settings, **defaulting to on** (existing behaviour preserved).

## Changes

- **Model/chain**: `SplashConfig.showCountdown` (default `true`) → `SplashBlock.showCountdown` → shell config `splashShowCountdown` via `ApkConfigJsonFactory`. `check_config_field_drift` OK (payload=437, shared=429). No Room migration needed (splashConfig is a JSON column).
- **Editor**: new **Show countdown** toggle in `SplashScreenCard` (`CreateAppScreen` + `AppModifierScreen` entry points), with 10-language strings.
- **Runtime**: when disabled, the countdown number is hidden in all three splash renderers — `ShellSplashOverlay` (generated APKs), `SplashOverlay` (WebViewActivity) and `SplashContent` (shortcut-launcher mode). The **skip button remains independent** of the countdown (still governed by `Allow Skip`).

## Verification

- `:app:compileDebugKotlin` passes; drift check OK; shell template rebuilt (dex contains `splashShowCountdown`).