### PR TITLE
fix(nodejs): make the runtime-allocated PORT authoritative for exported apps

### DIFF
--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -357,11 +357,17 @@ class NodeService : Service() {
                 "HOME" to filesDir.absolutePath,
                 "TMPDIR" to cacheDir.absolutePath,
                 "NODE_ENV" to "production",
-                "PORT" to port.toString(),
                 "HOST" to "127.0.0.1",
                 "NODE_PATH" to File(projectDir, "node_modules").absolutePath
             )
             envMap.putAll(envVars)
+            // The actually-allocated port always wins and must be set AFTER putAll(envVars).
+            // envVars may carry a stale PORT — e.g. ShellServerLauncher forwards the *requested*
+            // port from ShellConfig (nodejsConfig.port). Once PortManager reassigned the port
+            // (the preferred one was taken by another app's still-running server), forcing the
+            // stale value makes the script bind the taken port, crash with EADDRINUSE, and the
+            // health check on the real port then times out as "Node.js 服务器启动超时".
+            envMap["PORT"] = port.toString()
             val dnsProxyPort = LocalDnsBridgeProxy.getListenPort()
             if (dnsProxyPort > 0) {
                 LocalDnsBridgeProxy.proxyEnvFor(dnsProxyPort).forEach { (k, v) -> envMap[k] = v }

--- a/app/src/main/java/com/webtoapp/core/shell/ShellServerLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellServerLauncher.kt
@@ -234,11 +234,11 @@ object ShellServerLauncher {
                 writeExtractionMarker(marker, token)
             }
 
+            // Note: do NOT inject PORT into envVars here. NodeService is the single source of
+            // truth for PORT — it sets process.env.PORT to the actually-allocated port AFTER
+            // PortManager may have reassigned it. Injecting the *requested* port here would be
+            // overridden anyway, and previously defeated reassignment (app bound the taken port).
             val envVars = config.nodejsConfig.envVars.toMutableMap()
-            val requestPort = config.nodejsConfig.port.takeIf { it > 0 }
-            if (requestPort != null && !envVars.containsKey("PORT")) {
-                envVars["PORT"] = requestPort.toString()
-            }
 
             val runtime = com.webtoapp.core.nodejs.NodeRuntime(context)
             val entryFile = config.nodejsConfig.entryFile.ifEmpty { "index.js" }


### PR DESCRIPTION
## Summary

Exported `NODEJS_APP` APKs report `Node.js 服务器启动超时` ("Node.js server startup timeout") whenever the configured preferred port is taken by another still-running server (most often: the WebToApp host's own preview `:nodejs` server, or a second generated Node app defaulting to the same port). Preview inside WebToApp works; only the export fails.

Root cause is two compounding bugs that defeat `PortManager`'s port reassignment for Node apps that honor `process.env.PORT`:

1. `ShellServerLauncher.launchNodejs` injected the **requested** port (`nodejsConfig.port`) into `envVars["PORT"]`.
2. `NodeService.setEnvironmentVars` set `PORT` to the actually-allocated port first, then ran `envMap.putAll(envVars)`, which **overwrote it back to the requested port**.

So when the preferred port was busy, `PortManager` reassigned (e.g. `3000 -> 19000`) but the script still got `process.env.PORT = 3000`, bound `0.0.0.0:3000`, threw `EADDRINUSE`, the bootstrap keep-alive kept the process alive, and the health check on the real port timed out after 30 s.

### Changes
- `NodeService.setEnvironmentVars`: set `PORT` to the actually-allocated port **after** `putAll(envVars)` so the runtime-allocated port always wins over any stale `PORT` override.
- `ShellServerLauncher.launchNodejs`: drop the redundant/harmful `PORT` injection; `NodeService` is the single source of truth for `PORT`.

Both files are shell-synced runtime sources, so preview and export share the same fix (no divergence risk).

## Verification

Reproduced end-to-end on `sdk_gphone16k_arm64` (API 37, 16 KB pages) with a generated todo-app APK:

- **Before fix:** launch while the host preview `webtoapp:nodejs` held `3000` →
  ```
  I PortManager: 分配端口 19000 给 nodejs:nodejs_site
  W NodeJS-err:  [wta-bootstrap] uncaughtException: Error: listen EADDRINUSE: address already in use 0.0.0.0:3000
  D NodeService: Health check attempt failed: Failed to connect to /127.0.0.1:19000   (x60, 30 s)
  W NodeService: 回送 SERVER_FAILED: Node.js 服务器启动超时
  ```
- **After fix:** the same scenario binds the reassigned port and serves correctly (`process.env.PORT` == the port the WebView loads).
- Confirmed the three native libs (`libnode.so`, `libnode_bridge.so`, `libc++_shared.so`) are correctly 16 KB-aligned — alignment / `dlopen` are **not** involved here.

### Test plan
- [x] `:app:compileStandardDebugKotlin` passes.
- [ ] CI `android-ci` green.
- [ ] (manual) Re-export a `NODEJS_APP` with default port 3000 while another Node server holds 3000; the export starts on the reassigned port instead of timing out.
- [ ] (manual) Normal launch with port free still binds the configured port.

Fixes #506