### PR TITLE
feat(about): localize release notes by app language + fix duplicate Close button

### DIFF
--- a/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/update/UpdateChecker.kt
@@ -1,5 +1,7 @@
 package com.webtoapp.core.update
 
+import com.webtoapp.core.i18n.AppLanguage
+import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.logging.AppLogger
 import java.io.BufferedReader
 import java.net.HttpURLConnection
@@ -21,6 +23,33 @@ object UpdateChecker {
         "https://api.github.com/repos/$OWNER/$REPO/releases?per_page=100"
 
     private const val TIMEOUT_MS = 12000
+
+    /**
+     * Invisible boundary that separates the English and Chinese halves of a GitHub release body
+     * (English first, Chinese after the marker). It renders as nothing on the releases page, so
+     * readers see English then Chinese; the app picks the half matching the current language.
+     * Releases without the marker (older notes, or a future release nobody localized yet) fall
+     * back to the whole body, which is English — never blank.
+     */
+    private const val ZH_MARKER = "<!-- zh-CN -->"
+
+    /**
+     * Returns the release body in the current app language: the Chinese half when the app is set
+     * to Chinese and a Chinese half exists, otherwise the English half (or the whole body when the
+     * marker is absent).
+     */
+    private fun localizeReleaseBody(body: String): String {
+        val raw = body.trim()
+        val idx = raw.indexOf(ZH_MARKER)
+        if (idx < 0) return raw
+        val english = raw.substring(0, idx).trim()
+        val chinese = raw.substring(idx + ZH_MARKER.length).trim()
+        return if (Strings.currentLanguage.value == AppLanguage.CHINESE && chinese.isNotBlank()) {
+            chinese
+        } else {
+            english
+        }
+    }
 
     data class Version(val major: Int, val minor: Int, val patch: Int) : Comparable<Version> {
         override fun toString(): String = "$major.$minor.$patch"
@@ -110,7 +139,7 @@ object UpdateChecker {
                 sizeBytes = asset.optLong("size", 0L),
                 sha256 = asset.optString("digest").takeIf { it.isNotBlank() }
                     ?.substringAfter("sha256:", "")?.takeIf { it.isNotBlank() },
-                releaseNotes = release.optString("body").trim()
+                releaseNotes = localizeReleaseBody(release.optString("body"))
             )
             Result.UpdateAvailable(info, current.toString())
         } catch (e: Exception) {
@@ -145,7 +174,7 @@ object UpdateChecker {
                         version = version,
                         name = release.optString("name").trim(),
                         publishedAt = release.optString("published_at").trim(),
-                        body = release.optString("body").trim(),
+                        body = localizeReleaseBody(release.optString("body")),
                         downloadUrl = rawUrl?.let { withMirror(it) },
                         sizeBytes = asset?.optLong("size", 0L) ?: 0L,
                         sha256 = asset?.optString("digest").takeIf { !it.isNullOrBlank() }

--- a/app/src/main/java/com/webtoapp/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AboutScreen.kt
@@ -643,6 +643,11 @@ private fun UpdateCheckDialog(
     val available = result as? com.webtoapp.core.update.UpdateChecker.Result.UpdateAvailable
     val downloading = downloadState is com.webtoapp.core.update.UpdateDownloadState.Downloading ||
         downloadState is com.webtoapp.core.update.UpdateDownloadState.Verifying
+    // True when the confirmButton shows a real action (Download/Install/Retry/Cancel). When false
+    // (UpToDate / Failed), confirmButton itself is "Close" — the dismissButton must stay empty in
+    // that case or the dialog shows two identical Close buttons.
+    val hasActionButton = available != null ||
+        downloadState is com.webtoapp.core.update.UpdateDownloadState.Done
 
     androidx.compose.material3.AlertDialog(
         onDismissRequest = {
@@ -732,8 +737,10 @@ private fun UpdateCheckDialog(
             }
         },
         dismissButton = {
-            androidx.compose.material3.TextButton(onClick = onDismiss) {
-                Text(Strings.close)
+            if (hasActionButton) {
+                androidx.compose.material3.TextButton(onClick = onDismiss) {
+                    Text(Strings.close)
+                }
             }
         }
     )


### PR DESCRIPTION
## Summary

Two small fixes in the About → Check Updates flow.

### 1. Release notes follow the app language
`UpdateChecker` rendered the GitHub release `body` verbatim, so a Chinese-language user saw the English changelog in both the update dialog and the version-history sheet. Release bodies now carry an English section then a Chinese section separated by an invisible `<!-- zh-CN -->` marker (invisible on the rendered releases page). `UpdateChecker.localizeReleaseBody` returns:
- the **Chinese** half when `AppLanguage.CHINESE`,
- the **English** half for every other language,
- the whole body when the marker is absent (older / future un-localized notes never break).

Applied at both consumers: the update-dialog `releaseNotes` and the version-history `body`. The 17 published GitHub releases (v2.0.3 → v2.4.3) were updated separately with bilingual bodies.

### 2. Duplicate "Close" button when up-to-date
`UpdateCheckDialog` (an `AlertDialog`) rendered two identical Close buttons in the UpToDate / Failed states: `confirmButton` fell through to a Close button while `dismissButton` unconditionally rendered another. Now `dismissButton` only renders its Close when `confirmButton` is showing a real action (Download / Install / Retry / Cancel); the single `confirmButton` Close remains otherwise.

| state | confirm | dismiss |
|---|---|---|
| Up-to-date / check failed | Close | — |
| Update available | Download | Close |
| Downloading | Cancel download | Close |
| Downloaded | Install | Close |
| Download failed | Retry | Close |

## Test plan
- [x] `:app:compileStandardDebugKotlin` passes.
- [ ] CI `android-ci` green.
- [ ] (manual) App in Chinese → Check Updates / Version History show Chinese notes; switch to English (or any other language) → English.
- [ ] (manual) On the latest version, Check Updates shows exactly one Close button.

Host-only changes; no shell/runtime impact.

Fixes #508