### PR TITLE
fix(errorpage): pause auto-retry countdown while the mini-game is open

### DIFF
--- a/app/src/main/java/com/webtoapp/core/errorpage/ErrorPageManager.kt
+++ b/app/src/main/java/com/webtoapp/core/errorpage/ErrorPageManager.kt
@@ -332,22 +332,27 @@ function retryLoad(){
     else location.reload();
 }
 ${if (autoRetry > 0) """
-(function(){
+var __autoRetryTimer=null;
+function __stopAutoRetry(){if(__autoRetryTimer){clearInterval(__autoRetryTimer);__autoRetryTimer=null;}}
+function __startAutoRetry(){
+    if(__autoRetryTimer)return;
     var sec=$autoRetry,el=document.getElementById('countdown');
-    var t=setInterval(function(){
+    __autoRetryTimer=setInterval(function(){
         sec--;if(el)el.textContent=sec;
-        if(sec<=0){clearInterval(t);retryLoad();}
+        if(sec<=0){__stopAutoRetry();retryLoad();}
     },1000);
-})();
+}
+__startAutoRetry();
 """ else ""}
 
 ${if (showGame) """
 var __gameStarted=false;
 function showGame(){
+    __stopAutoRetry();
     document.getElementById('gameOverlay').classList.add('active');
     if(!__gameStarted){__gameStarted=true;startGame();}
 }
-function hideGame(){document.getElementById('gameOverlay').classList.remove('active');}
+function hideGame(){document.getElementById('gameOverlay').classList.remove('active');__startAutoRetry();}
 function startGame(){
     $gameJs
 }
@@ -478,22 +483,27 @@ function retryLoad(){
     else location.reload();
 }
 ${if (autoRetry > 0) """
-(function(){
+var __autoRetryTimer=null;
+function __stopAutoRetry(){if(__autoRetryTimer){clearInterval(__autoRetryTimer);__autoRetryTimer=null;}}
+function __startAutoRetry(){
+    if(__autoRetryTimer)return;
     var sec=$autoRetry,el=document.getElementById('countdown');
-    var t=setInterval(function(){
+    __autoRetryTimer=setInterval(function(){
         sec--;if(el)el.textContent=sec;
-        if(sec<=0){clearInterval(t);retryLoad();}
+        if(sec<=0){__stopAutoRetry();retryLoad();}
     },1000);
-})();
+}
+__startAutoRetry();
 """ else ""}
 
 ${if (showGame) """
 var __gameStarted=false;
 function showGame(){
+    __stopAutoRetry();
     document.getElementById('gameOverlay').classList.add('active');
     if(!__gameStarted){__gameStarted=true;startGame();}
 }
-function hideGame(){document.getElementById('gameOverlay').classList.remove('active');}
+function hideGame(){document.getElementById('gameOverlay').classList.remove('active');__startAutoRetry();}
 function startGame(){
     $gameJs
 }


### PR DESCRIPTION
## Problem

The offline error page's auto-retry (configured via `autoRetrySeconds`) ran an **unconditional JS countdown** that called `location.reload()` when it hit zero. Opening the offline mini-game did not stop it — after ~15s the page reloaded, the game DOM was rebuilt from scratch, and the game exited mid-play.

## Fix

Both error-page templates (built-in `generateBuiltInPage` and legacy `generateLegacyPage`) now expose `__stopAutoRetry()` / `__startAutoRetry()`:

- **Opening the game** (`showGame()`) pauses the countdown — game play is never interrupted.
- **Closing the game** (`hideGame()`) restarts the countdown from the configured interval, so connectivity re-checking resumes.
- Manual retry button and countdown display are unchanged.

## Verification

- `:app:compileStandardDebugKotlin` passes; shell template rebuilt (dex contains `__stopAutoRetry`).