### PR TITLE
fix(media): stop foreground-service crash on launch in generated apps

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
@@ -69,6 +69,15 @@ class MediaSessionBridge(
 
     private var playbackState = PlaybackState.STATE_NONE
 
+    /**
+     * `true` once any non-`none` playback state has ever been reported. Used to
+     * guard [clearPlayback] so the initial `STATE_NONE` event (emitted during
+     * page load before any media exists) does not run full media-session
+     * teardown — which would otherwise stop the playback service on every cold
+     * start.
+     */
+    private var hasActivePlaybackSession = false
+
     private val supportedActions = mutableSetOf<String>()
 
     @Volatile
@@ -244,9 +253,16 @@ class MediaSessionBridge(
 
     private fun publish() {
         if (playbackState == PlaybackState.STATE_NONE) {
-            clearPlayback()
+            // Only tear down when media has actually been active at some point.
+            // The initial "none" state arrives during page load before any media
+            // exists, and running full cleanup there is unnecessary and risky.
+            if (hasActivePlaybackSession || mediaSession.isActive || lastNotification != null) {
+                clearPlayback()
+            }
             return
         }
+
+        hasActivePlaybackSession = true
 
         applyMetadata()
         applyPlaybackState()
@@ -564,6 +580,8 @@ class MediaSessionBridge(
     }
 
     private fun clearPlayback() {
+        hasActivePlaybackSession = false
+
         playbackState = PlaybackState.STATE_NONE
         positionSeconds = 0.0
         durationSeconds = 0.0

--- a/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
@@ -55,17 +55,6 @@ class WebMediaPlaybackService : Service() {
                 stopSelf()
             }
 
-            ACTION_STOPPED -> {
-                releaseWakeLock()
-
-                stopForegroundCompat(STOP_FOREGROUND_REMOVE)
-
-                getSystemService(NotificationManager::class.java)
-                    .cancel(NOTIFICATION_ID)
-
-                stopSelf()
-            }
-
             ACTION_MEDIA_COMMAND -> {
                 /*
                  * A foreground-service PendingIntent is used for notification
@@ -196,9 +185,6 @@ class WebMediaPlaybackService : Service() {
         private const val ACTION_PAUSED =
             "com.webtoapp.media.PAUSED"
 
-        private const val ACTION_STOPPED =
-            "com.webtoapp.media.STOPPED"
-
         private const val ACTION_MEDIA_COMMAND =
             "com.webtoapp.media.COMMAND"
 
@@ -225,17 +211,31 @@ class WebMediaPlaybackService : Service() {
             }
         }
 
+        /**
+         * Stops the media playback service if it is running.
+         *
+         * This deliberately uses [Context.stopService] instead of
+         * [ContextCompat.startForegroundService] with a stop action: starting a
+         * foreground service only to stop it violates the foreground-service
+         * contract (the service must call [android.app.Service.startForeground]
+         * within the startup deadline), which crashed generated apps on launch
+         * when the initial Media Session state was `none`. [Context.stopService]
+         * is a no-op when the service is not running and creates no such
+         * obligation.
+         */
         fun stop(context: Context) {
-            val intent = Intent(
-                context,
-                WebMediaPlaybackService::class.java
-            ).setAction(ACTION_STOPPED)
+            val appContext = context.applicationContext
 
-            try {
-                ContextCompat.startForegroundService(context, intent)
-            } catch (e: Exception) {
-                android.util.Log.w("WebMediaPlayback", "startForegroundService rejected for media stop", e)
-            }
+            appContext
+                .getSystemService(NotificationManager::class.java)
+                .cancel(NOTIFICATION_ID)
+
+            appContext.stopService(
+                Intent(
+                    appContext,
+                    WebMediaPlaybackService::class.java
+                )
+            )
         }
 
         fun commandPendingIntent(


### PR DESCRIPTION
Closes #495

## Problem

Generated apps crashed shortly after launch with `ForegroundServiceDidNotStartInTimeException` when **Media Session integration** was enabled — no playback needed, the initial `none` state alone triggered it. This was a critical regression introduced in v2.4.3 by commit `d9dee285` (#487).

## Root cause

`WebMediaPlaybackService.stop()` started a foreground service (`ContextCompat.startForegroundService` with `ACTION_STOPPED`) only to stop it, but the `ACTION_STOPPED` branch never called `startForeground()`. Android requires a service started via `startForegroundService()` to call `startForeground()` within the startup deadline; otherwise it throws `ForegroundServiceDidNotStartInTimeException` and kills the app.

The crash path on cold start:
```
App launches
  → JS bridge reports initial state playbackState = "none"  (normal, no media yet)
  → MediaSessionBridge.updatePlaybackState("none") → publish()
  → STATE_NONE branch → clearPlayback() → WebMediaPlaybackService.stop()
  → ContextCompat.startForegroundService(ACTION_STOPPED)
  → onStartCommand: ACTION_STOPPED → stopForeground() + stopSelf()  (no startForeground!)
  → ForegroundServiceDidNotStartInTimeException → crash
```

The `try/catch` around `startForegroundService()` could not help because the exception is thrown asynchronously by the system after the FGS deadline, outside the try block.

## Fix

### 1. `WebMediaPlaybackService.stop()` — use `Context.stopService()`
Replaced `startForegroundService(ACTION_STOPPED)` with `Context.stopService()`, which is a no-op when the service isn't running and creates **no** foreground-service obligation. Removed the `ACTION_STOPPED` constant and its `onStartCommand` branch (the service no longer needs an action to stop itself).

### 2. `MediaSessionBridge` — `hasActivePlaybackSession` guard
Added a `hasActivePlaybackSession` flag so `publish()` does not run full media-session teardown (`clearPlayback()` → `stop()`) for the initial `STATE_NONE` event that arrives during page load before any media has ever existed. It is set `true` on the first non-`none` state and reset in `clearPlayback()`. This is a defensive second layer — the primary fix is the `stopService()` change.

## Shell template

Both classes are shell-synced (`**/core/webview/**`), so the fix reaches generated APKs through the `webview_shell.apk` template. Verified the rebuilt template DEX no longer contains the `com.webtoapp.media.STOPPED` action string.

## Verification
- `:app:compileStandardDebugKotlin` / `:app:compileGplayDebugKotlin` ✅
- `:shell:assembleRelease` + `:app:syncShellTemplateApk` ✅ (clean rebuild)
- Template DEX confirmed free of `ACTION_STOPPED` string ✅

🤖 Generated with help from ZCode