### PR TITLE
feat(gplay): Google Play distribution channel with high-targetSdk runtime guards

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -56,7 +56,7 @@ jobs:
             -PallowDebugSignedRelease=true \
             :app:compileStandardDebugKotlin \
             :shell:compileDebugKotlin \
-            :app:testDebugUnitTest \
+            :app:testStandardDebugUnitTest \
             :app:checkConfigFieldDrift
 
   package-apks:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -54,7 +54,7 @@ jobs:
             -Dkotlin.compiler.execution.strategy=in-process \
             -PskipShellTemplateSync=true \
             -PallowDebugSignedRelease=true \
-            :app:compileDebugKotlin \
+            :app:compileStandardDebugKotlin \
             :shell:compileDebugKotlin \
             :app:testDebugUnitTest \
             :app:checkConfigFieldDrift
@@ -98,8 +98,8 @@ jobs:
           ./gradlew --no-daemon --no-configuration-cache \
             -Dkotlin.compiler.execution.strategy=in-process \
             -PallowDebugSignedRelease=true \
-            :app:assembleDebug \
-            :app:assembleRelease \
+            :app:assembleStandardDebug \
+            :app:assembleStandardRelease \
             :shell:assembleDebug \
             :shell:assembleRelease
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,24 @@ android {
         }
     }
 
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("standard") {
+            // Default full-capability variant: targetSdk 28 is required so the host can
+            // fork+exec native server runtimes (Node/PHP/Python/Go/WordPress) from app
+            // storage. Keep this low — do not raise without re-validating every runtime.
+            buildConfigField("boolean", "GPLAY_CHANNEL", "false")
+        }
+        create("gplay") {
+            // Google Play distribution variant. Play requires targetSdk 35+ for new apps.
+            // NOTE: native fork+exec runtimes (esp. Node.js V8 JIT, Go memfd exec) may fail
+            // under the stricter SELinux policy of high targetSdk; runtime launch is guarded
+            // to degrade gracefully (see BuildConfig.GPLAY_CHANNEL) rather than crash.
+            targetSdk = 35
+            buildConfigField("boolean", "GPLAY_CHANNEL", "true")
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")

--- a/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/runtime/AgentService.kt
@@ -315,7 +315,16 @@ class AgentService : Service() {
 
     private fun promoteToForeground(text: String) {
         if (inForeground) return
-        startForeground(NOTIFICATION_ID, buildNotification(text))
+        val notification = buildNotification(text)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
         inForeground = true
     }
 

--- a/app/src/main/java/com/webtoapp/core/floatingwindow/FloatingWindowService.kt
+++ b/app/src/main/java/com/webtoapp/core/floatingwindow/FloatingWindowService.kt
@@ -107,7 +107,16 @@ class FloatingWindowService : Service() {
                     FloatingWindowConfig(enabled = true)
                 }
 
-                startForeground(NOTIFICATION_ID, createNotification(appName))
+                val notification = createNotification(appName)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    startForeground(
+                        NOTIFICATION_ID,
+                        notification,
+                        android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                    )
+                } else {
+                    startForeground(NOTIFICATION_ID, notification)
+                }
 
                 val translateBridgeFactory: ((WebView) -> Unit)? = if (translateEnabled) {
                     { webView ->

--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -25,6 +25,17 @@ class GoRuntime(private val context: Context) {
         private const val TAG = "GoRuntime"
         private const val MAX_HEALTH_CHECK_RETRIES = 30
         private const val HEALTH_CHECK_INTERVAL_MS = 500L
+
+        /**
+         * Go execs via memfd_create + execveat, which is increasingly restricted under the SELinux
+         * policy of a high-targetSdk (Google Play) channel. Surface the channel limitation on
+         * launch failure instead of looking like a generic crash.
+         * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
+         */
+        private fun channelNote(): String =
+            if (com.webtoapp.BuildConfig.GPLAY_CHANNEL) {
+                " [Google Play 渠道：受高 targetSdk 限制，Go 运行时可能不可用]"
+            } else ""
     }
 
     sealed class ServerState {
@@ -194,12 +205,12 @@ class GoRuntime(private val context: Context) {
             }
         } catch (e: Exception) {
             AppLogger.e(TAG, "启动 Go 服务器失败", e)
-            ShellLogger.e(TAG, "启动 Go 服务器失败: ${e.message}")
+            ShellLogger.e(TAG, "启动 Go 服务器失败: ${e.message}${channelNote()}")
             if (dnsProxyStarted) {
                 LocalDnsBridgeProxy.stop()
                 dnsProxyStarted = false
             }
-            _serverState.value = ServerState.Error("启动失败: ${e.message}")
+            _serverState.value = ServerState.Error("启动失败: ${e.message}${channelNote()}")
             -1
         }
     }

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -25,6 +25,17 @@ class NodeService : Service() {
         private const val TAG = "NodeService"
         private const val MAX_HEALTH_CHECK_RETRIES = 60
         private const val HEALTH_CHECK_INTERVAL_MS = 500L
+
+        /**
+         * Node.js runs via dlopen(libnode.so) + V8 JIT, which needs RWX memory. Under the stricter
+         * SELinux policy of a high-targetSdk (Google Play) channel this can fail at dlopen/exec time.
+         * Surface the channel limitation to the user instead of looking like a generic crash.
+         * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
+         */
+        private fun channelNote(): String =
+            if (com.webtoapp.BuildConfig.GPLAY_CHANNEL) {
+                " [Google Play 渠道：受高 targetSdk 限制，Node.js 运行时可能不可用]"
+            } else ""
     }
 
     private val workerThread = HandlerThread("NodeService-worker").apply { start() }
@@ -150,7 +161,7 @@ class NodeService : Service() {
                 replyFailed(
                     replyTo,
                     requestId,
-                    "libnode_bridge.so 加载失败 ($detail)。导出的 NODEJS_APP 需包含 libnode_bridge.so 与 libc++_shared.so；请用最新构建器重新导出。"
+                    "libnode_bridge.so 加载失败 ($detail)。导出的 NODEJS_APP 需包含 libnode_bridge.so 与 libc++_shared.so；请用最新构建器重新导出。${channelNote()}"
                 )
                 return
             }
@@ -160,7 +171,7 @@ class NodeService : Service() {
                 replyFailed(
                     replyTo,
                     requestId,
-                    "libnode.so 加载失败 ($path)。请确认 APK 含 16KB 对齐的 libnode.so，或在主机下载 Node 运行时后重新导出。"
+                    "libnode.so 加载失败 ($path)。请确认 APK 含 16KB 对齐的 libnode.so，或在主机下载 Node 运行时后重新导出。${channelNote()}"
                 )
                 return
             }

--- a/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
@@ -216,7 +216,13 @@ class WebMediaPlaybackService : Service() {
                 if (isPlaying) ACTION_PLAYING else ACTION_PAUSED
             )
 
-            ContextCompat.startForegroundService(context, intent)
+            try {
+                ContextCompat.startForegroundService(context, intent)
+            } catch (e: Exception) {
+                // targetSdk 34+ may reject background FGS start with
+                // ForegroundServiceStartNotAllowedException; fail soft rather than crash.
+                android.util.Log.w("WebMediaPlayback", "startForegroundService rejected for media playback", e)
+            }
         }
 
         fun stop(context: Context) {
@@ -225,7 +231,11 @@ class WebMediaPlaybackService : Service() {
                 WebMediaPlaybackService::class.java
             ).setAction(ACTION_STOPPED)
 
-            ContextCompat.startForegroundService(context, intent)
+            try {
+                ContextCompat.startForegroundService(context, intent)
+            } catch (e: Exception) {
+                android.util.Log.w("WebMediaPlayback", "startForegroundService rejected for media stop", e)
+            }
         }
 
         fun commandPendingIntent(

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -1365,7 +1365,12 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun bindService() {
         val intent = Intent(ctx, AgentService::class.java)
-        ContextCompat.startForegroundService(ctx, intent)
+        try {
+            ContextCompat.startForegroundService(ctx, intent)
+        } catch (e: Exception) {
+            // targetSdk 34+ may reject background FGS start; bind only in that case.
+            AppLogger.w("AgentViewModel", "startForegroundService rejected, falling back to bind only", e)
+        }
         ctx.bindService(intent, connection, Context.BIND_AUTO_CREATE)
     }
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -700,10 +700,15 @@ class ShellActivity : AppCompatActivity() {
             putExtra(FloatingWindowService.EXTRA_TRANSLATE_TARGET_LANGUAGE, config.translateTargetLanguage)
             putExtra(FloatingWindowService.EXTRA_TRANSLATE_SHOW_BUTTON, config.translateShowButton)
         }
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            startForegroundService(intent)
-        } else {
-            startService(intent)
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                startForegroundService(intent)
+            } else {
+                startService(intent)
+            }
+        } catch (e: Exception) {
+            // targetSdk 34+ may reject background FGS start; the floating window may not appear.
+            com.webtoapp.core.shell.ShellLogger.w("ShellActivity", "悬浮窗服务启动被拒: ${e.message}")
         }
         com.webtoapp.core.shell.ShellLogger.i("ShellActivity", "悬浮窗服务已启动，关闭主 Activity")
         finish()

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -28,6 +28,11 @@ android {
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 
+        // Shell template never ships to Google Play — it is the runtime host for *generated* apps,
+        // which always use targetSdk 28 (fork+exec). The GPLAY_CHANNEL flag is mirrored here only so
+        // shell-synced runtime sources (NodeService/GoRuntime) that reference it compile cleanly.
+        buildConfigField("boolean", "GPLAY_CHANNEL", "false")
+
         vectorDrawables {
             useSupportLibrary = true
         }


### PR DESCRIPTION
## What

Adds a **distribution flavor split** so the host app can ship on Google Play (which requires targetSdk 35+ for new apps) while **generated APKs and the shell template keep targetSdk 28** (required for on-device fork+exec native runtimes).

## Changes

- **app/build.gradle.kts**: product flavors
  - `standard` — targetSdk 28, GPLAY_CHANNEL=false (default full capability)
  - `gplay` — targetSdk 35, GPLAY_CHANNEL=true (Play distribution)
- **shell/build.gradle.kts**: mirrors GPLAY_CHANNEL=false so shell-synced sources compiling against BuildConfig.GPLAY_CHANNEL stay clean; the shell template never ships to Play and always stays targetSdk 28.
- **Foreground service type (Android 14+)**: AgentService (DATA_SYNC) and FloatingWindowService (SPECIAL_USE) pass the required FOREGROUND_SERVICE_TYPE so startForeground doesn't crash under targetSdk 35.
- **Graceful FGS start**: startForegroundService in WebMediaPlaybackService, AgentViewModel and ShellActivity (floating window) is wrapped so a background-start rejection (targetSdk 34+) degrades instead of crashing.
- **Channel-aware runtime errors**: GoRuntime / NodeService append a channel limitation note when GPLAY_CHANNEL is true (memfd exec / V8 RWX JIT may be restricted under high-targetSdk SELinux policy).

## Verification

- :app:compileStandardDebugKotlin and :app:compileGplayDebugKotlin both pass.
- Shell template rebuilt (dex contains GPLAY_CHANNEL).
