### PR TITLE
fix(python): make pip subprocess installs work on-device (Fixes #505)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -3581,6 +3581,8 @@ object Strings {
     val pyDepsRetrying: String get() = StringsD.pyDepsRetrying
     val pyDepsInstallTimeout: String get() = StringsD.pyDepsInstallTimeout
     val pyDepsInstallFailedCode: String get() = StringsD.pyDepsInstallFailedCode
+    val pyDepsNoWheelHint: String get() = StringsD.pyDepsNoWheelHint
+    val pyDepsSourceBuildHint: String get() = StringsD.pyDepsSourceBuildHint
     val pyDownloadSourceLabel: String get() = StringsD.pyDownloadSourceLabel
     val pyExtractNoBinary: String get() = StringsD.pyExtractNoBinary
     val pyExtractFailed: String get() = StringsD.pyExtractFailed
@@ -49647,6 +49649,30 @@ object StringsD {
         AppLanguage.RUSSIAN -> "Установка зависимостей не удалась (exitCode=%d)"
         AppLanguage.JAPANESE -> "依存関係のインストール失敗 (exitCode=%d)"
         AppLanguage.KOREAN -> "의존성 설치 실패 (exitCode=%d)"
+    }
+    val pyDepsNoWheelHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "软件包 \"%s\" 没有适用于本机 Python %s 的预编译 wheel，且设备端 Python 无法从源码编译。请尝试升级该软件包或移除版本锁定。"
+        AppLanguage.ENGLISH -> "Package \"%s\" has no prebuilt wheel for Python %s on this device, and the on-device Python cannot compile packages from source. Try upgrading the package or removing its version pin."
+        AppLanguage.ARABIC -> "لا توجد حزمة wheel جاهزة للحزمة \"%s\" لإصدار Python %s على هذا الجهاز، ولا يمكن لبيئة Python على الجهاز تجميع الحزم من المصدر. جرّب ترقية الحزمة أو إزالة تثبيت الإصدار."
+        AppLanguage.PORTUGUESE -> "O pacote \"%s\" não tem wheel pré-compilada para Python %s neste dispositivo, e o Python no dispositivo não consegue compilar pacotes a partir do código-fonte. Tente atualizar o pacote ou remover a fixação de versão."
+        AppLanguage.SPANISH -> "El paquete \"%s\" no tiene wheel precompilada para Python %s en este dispositivo, y el Python del dispositivo no puede compilar paquetes desde el código fuente. Intenta actualizar el paquete o eliminar la fijación de versión."
+        AppLanguage.FRENCH -> "Le paquet « %s » n'a pas de wheel précompilée pour Python %s sur cet appareil, et le Python de l'appareil ne peut pas compiler les paquets depuis le code source. Essayez de mettre à jour le paquet ou de retirer l'épinglage de version."
+        AppLanguage.GERMAN -> "Für Paket \"%s\" gibt es kein vorgefertigtes Wheel für Python %s auf diesem Gerät, und das Python auf dem Gerät kann Pakete nicht aus dem Quellcode kompilieren. Versuchen Sie, das Paket zu aktualisieren oder die Versionsfestlegung zu entfernen."
+        AppLanguage.RUSSIAN -> "Для пакета «%s» нет готового wheel для Python %s на этом устройстве, а Python на устройстве не может компилировать пакеты из исходного кода. Попробуйте обновить пакет или убрать фиксацию версии."
+        AppLanguage.JAPANESE -> "このデバイスの Python %s 向けにパッケージ「%s」のプリビルド wheel がなく、デバイス上の Python はソースからのコンパイルができません。パッケージをアップグレードするか、バージョン固定を解除してみてください。"
+        AppLanguage.KOREAN -> "이 기기의 Python %s용 패키지 \"%s\" 사전 빌드 wheel이 없으며, 기기 내 Python은 소스에서 패키지를 컴파일할 수 없습니다. 패키지를 업그레이드하거나 버전 고정을 제거해 보세요."
+    }
+    val pyDepsSourceBuildHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "本机 Python %s 没有可用的预编译 wheel，源码构建需要编译器，而设备端没有编译器。请尝试升级软件包或移除版本锁定。"
+        AppLanguage.ENGLISH -> "No prebuilt wheel is available for Python %s on this device, and source builds need a compiler that is not available on-device. Try upgrading the package or removing the version pin."
+        AppLanguage.ARABIC -> "لا توجد حزمة wheel جاهزة لإصدار Python %s على هذا الجهاز، ويتطلب البناء من المصدر مترجمًا غير متوفر على الجهاز. جرّب ترقية الحزمة أو إزالة تثبيت الإصدار."
+        AppLanguage.PORTUGUESE -> "Não há wheel pré-compilada disponível para Python %s neste dispositivo, e a compilação a partir do código-fonte exige um compilador indisponível no dispositivo. Tente atualizar o pacote ou remover a fixação de versão."
+        AppLanguage.SPANISH -> "No hay wheel precompilada disponible para Python %s en este dispositivo, y compilar desde el código fuente requiere un compilador no disponible en el dispositivo. Intenta actualizar el paquete o eliminar la fijación de versión."
+        AppLanguage.FRENCH -> "Aucune wheel précompilée n'est disponible pour Python %s sur cet appareil, et la compilation depuis le code source nécessite un compilateur indisponible sur l'appareil. Essayez de mettre à jour le paquet ou de retirer l'épinglage de version."
+        AppLanguage.GERMAN -> "Für Python %s ist auf diesem Gerät kein vorgefertigtes Wheel verfügbar, und Quellcode-Builds benötigen einen Compiler, der auf dem Gerät nicht vorhanden ist. Versuchen Sie, das Paket zu aktualisieren oder die Versionsfestlegung zu entfernen."
+        AppLanguage.RUSSIAN -> "Нет готового wheel для Python %s на этом устройстве, а сборка из исходного кода требует компилятор, который недоступен на устройстве. Попробуйте обновить пакет или убрать фиксацию версии."
+        AppLanguage.JAPANESE -> "このデバイスの Python %s 向けにプリビルド wheel がなく、ソースビルドにはデバイス上にないコンパイラが必要です。パッケージをアップグレードするか、バージョン固定を解除してみてください。"
+        AppLanguage.KOREAN -> "이 기기의 Python %s용 사전 빌드 wheel이 없으며, 소스 빌드에는 기기에 없는 컴파일러가 필요합니다. 패키지를 업그레이드하거나 버전 고정을 제거해 보세요."
     }
     val pyDownloadSourceLabel: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "%s [源%d/%d]"

--- a/app/src/main/java/com/webtoapp/core/python/ElfInterpPatcher.kt
+++ b/app/src/main/java/com/webtoapp/core/python/ElfInterpPatcher.kt
@@ -1,0 +1,252 @@
+package com.webtoapp.core.python
+
+import com.webtoapp.core.logging.AppLogger
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.charset.StandardCharsets
+
+/**
+ * Rewrites the PT_INTERP (ELF program interpreter) of executables so the
+ * kernel can locate the musl dynamic linker without relying on `/lib`, which
+ * does not exist on Android.
+ *
+ * The python-build-standalone musl builds ship with an absolute interpreter
+ * path such as `/lib/ld-musl-aarch64.so.1`. Launching them through the explicit
+ * loader (`ld-musl-* --library-path ... python3`) works, but **any subprocess
+ * spawned by Python itself** (e.g. pip's PEP 517 build-isolation venv pythons)
+ * is exec'd directly by the kernel, which resolves PT_INTERP verbatim and
+ * fails with `ENOENT` on Android.
+ *
+ * Patching the interpreter to an `$ORIGIN`-relative path
+ * (`$ORIGIN/../lib/ld-musl-<arch>.so.1`) makes direct kernel execs resolve the
+ * bundled loader, which is exactly how relocatable musl toolchains work on
+ * regular Linux.
+ */
+object ElfInterpPatcher {
+
+    private const val TAG = "ElfInterpPatcher"
+
+    private const val EI_MAGIC0 = 0
+    private const val EI_MAGIC1 = 1
+    private const val EI_MAGIC2 = 2
+    private const val EI_MAGIC3 = 3
+    private const val EI_CLASS = 4
+    private const val EI_DATA = 5
+
+    private const val ELFCLASS32 = 1
+    private const val ELFCLASS64 = 2
+    private const val ELFDATA2LSB = 1
+
+    private const val PT_INTERP = 3
+
+    private const val SIZEOF_EHDR64 = 64
+    private const val SIZEOF_PHDR64 = 56
+
+    private const val SIZEOF_EHDR32 = 52
+    private const val SIZEOF_PHDR32 = 32
+
+    /** The interpreter path of an Android-incompatible absolute musl loader. */
+    private val ABSOLUTE_MUSL_INTERP = Regex("^/lib/ld-musl-[^/]+\\.so\\.1$")
+
+    /**
+     * The `$ORIGIN`-relative interpreter path that resolves to the on-device
+     * musl loader bundled under `<pythonHome>/lib/`.
+     *
+     * @param linkerName e.g. `ld-musl-aarch64.so.1` (see
+     * [PythonDependencyManager.getMuslLinkerName]).
+     */
+    fun relocatableInterp(linkerName: String): String = "\$ORIGIN/../lib/$linkerName"
+
+    /** True when [interp] is an absolute musl loader path that Android cannot resolve. */
+    fun isAbsoluteMuslInterp(interp: String): Boolean =
+        ABSOLUTE_MUSL_INTERP.matches(interp)
+
+    /**
+     * Reads the current PT_INTERP of [file], or null when the file is not a
+     * supported little-endian ELF with an interpreter.
+     */
+    fun currentInterp(file: File): String? {
+        if (!file.isFile || file.length() < SIZEOF_EHDR64) return null
+        return try {
+            RandomAccessFile(file, "r").use { raf ->
+                val ident = ByteArray(16)
+                raf.seek(0)
+                raf.readFully(ident)
+                if (!isElf(ident)) return null
+                if (ident[EI_CLASS].toInt() != ELFCLASS64 && ident[EI_CLASS].toInt() != ELFCLASS32) return null
+                if (ident[EI_DATA].toInt() != ELFDATA2LSB) return null
+
+                val is64 = ident[EI_CLASS] == ELFCLASS64.toByte()
+                val ehdrSize = if (is64) SIZEOF_EHDR64 else SIZEOF_EHDR32
+                val header = ByteArray(ehdrSize)
+                raf.seek(0)
+                raf.readFully(header)
+                val phOff = if (is64) readU32(header, 32).toLong() else readU32(header, 28).toLong()
+                val phEntSize = if (is64) readU16(header, 54) else readU16(header, 42)
+                val phNum = if (is64) readU16(header, 56) else readU16(header, 44)
+                if (phEntSize < (if (is64) SIZEOF_PHDR64 else SIZEOF_PHDR32)) return null
+
+                for (i in 0 until phNum) {
+                    val ph = ByteArray(phEntSize)
+                    raf.seek(phOff + i * phEntSize.toLong())
+                    raf.readFully(ph)
+                    if (readU32(ph, 0) != PT_INTERP) continue
+                    val pOffset = if (is64) readU64(ph, 8) else readU32(ph, 4).toLong()
+                    val pFilesz = if (is64) readU64(ph, 32) else readU32(ph, 16).toLong()
+                    if (pFilesz <= 0 || pFilesz > 4096) return null
+                    // Some builds truncate p_filesz before the NUL terminator
+                    // (e.g. 26 bytes for a 27-char path). Peek past the segment
+                    // so we detect the real interpreter; the region is file-only
+                    // padding, never mapped.
+                    val readLen = minOf(pFilesz + 64, file.length() - pOffset).toInt()
+                    if (readLen <= 0) return null
+                    raf.seek(pOffset)
+                    val bytes = ByteArray(readLen)
+                    raf.readFully(bytes)
+                    val end = bytes.indexOf(0).let { if (it < 0) bytes.size else it }
+                    return String(bytes, 0, end, StandardCharsets.UTF_8)
+                }
+                null
+            }
+        } catch (e: Exception) {
+            AppLogger.d(TAG, "Failed to read PT_INTERP of ${file.absolutePath}: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Rewrites the PT_INTERP of [file] to [newInterp]. Grows the segment in
+     * place when the new path does not fit, which is safe because the kernel
+     * only reads the interpreter string from the segment and it lives inside
+     * the ELF header page (load segments start at the next page boundary).
+     *
+     * @return true when the file was modified.
+     */
+    fun rewriteInterp(file: File, newInterp: String): Boolean {
+        val newBytes = newInterp.toByteArray(StandardCharsets.UTF_8) + 0
+        return try {
+            RandomAccessFile(file, "rw").use { raf ->
+                val ident = ByteArray(16)
+                raf.seek(0)
+                raf.readFully(ident)
+                if (!isElf(ident)) return false
+                if (ident[EI_CLASS].toInt() != ELFCLASS64 && ident[EI_CLASS].toInt() != ELFCLASS32) return false
+                if (ident[EI_DATA].toInt() != ELFDATA2LSB) return false
+
+                val is64 = ident[EI_CLASS] == ELFCLASS64.toByte()
+                val ehdrSize = if (is64) SIZEOF_EHDR64 else SIZEOF_EHDR32
+                val header = ByteArray(ehdrSize)
+                raf.seek(0)
+                raf.readFully(header)
+                val phOff = if (is64) readU32(header, 32).toLong() else readU32(header, 28).toLong()
+                val phEntSize = if (is64) readU16(header, 54) else readU16(header, 42)
+                val phNum = if (is64) readU16(header, 56) else readU16(header, 44)
+                if (phEntSize < (if (is64) SIZEOF_PHDR64 else SIZEOF_PHDR32)) return false
+
+                for (i in 0 until phNum) {
+                    val ph = ByteArray(phEntSize)
+                    raf.seek(phOff + i * phEntSize.toLong())
+                    raf.readFully(ph)
+                    if (readU32(ph, 0) != PT_INTERP) continue
+                    val pOffset = if (is64) readU64(ph, 8) else readU32(ph, 4).toLong()
+                    val pFilesz = if (is64) readU64(ph, 32) else readU32(ph, 16).toLong()
+                    if (pOffset <= 0 || pFilesz <= 0 || pFilesz > 4096) return false
+
+                    if (newBytes.size <= pFilesz) {
+                        raf.seek(pOffset)
+                        raf.write(newBytes)
+                        val padding = ByteArray((pFilesz - newBytes.size).toInt())
+                        raf.write(padding)
+                        AppLogger.i(TAG, "Rewrote PT_INTERP in place (${file.name})")
+                        return true
+                    }
+
+                    // Grow in place. The interpreter lives in the first page with
+                    // the ELF header; the next load segment starts at the next
+                    // page boundary, so there is slack as long as the new path
+                    // stays within this page.
+                    val pageStart = pOffset - (pOffset % 4096)
+                    if (pOffset + newBytes.size > pageStart + 4096) {
+                        AppLogger.w(TAG, "New interpreter does not fit in header page of ${file.name}; skipping")
+                        return false
+                    }
+                    raf.seek(pOffset)
+                    raf.write(newBytes)
+                    raf.seek(phOff + i * phEntSize.toLong() + if (is64) 32 else 16)
+                    if (is64) {
+                        writeU64(raf, newBytes.size.toLong())
+                    } else {
+                        writeU32(raf, newBytes.size)
+                    }
+                    AppLogger.i(TAG, "Rewrote PT_INTERP (grew segment to ${newBytes.size} bytes, ${file.name})")
+                    return true
+                }
+                false
+            }
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "Failed to rewrite PT_INTERP of ${file.absolutePath}: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Patches [file] when its interpreter is an absolute musl path that cannot
+     * resolve on Android.
+     *
+     * @return true when the file was modified.
+     */
+    fun patchMuslInterp(file: File, linkerName: String): Boolean {
+        val current = currentInterp(file) ?: return false
+        if (!isAbsoluteMuslInterp(current)) return false
+        val newInterp = relocatableInterp(linkerName)
+        if (current == newInterp) return false
+        return rewriteInterp(file, newInterp)
+    }
+
+    /**
+     * Patches every ELF executable under `<pythonHome>/bin/` that carries an
+     * absolute musl interpreter.
+     *
+     * @return number of binaries patched.
+     */
+    fun patchPythonBinaries(pythonHome: File, linkerName: String): Int {
+        val binDir = File(pythonHome, "bin")
+        if (!binDir.isDirectory) return 0
+        var patched = 0
+        binDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.length() > 1024 * 1024) {
+                if (patchMuslInterp(file, linkerName)) patched++
+            }
+        }
+        return patched
+    }
+
+    private fun isElf(ident: ByteArray): Boolean =
+        ident.size >= 16 &&
+            ident[EI_MAGIC0] == 0x7F.toByte() &&
+            ident[EI_MAGIC1] == 'E'.code.toByte() &&
+            ident[EI_MAGIC2] == 'L'.code.toByte() &&
+            ident[EI_MAGIC3] == 'F'.code.toByte()
+
+    private fun readU16(bytes: ByteArray, offset: Int): Int =
+        (bytes[offset].toInt() and 0xFF) or ((bytes[offset + 1].toInt() and 0xFF) shl 8)
+
+    private fun readU32(bytes: ByteArray, offset: Int): Int =
+        readU16(bytes, offset) or (readU16(bytes, offset + 2) shl 16)
+
+    private fun readU64(bytes: ByteArray, offset: Int): Long =
+        (readU32(bytes, offset).toLong() and 0xFFFFFFFFL) or
+            ((readU32(bytes, offset + 4).toLong() and 0xFFFFFFFFL) shl 32)
+
+    private fun writeU32(raf: RandomAccessFile, value: Int) {
+        raf.write(value and 0xFF)
+        raf.write((value shr 8) and 0xFF)
+        raf.write((value shr 16) and 0xFF)
+        raf.write((value shr 24) and 0xFF)
+    }
+
+    private fun writeU64(raf: RandomAccessFile, value: Long) {
+        writeU32(raf, value.toInt())
+        writeU32(raf, (value shr 32).toInt())
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -27,9 +27,28 @@ object PythonDependencyManager {
         RegexOption.IGNORE_CASE
     )
 
+    /** pip reports this when no wheel matches the interpreter/platform, or the index is unreachable. */
+    private val NO_DISTRIBUTION_RE = Regex(
+        """(?:No matching distribution found for|Could not find a version that satisfies the requirement)\s+(\S+)"""
+    )
+
+    /** Evidence that the package index actually responded (downloads started). */
+    private val INDEX_PROOF_RE = Regex("""Collecting \S+|Downloading \S+""")
+
+    /** A source build failed while building a wheel (usually a missing compiler). */
+    private val FAILED_BUILD_WHEEL_RE = Regex("""Failed building wheel for (\S+)""")
+
+    /** A compiler invocation failed (no toolchain ships with the on-device Python). */
+    private val COMPILER_MISSING_RE = Regex("""error: command '[^']*' failed""")
+
     const val PYTHON_VERSION = "3.14"
     const val PYTHON_FULL_VERSION = "3.14.6"
     private const val PYTHON_BUILD_TAG = "20260623"
+
+    private const val SITE_CUSTOMIZE_FILE_NAME = "sitecustomize.py"
+
+    /** Cap on pip output retained for failure analysis (pattern matching). */
+    private const val MAX_PIP_OUTPUT_CHARS = 512 * 1024
 
     private const val MUSL_VERSION = "1.2.5-r11"
     private const val MUSL_ALPINE_BRANCH = "v3.21"
@@ -394,6 +413,93 @@ object PythonDependencyManager {
         }
     }
 
+    /**
+     * Extracts the package name pip could not resolve, when the failure is a
+     * missing distribution (no wheel for this Python/platform). Returns null
+     * for other failure modes.
+     */
+    internal fun findNoWheelPackage(output: String): String? {
+        NO_DISTRIBUTION_RE.find(output)?.let { return it.groupValues[1] }
+        FAILED_BUILD_WHEEL_RE.find(output)?.let { return it.groupValues[1] }
+        return null
+    }
+
+    /**
+     * True when the `--only-binary` pass failed because no wheel matched and
+     * the index clearly responded. Retrying without `--only-binary` would try
+     * to build from source, which cannot work on-device (no compiler), so we
+     * skip it and report an actionable hint instead.
+     */
+    internal fun shouldSkipSourceBuildRetry(output: String): Boolean {
+        if (!NO_DISTRIBUTION_RE.containsMatchIn(output)) return false
+        return INDEX_PROOF_RE.containsMatchIn(output)
+    }
+
+    /**
+     * A `sitecustomize.py` installed into the Python runtime dir. It is imported
+     * by *every* Python process (including pip subprocesses and PEP 517 build
+     * isolation venv pythons) and routes any python-like executable through the
+     * on-device musl loader, because the ELF interpreter path
+     * (`/lib/ld-musl-<arch>.so.1`) does not exist on Android. This is the safety
+     * net for subprocess spawns that bypass the explicit-loader launcher; the
+     * primary fix is patching PT_INTERP to an `$ORIGIN`-relative path.
+     */
+    internal fun buildSitecustomizeScript(): String = """
+import os
+import sys
+
+# WebToApp: route python subprocesses through the on-device musl dynamic linker.
+# The python ELF interpreter (/lib/ld-musl-*.so.1) does not exist on Android,
+# so direct kernel execs of the binary fail. This module is imported by every
+# python process via the site machinery and rewrites subprocess/exec calls that
+# target python-like executables to go through the bundled loader instead.
+
+_MUSL = os.environ.get('_WTA_MUSL_LINKER', '')
+_LIB = os.environ.get('_WTA_MUSL_LIB_PATH', '')
+_PYBIN = os.environ.get('_WTA_PYTHON_BIN', '')
+# 'python' covers venv symlinks (pip build isolation creates venv/bin/python).
+_PYNAMES = ('python', 'python3', 'python${PYTHON_VERSION}', 'libpython3.so')
+
+
+def _is_py(p):
+    return bool(p) and (p == _PYBIN or os.path.basename(str(p)) in _PYNAMES)
+
+
+if _MUSL and _LIB:
+    import subprocess
+
+    _OrigPopen = subprocess.Popen
+
+    class _MPopen(_OrigPopen):
+        def __init__(self, args, *a, **kw):
+            if isinstance(args, (list, tuple)) and len(args) > 0 and _is_py(str(args[0])):
+                args = [_MUSL, '--library-path', _LIB] + list(args)
+            super().__init__(args, *a, **kw)
+
+    subprocess.Popen = _MPopen
+
+    _oexecv = os.execv
+
+    def _mexecv(p, a):
+        if _is_py(p):
+            a = [_MUSL, '--library-path', _LIB] + list(a)
+            p = _MUSL
+        return _oexecv(p, a)
+
+    os.execv = _mexecv
+
+    if hasattr(os, 'execve'):
+        _oexecve = os.execve
+
+        def _mexecve(p, a, e):
+            if _is_py(p):
+                a = [_MUSL, '--library-path', _LIB] + list(a)
+                p = _MUSL
+            return _oexecve(p, a, e)
+
+        os.execve = _mexecve
+""".trimIndent()
+
     private fun runPipWithWrapper(
         context: Context,
         projectDir: File,
@@ -492,12 +598,28 @@ sys.exit(main())
 
         AppLogger.i(TAG, "Installing Python dependencies (wrapper mode): ${command.joinToString(" ")}")
 
-        val exitCode = executeCommand(command, projectDir, pythonBin, pythonHome, muslLinker,
+        val firstResult = executeCommand(command, projectDir, pythonBin, pythonHome, muslLinker,
             wrapperScript.absolutePath, context, extraEnv, onOutput)
 
-        if (exitCode == 0) return true
+        if (firstResult.exitCode == 0) return true
 
-        AppLogger.w(TAG, "pip --only-binary failed (exitCode=$exitCode), retrying without restrictions...")
+        val noWheelPackage = findNoWheelPackage(firstResult.output)
+        if (noWheelPackage != null && shouldSkipSourceBuildRetry(firstResult.output)) {
+            // A source build needs a compiler, which does not exist on-device.
+            // Retrying without --only-binary would only fail at the gcc step
+            // with a confusing error, so surface an actionable hint instead.
+            AppLogger.w(
+                TAG,
+                "pip --only-binary found no usable wheel for '$noWheelPackage' on Python $PYTHON_VERSION; skipping source-build retry"
+            )
+            sitePackages.deleteRecursively()
+            onOutput?.invoke(
+                String.format(com.webtoapp.core.i18n.Strings.pyDepsNoWheelHint, noWheelPackage, PYTHON_VERSION)
+            )
+            return false
+        }
+
+        AppLogger.w(TAG, "pip --only-binary failed (exitCode=${firstResult.exitCode}), retrying without restrictions...")
         onOutput?.invoke(com.webtoapp.core.i18n.Strings.pyDepsRetrying)
         sitePackages.deleteRecursively()
         sitePackages.mkdirs()
@@ -520,8 +642,21 @@ sys.exit(main())
 
         AppLogger.i(TAG, "Installing Python dependencies (wrapper-mode retry): ${retryCommand.joinToString(" ")}")
 
-        return executeCommand(retryCommand, projectDir, pythonBin, pythonHome, muslLinker,
-            wrapperScript.absolutePath, context, extraEnv, onOutput) == 0
+        val retryResult = executeCommand(retryCommand, projectDir, pythonBin, pythonHome, muslLinker,
+            wrapperScript.absolutePath, context, extraEnv, onOutput)
+        if (retryResult.exitCode == 0) return true
+
+        // The retry also failed: give an actionable hint when the cause is a
+        // missing wheel/compiler rather than a transient network issue.
+        val retryPackage = findNoWheelPackage(retryResult.output)
+        if (retryPackage != null) {
+            onOutput?.invoke(
+                String.format(com.webtoapp.core.i18n.Strings.pyDepsNoWheelHint, retryPackage, PYTHON_VERSION)
+            )
+        } else if (COMPILER_MISSING_RE.containsMatchIn(retryResult.output)) {
+            onOutput?.invoke(String.format(com.webtoapp.core.i18n.Strings.pyDepsSourceBuildHint, PYTHON_VERSION))
+        }
+        return false
     }
 
     private fun runPipDirect(
@@ -543,8 +678,10 @@ sys.exit(main())
         )
         AppLogger.i(TAG, "Installing Python dependencies (direct mode): ${command.joinToString(" ")}")
         return executeCommand(command, projectDir, pythonBin, pythonHome, null, null,
-            context, emptyMap(), onOutput) == 0
+            context, emptyMap(), onOutput).exitCode == 0
     }
+
+    data class CommandResult(val exitCode: Int, val output: String)
 
     private fun executeCommand(
         command: List<String>,
@@ -556,7 +693,7 @@ sys.exit(main())
         context: Context,
         extraEnv: Map<String, String>,
         onOutput: ((String) -> Unit)?
-    ): Int {
+    ): CommandResult {
         val processBuilder = ProcessBuilder(command)
         processBuilder.directory(workDir)
         processBuilder.redirectErrorStream(true)
@@ -583,14 +720,17 @@ sys.exit(main())
         AppLogger.i(TAG, "executeCommand: starting process...")
         val process = processBuilder.start()
 
-        val outputLines = mutableListOf<String>()
+        val output = StringBuilder()
+        val outputLock = Any()
         val readerThread = Thread {
             try {
                 process.inputStream.bufferedReader().forEachLine { line ->
                     AppLogger.d(TAG, "[pip] $line")
                     onOutput?.invoke(line)
-                    synchronized(outputLines) {
-                        if (outputLines.size < 50) outputLines.add(line)
+                    synchronized(outputLock) {
+                        if (output.length < MAX_PIP_OUTPUT_CHARS) {
+                            output.append(line).append('\n')
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -617,18 +757,19 @@ sys.exit(main())
             onOutput?.invoke(String.format(com.webtoapp.core.i18n.Strings.pyDepsInstallTimeout, PIP_TIMEOUT_SECONDS))
             process.destroyForciblyCompat()
             readerThread.interrupt()
-            return -1
+            return CommandResult(-1, synchronized(outputLock) { output.toString() })
         }
 
         readerThread.join(3000)
 
         val exitCode = process.exitValue()
+        val capturedOutput = synchronized(outputLock) { output.toString() }
         if (exitCode != 0) {
-            val lastOutput = synchronized(outputLines) { outputLines.takeLast(5).joinToString("\n") }
+            val lastOutput = capturedOutput.lines().takeLast(5).joinToString("\n")
             AppLogger.e(TAG, "pip install failed, exitCode=$exitCode, output=$lastOutput")
             onOutput?.invoke(String.format(com.webtoapp.core.i18n.Strings.pyDepsInstallFailedCode, exitCode))
         }
-        return exitCode
+        return CommandResult(exitCode, capturedOutput)
     }
 
     fun clearCache(context: Context) {
@@ -733,6 +874,30 @@ sys.exit(main())
 
             File(destDir, "lib").listFiles()?.filter { it.name.endsWith(".so") || it.name.contains(".so.") }?.forEach {
                 it.setExecutable(true, false)
+            }
+
+            // The python binaries ship with an absolute ELF interpreter
+            // (/lib/ld-musl-<arch>.so.1) that does not exist on Android. Direct
+            // launches work because we exec through the explicit loader, but
+            // pip's PEP 517 build isolation spawns subprocesses (venv pythons)
+            // that the kernel execs directly. Patch PT_INTERP to an
+            // $ORIGIN-relative path so those execs resolve the bundled loader.
+            val linkerName = getMuslLinkerName(abi)
+            val patchedCount = ElfInterpPatcher.patchPythonBinaries(destDir, linkerName)
+            if (patchedCount > 0) {
+                AppLogger.i(TAG, "Patched $patchedCount Python ELF interpreter(s) to \$ORIGIN-relative musl loader")
+            } else {
+                AppLogger.w(TAG, "No Python ELF binaries needed interpreter patching")
+            }
+
+            // Fallback for any subprocess spawn that still bypasses the patched
+            // interpreter (e.g. older kernels without $ORIGIN expansion): every
+            // python process imports sitecustomize, which routes python-like
+            // executables through the musl loader.
+            val siteCustomize = File(destDir, "lib/python$PYTHON_VERSION/$SITE_CUSTOMIZE_FILE_NAME")
+            if (!siteCustomize.exists()) {
+                siteCustomize.writeText(buildSitecustomizeScript())
+                AppLogger.i(TAG, "Installed $SITE_CUSTOMIZE_FILE_NAME for subprocess loader bridging: ${siteCustomize.absolutePath}")
             }
 
             archiveFile.delete()

--- a/app/src/test/java/com/webtoapp/core/python/ElfInterpPatcherTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/ElfInterpPatcherTest.kt
@@ -1,0 +1,157 @@
+package com.webtoapp.core.python
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.charset.StandardCharsets
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ElfInterpPatcherTest {
+
+    @Rule @JvmField
+    val tmp = TemporaryFolder()
+
+    private val ABSOLUTE = "/lib/ld-musl-aarch64.so.1"
+    private val RELATIVE = "\$ORIGIN/../lib/ld-musl-aarch64.so.1"
+
+    @Test
+    fun `currentInterp reads the interp string`() {
+        val file = writeElf(ABSOLUTE)
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(ABSOLUTE)
+    }
+
+    @Test
+    fun `currentInterp recovers the full string when p_filesz truncates before the NUL`() {
+        // The real python-build-standalone builds declare p_filesz=26 for the
+        // 27-char path; the kernel would see a truncated string, but our reader
+        // must detect the real interpreter to patch it.
+        val file = writeElf(ABSOLUTE, pFilesz = 5)
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(ABSOLUTE)
+    }
+
+    @Test
+    fun `currentInterp returns null for non-ELF files`() {
+        val file = tmp.newFile("plain.txt")
+        file.writeText("hello")
+        assertThat(ElfInterpPatcher.currentInterp(file)).isNull()
+    }
+
+    @Test
+    fun `rewriteInterp writes in place when the new path fits`() {
+        val file = writeElf(ABSOLUTE, pFilesz = 64)
+        assertThat(ElfInterpPatcher.rewriteInterp(file, RELATIVE)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+    }
+
+    @Test
+    fun `rewriteInterp grows the segment when the new path is longer`() {
+        val file = writeElf(ABSOLUTE) // p_filesz = 28
+        assertThat(ElfInterpPatcher.rewriteInterp(file, RELATIVE)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+    }
+
+    @Test
+    fun `patchMuslInterp rewrites absolute musl interp and is idempotent`() {
+        val file = writeElf(ABSOLUTE)
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, "ld-musl-aarch64.so.1")).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+        // Second pass: already relative, nothing to do.
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, "ld-musl-aarch64.so.1")).isFalse()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+    }
+
+    @Test
+    fun `patchMuslInterp leaves non-musl interps alone`() {
+        val file = writeElf("/lib/ld-linux-aarch64.so.1")
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, "ld-musl-aarch64.so.1")).isFalse()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo("/lib/ld-linux-aarch64.so.1")
+    }
+
+    @Test
+    fun `relocatableInterp builds an origin-relative path`() {
+        assertThat(ElfInterpPatcher.relocatableInterp("ld-musl-aarch64.so.1"))
+            .isEqualTo("\$ORIGIN/../lib/ld-musl-aarch64.so.1")
+    }
+
+    @Test
+    fun `patchPythonBinaries scans the bin dir and reports the patched count`() {
+        val pythonHome = tmp.newFolder("python")
+        val binDir = File(pythonHome, "bin").apply { mkdirs() }
+        val pythonBin = File(binDir, "python3.14").apply { writeBytes(ByteArray(1024 * 1024 + 1) { 0 }) }
+        val other = File(binDir, "python3.14-config").apply { writeText("#!/bin/sh\necho hi") }
+
+        // Overwrite the padding with a real ELF so patching applies. Real
+        // binaries are tens of MB, so pad to clear the >1MB binary filter.
+        pythonBin.writeBytes(buildElfBytes(ABSOLUTE) + ByteArray(1024 * 1024))
+
+        val patched = ElfInterpPatcher.patchPythonBinaries(pythonHome, "ld-musl-aarch64.so.1")
+        assertThat(patched).isEqualTo(1)
+        assertThat(ElfInterpPatcher.currentInterp(pythonBin)).isEqualTo(RELATIVE)
+        assertThat(other.readText()).contains("#!/bin/sh")
+    }
+
+    private fun writeElf(interp: String, pFilesz: Int = -1): File {
+        val file = tmp.newFile("python-${System.nanoTime()}")
+        file.writeBytes(buildElfBytes(interp, pFilesz))
+        return file
+    }
+
+    private fun buildElfBytes(interp: String, pFilesz: Int = -1): ByteArray {
+        val interpBytes = interp.toByteArray(StandardCharsets.UTF_8) + 0
+        val filesz = if (pFilesz < 0) interpBytes.size else pFilesz
+
+        val ehdr = ByteArray(64)
+        ehdr[0] = 0x7F.toByte()
+        ehdr[1] = 'E'.code.toByte()
+        ehdr[2] = 'L'.code.toByte()
+        ehdr[3] = 'F'.code.toByte()
+        ehdr[4] = 2 // ELFCLASS64
+        ehdr[5] = 1 // ELFDATA2LSB
+        putU16(ehdr, 16, 2) // e_type ET_EXEC
+        putU16(ehdr, 18, 183) // e_machine AArch64
+        putU32(ehdr, 20, 1) // e_version
+        putU64(ehdr, 24, 0x400000L) // e_entry
+        putU64(ehdr, 32, 64) // e_phoff
+        putU64(ehdr, 40, 0) // e_shoff
+        putU32(ehdr, 48, 0) // e_flags
+        putU16(ehdr, 52, 64) // e_ehsize
+        putU16(ehdr, 54, 56) // e_phentsize
+        putU16(ehdr, 56, 1) // e_phnum
+
+        val phdr = ByteArray(56)
+        putU32(phdr, 0, 3) // PT_INTERP
+        putU32(phdr, 4, 4) // p_flags PF_R
+        putU64(phdr, 8, 120) // p_offset (after header + phdr)
+        putU64(phdr, 16, 0x400000L) // p_vaddr
+        putU64(phdr, 24, 0x400000L) // p_paddr
+        putU64(phdr, 32, filesz.toLong()) // p_filesz
+        putU64(phdr, 40, filesz.toLong()) // p_memsz
+        putU64(phdr, 48, 1) // p_align
+
+        val out = ByteArrayOutputStream()
+        out.write(ehdr)
+        out.write(phdr)
+        out.write(interpBytes)
+        if (filesz > interpBytes.size) {
+            out.write(ByteArray(filesz - interpBytes.size))
+        }
+        return out.toByteArray()
+    }
+
+    private fun putU16(bytes: ByteArray, offset: Int, value: Int) {
+        bytes[offset] = (value and 0xFF).toByte()
+        bytes[offset + 1] = ((value shr 8) and 0xFF).toByte()
+    }
+
+    private fun putU32(bytes: ByteArray, offset: Int, value: Int) {
+        putU16(bytes, offset, value and 0xFFFF)
+        putU16(bytes, offset + 2, (value shr 16) and 0xFFFF)
+    }
+
+    private fun putU64(bytes: ByteArray, offset: Int, value: Long) {
+        putU32(bytes, offset, value.toInt())
+        putU32(bytes, offset + 4, (value shr 32).toInt())
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/python/PythonDependencyManagerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/PythonDependencyManagerTest.kt
@@ -152,6 +152,58 @@ class PythonDependencyManagerTest {
         assertThat(PythonDependencyManager.hasInstalledPackages(emptyDir)).isTrue()
     }
 
+    @Test
+    fun `findNoWheelPackage extracts the package from pip missing-distribution output`() {
+        assertThat(PythonDependencyManager.findNoWheelPackage(
+            "Collecting MarkupSafe==3.0.2 (from -r requirements.txt)\n" +
+                "ERROR: Could not find a version that satisfies the requirement MarkupSafe==3.0.2 (from versions: none)"
+        )).isEqualTo("MarkupSafe==3.0.2")
+
+        assertThat(PythonDependencyManager.findNoWheelPackage(
+            "ERROR: No matching distribution found for MarkupSafe==3.0.2"
+        )).isEqualTo("MarkupSafe==3.0.2")
+
+        assertThat(PythonDependencyManager.findNoWheelPackage(
+            "ERROR: Failed building wheel for MarkupSafe"
+        )).isEqualTo("MarkupSafe")
+    }
+
+    @Test
+    fun `findNoWheelPackage returns null when no distribution failure is present`() {
+        assertThat(PythonDependencyManager.findNoWheelPackage(
+            "Collecting Flask==3.0.0\nDownloading flask-3.0.0-py3-none-any.whl (101 kB)\nInstalling collected packages: Flask"
+        )).isNull()
+    }
+
+    @Test
+    fun `shouldSkipSourceBuildRetry requires a responding index`() {
+        // Index responded (Collecting...) and no wheel matched -> skip retry.
+        assertThat(PythonDependencyManager.shouldSkipSourceBuildRetry(
+            "Collecting MarkupSafe==3.0.2\n" +
+                "ERROR: No matching distribution found for MarkupSafe==3.0.2"
+        )).isTrue()
+
+        // No evidence the index responded -> likely a network problem; keep retrying.
+        assertThat(PythonDependencyManager.shouldSkipSourceBuildRetry(
+            "ERROR: No matching distribution found for MarkupSafe==3.0.2"
+        )).isFalse()
+
+        // Not a distribution failure at all.
+        assertThat(PythonDependencyManager.shouldSkipSourceBuildRetry(
+            "Collecting Flask==3.0.0\nDownloading flask-3.0.0-py3-none-any.whl (101 kB)"
+        )).isFalse()
+    }
+
+    @Test
+    fun `sitecustomize script bridges python subprocesses through the musl loader`() {
+        val script = PythonDependencyManager.buildSitecustomizeScript()
+        assertThat(script).contains("_WTA_MUSL_LINKER")
+        assertThat(script).contains("_WTA_MUSL_LIB_PATH")
+        assertThat(script).contains("'python', 'python3', 'python${PythonDependencyManager.PYTHON_VERSION}'")
+        assertThat(script).contains("subprocess.Popen = _MPopen")
+        assertThat(script).contains("--library-path")
+    }
+
     private fun tempDir(name: String): File {
         return File(context.cacheDir, "python-dep-test-$name-${System.nanoTime()}").apply { mkdirs() }
     }


### PR DESCRIPTION
## Summary

Fixes #505 — `pip install -r requirements.txt` fails in generated Python apps when any package needs a source build (e.g. `MarkupSafe==3.0.2`, which predates Python 3.14 and has no cp314 wheel).

The python-build-standalone musl builds ship with an **absolute ELF interpreter** (`/lib/ld-musl-aarch64.so.1`) that does not exist on Android. Direct launches worked because the app execs python through the explicit musl loader, but pip's PEP 517 build isolation spawns venv pythons that the **kernel execs directly**, so the build-env step crashed:

```
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/lib/ld-musl-aarch64.so.1'
```

Verified against the real `aarch64-unknown-linux-musl` build: `bin/python3.14` has `PT_INTERP = /lib/ld-musl-aarch64.so.1` (absolute), and the package does not bundle the loader.

## What changed

- **`ElfInterpPatcher` (new)** — rewrites `PT_INTERP` of the extracted python binaries to an `$ORIGIN`-relative path (`$ORIGIN/../lib/ld-musl-<arch>.so.1`) so direct kernel execs resolve the bundled loader. Handles in-place writes, segment growth (the interp lives in a file-only region, validated against the real binary layout), truncated `p_filesz`, and is idempotent.
- **`sitecustomize.py` fallback** — installed into the runtime dir; every python process (including nested pip and build-isolation venvs) routes python-like subprocess execs through the musl loader. Covers kernels without `$ORIGIN` interp expansion and the `venv/bin/python` symlink case the old bootstrap missed.
- **Smarter pip failure handling** — when the `--only-binary` pass fails with "no matching distribution" and the index clearly responded, skip the pointless source-build retry (no compiler exists on-device) and show an actionable hint (`pyDepsNoWheelHint` / `pyDepsSourceBuildHint`, all 10 languages) instead of the confusing `gcc` failure.

## User-visible effect

- Installing dependencies that need a source build no longer crashes with the cryptic loader error.
- Packages without a prebuilt wheel for Python 3.14 on this platform now fail fast with a clear message: "try upgrading the package or removing its version pin" (e.g. `MarkupSafe>=3.0.3` ships cp314 `musllinux_1_2_aarch64` wheels).

## Test plan

- New `ElfInterpPatcherTest` (9 cases: read, truncated p_filesz recovery, in-place rewrite, grow, idempotency, non-musl interp untouched, bin-dir scan).
- New pure-function tests in `PythonDependencyManagerTest` (no-wheel detection, skip-retry heuristic, sitecustomize content).
- Local: `:app:compileStandardDebugKotlin`, `:shell:compileDebugKotlin`, full `:app:testStandardDebugUnitTest`, `:app:checkConfigFieldDrift`, and `:shell:assembleRelease` + `:app:syncShellTemplateApk` all pass.

Closes #505 on merge.
