### PR TITLE
fix(extension): repair chrome polyfill crash and inactive panel state (Fixes #502)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/extension/ChromeExtensionPolyfill.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ChromeExtensionPolyfill.kt
@@ -15,6 +15,7 @@ object ChromeExtensionPolyfill {
     'use strict';
 
     var EXT_ID = '$safeExtId';
+    var STORAGE_PREFIX = '__WTA_EXT_' + EXT_ID + '_';
 
     // ===== Prevent double-init (per extension) =====
     var POLYFILL_KEY = '__WTA_CHROME_POLYFILL_' + EXT_ID + '__';

--- a/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
+++ b/app/src/main/java/com/webtoapp/core/extension/ExtensionModule.kt
@@ -731,6 +731,7 @@ data class ExtensionModule(
             "showOnlyOnMatch" to uiConfig.showOnlyOnMatch
         ))
         val runModeStr = runMode.name
+        val urlMatchesJson = gson.toJson(urlMatches)
 
         val effectiveCode = if (codeFiles.isNotEmpty()) {
 
@@ -753,6 +754,44 @@ data class ExtensionModule(
                 const __MODULE_CONFIG__ = $configJson;
                 const __MODULE_UI_CONFIG__ = $uiConfigJson;
                 const __MODULE_RUN_MODE__ = '$runModeStr';
+                // URL匹配规则（与 matchesUrl 语义一致）：面板据此显示 Active/Inactive
+                const __MODULE_URL_MATCHES__ = $urlMatchesJson;
+                function __moduleMatchesUrl__() {
+                    try {
+                        var href = location.href;
+                        if (!__MODULE_URL_MATCHES__ || __MODULE_URL_MATCHES__.length === 0) return true;
+                        function __escapeReChar__(c) {
+                            return '.+?^${'$'}()|[]/'.indexOf(c) !== -1 ? '\\' + c : c;
+                        }
+                        function __ruleToRegExp__(rule) {
+                            var p = rule.pattern;
+                            if (rule.isRegex) return new RegExp(p, 'i');
+                            if (p === '*' || p === '<all_urls>') return null;
+                            var re = '^';
+                            var i = 0;
+                            while (i < p.length) {
+                                var c = p[i];
+                                if (c === '*' && p.startsWith('*://', i)) { re += '(https?|ftp|file)://'; i += 4; }
+                                else if (c === '*') { re += '.*'; i++; }
+                                else { re += __escapeReChar__(c); i++; }
+                            }
+                            re += '${'$'}';
+                            return new RegExp(re, 'i');
+                        }
+                        var excludes = __MODULE_URL_MATCHES__.filter(function(r) { return r.exclude; });
+                        for (var j = 0; j < excludes.length; j++) {
+                            var er = __ruleToRegExp__(excludes[j]);
+                            if (er && er.test(href)) return false;
+                        }
+                        var includes = __MODULE_URL_MATCHES__.filter(function(r) { return !r.exclude; });
+                        if (includes.length === 0) return true;
+                        for (var k = 0; k < includes.length; k++) {
+                            var ir = __ruleToRegExp__(includes[k]);
+                            if (!ir || ir.test(href)) return true;
+                        }
+                        return false;
+                    } catch (e) { return true; }
+                }
                 const __MODULE_INFO__ = {
                     id: '${id.escapeForJsSingleQuote()}',
                     name: '${name.escapeForJsSingleQuote()}',
@@ -812,6 +851,8 @@ data class ExtensionModule(
                         icon: __MODULE_INFO__.icon,
                         uiConfig: __MODULE_UI_CONFIG__,
                         runMode: __MODULE_RUN_MODE__,
+                        active: __moduleMatchesUrl__(),
+                        urlMatches: __MODULE_URL_MATCHES__,
                         panelHtml: __MODULE_PANEL_HTML__ || undefined
                     });
                 })();

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -573,6 +573,7 @@ data class EmbeddedShellModule(
     fun generateExecutableCode(): String {
         _cachedCode?.let { return it }
         val configJson = GSON.toJson(configValues)
+        val urlMatchesJson = GSON.toJson(urlMatches)
         val uiConfigJson = GSON.toJson(
             mapOf(
                 "type" to uiConfig.type,
@@ -588,6 +589,44 @@ data class EmbeddedShellModule(
                 const __MODULE_CONFIG__ = $configJson;
                 const __MODULE_UI_CONFIG__ = $uiConfigJson;
                 const __MODULE_RUN_MODE__ = '${runMode.escapeForJsSingleQuote()}';
+                // URL匹配规则（与 matchesUrl 语义一致）：面板据此显示 Active/Inactive
+                const __MODULE_URL_MATCHES__ = $urlMatchesJson;
+                function __moduleMatchesUrl__() {
+                    try {
+                        var href = location.href;
+                        if (!__MODULE_URL_MATCHES__ || __MODULE_URL_MATCHES__.length === 0) return true;
+                        function __escapeReChar__(c) {
+                            return '.+?^${'$'}()|[]/'.indexOf(c) !== -1 ? '\\' + c : c;
+                        }
+                        function __ruleToRegExp__(rule) {
+                            var p = rule.pattern;
+                            if (rule.isRegex) return new RegExp(p, 'i');
+                            if (p === '*' || p === '<all_urls>') return null;
+                            var re = '^';
+                            var i = 0;
+                            while (i < p.length) {
+                                var c = p[i];
+                                if (c === '*' && p.startsWith('*://', i)) { re += '(https?|ftp|file)://'; i += 4; }
+                                else if (c === '*') { re += '.*'; i++; }
+                                else { re += __escapeReChar__(c); i++; }
+                            }
+                            re += '${'$'}';
+                            return new RegExp(re, 'i');
+                        }
+                        var excludes = __MODULE_URL_MATCHES__.filter(function(r) { return r.exclude; });
+                        for (var j = 0; j < excludes.length; j++) {
+                            var er = __ruleToRegExp__(excludes[j]);
+                            if (er && er.test(href)) return false;
+                        }
+                        var includes = __MODULE_URL_MATCHES__.filter(function(r) { return !r.exclude; });
+                        if (includes.length === 0) return true;
+                        for (var k = 0; k < includes.length; k++) {
+                            var ir = __ruleToRegExp__(includes[k]);
+                            if (!ir || ir.test(href)) return true;
+                        }
+                        return false;
+                    } catch (e) { return true; }
+                }
                 const __MODULE_INFO__ = {
                     id: '${id.escapeForJsSingleQuote()}',
                     name: '${name.escapeForJsSingleQuote()}',
@@ -638,7 +677,9 @@ data class EmbeddedShellModule(
                         name: __MODULE_INFO__.name,
                         icon: __MODULE_INFO__.icon,
                         uiConfig: __MODULE_UI_CONFIG__,
-                        runMode: __MODULE_RUN_MODE__
+                        runMode: __MODULE_RUN_MODE__,
+                        active: __moduleMatchesUrl__(),
+                        urlMatches: __MODULE_URL_MATCHES__
                     });
                 })();
                 """ else ""}

--- a/app/src/test/java/com/webtoapp/core/extension/ChromeExtensionPolyfillTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ChromeExtensionPolyfillTest.kt
@@ -1,0 +1,34 @@
+package com.webtoapp.core.extension
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ChromeExtensionPolyfillTest {
+
+    @Test
+    fun `polyfill defines STORAGE_PREFIX before using it`() {
+        // Regression (#502): the polyfill referenced an undefined STORAGE_PREFIX,
+        // throwing a ReferenceError that aborted the whole IIFE (onInstalled event
+        // and background message delivery never got installed).
+        val polyfill = ChromeExtensionPolyfill.generatePolyfill(
+            extensionId = "abcdefghijklmnop",
+            manifestJson = """{"name":"test"}""",
+            isBackground = false
+        )
+
+        assertThat(polyfill).contains("var STORAGE_PREFIX = '__WTA_EXT_' + EXT_ID + '_';")
+        assertThat(polyfill).contains("var installedKey = STORAGE_PREFIX + '__installed__';")
+        assertThat(polyfill).contains("__WTA_DELIVER_TO_BACKGROUND__")
+    }
+
+    @Test
+    fun `polyfill escapes extension ids that could break the generated script`() {
+        val polyfill = ChromeExtensionPolyfill.generatePolyfill(
+            extensionId = "id'with'quotes",
+            manifestJson = "{}",
+            isBackground = false
+        )
+
+        assertThat(polyfill).contains("'id\\'with\\'quotes'")
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/extension/ExtensionModuleTest.kt
+++ b/app/src/test/java/com/webtoapp/core/extension/ExtensionModuleTest.kt
@@ -90,6 +90,35 @@ class ExtensionModuleTest {
     }
 
     @Test
+    fun `generateExecutableCode auto-registration carries url match state`() {
+        val module = ExtensionModule(
+            id = "module-2",
+            name = "Reddit tweak",
+            icon = "🧰",
+            code = "console.log('hi')",
+            urlMatches = listOf(
+                UrlMatchRule(pattern = "https://*.reddit.com/*", isRegex = false, exclude = false),
+                UrlMatchRule(pattern = "*://*.reddit.com/r/nsfw*", isRegex = false, exclude = true)
+            )
+        )
+
+        val executable = module.generateExecutableCode()
+
+        // The panel decides Active/Inactive from the module's url match state;
+        // without it every module registered through the auto-register path was
+        // shown as "Inactive / Does not match current page".
+        assertThat(executable).contains("const __MODULE_URL_MATCHES__")
+        assertThat(executable).contains("https://*.reddit.com/*")
+        assertThat(executable).contains("\"exclude\":true")
+        assertThat(executable).contains("function __moduleMatchesUrl__")
+        assertThat(executable).contains("active: __moduleMatchesUrl__(),")
+        assertThat(executable).contains("urlMatches: __MODULE_URL_MATCHES__,")
+        // The JS matcher must escape regex metacharacters and anchor the pattern.
+        assertThat(executable).contains("__escapeReChar__")
+        assertThat(executable).contains("re += '${'$'}';")
+    }
+
+    @Test
     fun `sanitized coerces Gson-null fields back to defaults`() {
         // Gson allocates via Unsafe and leaves Kotlin non-null fields null when the JSON
         // omits them (Kotlin defaults are bypassed). sanitized() must restore the declared


### PR DESCRIPTION
## Summary

Fixes #502 — extensions (Sink It for Reddit, Reddit enhancer) misbehave: not shown in preview, "Inactive / Does not match current page" in built APKs, empty popup.

I pulled the three screenshots from the issue and matched each symptom against the code. Two concrete WTA-side defects found and fixed:

### 1. Polyfill crash: `STORAGE_PREFIX` was undefined
`ChromeExtensionPolyfill.kt` generated JS containing `var installedKey = STORAGE_PREFIX + '__installed__';` — but `STORAGE_PREFIX` was **never defined anywhere** (verified repo-wide). This threw `Uncaught ReferenceError: STORAGE_PREFIX is not defined` at the top level of the polyfill IIFE, so **everything after that line never ran**: the `onInstalled` event and the background message delivery function (`__WTA_DELIVER_TO_BACKGROUND__`) were never installed. Fixed by defining `STORAGE_PREFIX = '__WTA_EXT_' + EXT_ID + '_'` per extension.

### 2. Panel "Inactive" state: auto-registered modules carried no URL-match state
Modules registered through the auto-register path in `generateExecutableCode` (host `ExtensionModule` **and** shell `EmbeddedShellModule` — the APK path that matches the issue's log line `keys: id,name,icon,uiConfig,runMode`) sent no `active`/`urlMatches` to the panel, so the panel rendered them "Inactive / Does not match current page" even on matching pages (screenshot 2). Now the generated code embeds `urlMatches` and computes `active` by matching `location.href` against the same semantics as `matchesUrl` (Chrome match patterns, `*://` scheme wildcard, excludes, `isRegex`, `<all_urls>`).

## What was deliberately NOT changed

- **Preview showing 0 modules** — the repro log shows `0 modules pre-registered` with no `registerModule` calls. No WTA-side defect confirmed from code alone; needs repro info (were the extension modules enabled in the app editor before previewing?).
- **`TypeError: "openweb" is not a function`** — the extension calls a global that no WTA API provides (not in `chrome.*` either); it works in browsers that inject it. Not a WTA defect.
- **Empty popup ("No description")** — already the designed fallback for panel-less modules (`T.noDescription`), not a regression.

## Test plan

- New `ChromeExtensionPolyfillTest`: `STORAGE_PREFIX` defined before use; extension-id escaping.
- `ExtensionModuleTest`: auto-registration carries `urlMatches`/`active`; generated matcher escapes metacharacters and anchors patterns.
- Matcher semantics cross-verified against Kotlin `matchRule` with 10 node cases (www/old/sh.reddit matching, excludes, regex rules, `<all_urls>`, empty rules).
- Local: `:app:compileStandardDebugKotlin`, `:shell:compileDebugKotlin`, full `:app:testStandardDebugUnitTest`, `:app:checkConfigFieldDrift`, `:shell:assembleRelease` + `:app:syncShellTemplateApk` all pass.

Closes #502 on merge.
