### PR TITLE
fix(custom-ca): robust cert import + honor imported CAs in built APKs

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -37,6 +37,7 @@ import java.io.*
 import java.util.zip.*
 import javax.crypto.SecretKey
 import com.webtoapp.util.AppConstants
+import com.webtoapp.util.NetworkTrustStorage
 import com.webtoapp.util.TextFileClassifier
 
 private fun resolveOutputDir(context: Context): File {
@@ -1340,6 +1341,8 @@ class ApkBuilder(private val context: Context) {
                     addBgmToAssets(zipOut, bgmPlaylistPaths, bgmLrcDataList, bgmCoverPaths, assetEncryptor, encryptionConfig)
                 }
 
+                addCustomCaCertsToAssets(zipOut, config.networkTrustConfig.customCaCertificates)
+
                 val projectDir = when (config.appType) {
                     "WORDPRESS" -> wordPressProjectDir
                     "NODEJS_APP" -> nodejsProjectDir
@@ -1697,6 +1700,45 @@ class ApkBuilder(private val context: Context) {
         } catch (e: Exception) {
             AppLogger.e("ApkBuilder", "Failed to embed status bar background: ${e.message}", e)
         }
+    }
+
+    /**
+     * Embed each imported custom CA as canonical DER under assets/wta_custom_ca/. The generated
+     * APK's runtime (CustomCaTrustStore) scans this directory and trusts leaves that validate
+     * against these anchors. CA certificates are public, so they are stored as plain (unencrypted)
+     * assets even for encrypted builds — nothing sensitive is leaked.
+     */
+    private fun addCustomCaCertsToAssets(
+        zipOut: ZipOutputStream,
+        certificates: List<com.webtoapp.data.model.CustomCaCertificate>
+    ) {
+        if (certificates.isEmpty()) return
+        val factory = java.security.cert.CertificateFactory.getInstance("X.509")
+        var written = 0
+        certificates.forEachIndexed { index, cert ->
+            val file = File(cert.filePath)
+            if (!file.isFile || !file.canRead()) {
+                AppLogger.w("ApkBuilder", "Custom CA file unavailable, skipping: ${cert.filePath}")
+                return@forEachIndexed
+            }
+            runCatching {
+                // Re-parse and re-encode to canonical DER so the stored format is robust to the
+                // original import source (PEM/DER/PKCS#7/base64).
+                val parsed = NetworkTrustStorage.parseCertificates(file.readBytes())
+                if (parsed.isEmpty()) {
+                    AppLogger.w("ApkBuilder", "Custom CA unparsable at build time, skipping: ${cert.filePath}")
+                    return@runCatching
+                }
+                parsed.forEachIndexed { sub, x509 ->
+                    val name = if (parsed.size == 1) "${index + 1}.cer" else "${index + 1}_${sub + 1}.cer"
+                    writeEntryDeflated(zipOut, "assets/wta_custom_ca/$name", x509.encoded)
+                    written++
+                }
+            }.onFailure { e ->
+                AppLogger.w("ApkBuilder", "Failed to embed custom CA ${cert.filePath}: ${e.message}")
+            }
+        }
+        logger.logKeyValue("customCaCertsEmbedded", written.toString())
     }
 
     private fun addFloatingWindowMinimizedIconToAssets(

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/NetworkSecurityConfigBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/NetworkSecurityConfigBuilder.kt
@@ -6,7 +6,13 @@ import java.io.File
 
 object NetworkSecurityConfigBuilder {
     fun build(config: NetworkTrustConfig): String {
-        val anchors = buildAnchors(config)
+        // Filter unreadable certs once and re-index sequentially, so the trust anchors and the
+        // res/raw entries we emit always reference the SAME resource names. Previously
+        // buildAnchors emitted @raw/wta_custom_ca_N for every cert by original index while
+        // customRawEntries dropped the unreadable ones — a missing middle cert then produced
+        // a <certificates src="@raw/..."> with no matching res/raw file and aapt failed.
+        val entries = customRawEntries(config)
+        val anchors = buildAnchors(config, entries)
         val cleartext = config.cleartextTrafficPermitted.toString()
         return """
 <?xml version="1.0" encoding="utf-8"?>
@@ -24,22 +30,27 @@ $anchors
         """.trimIndent()
     }
 
-    fun customRawEntries(config: NetworkTrustConfig): List<CustomCaRawEntry> =
-        config.customCaCertificates.mapIndexedNotNull { index, certificate ->
+    fun customRawEntries(config: NetworkTrustConfig): List<CustomCaRawEntry> {
+        var seq = 0
+        return config.customCaCertificates.mapNotNull { certificate ->
             val file = File(certificate.filePath)
-            if (!file.isFile || !file.canRead()) return@mapIndexedNotNull null
+            if (!file.isFile || !file.canRead()) return@mapNotNull null
             CustomCaRawEntry(
-                resourceName = NetworkTrustStorage.rawResourceName(index),
+                resourceName = NetworkTrustStorage.rawResourceName(seq++),
                 sourceFile = file
             )
         }
+    }
 
-    private fun buildAnchors(config: NetworkTrustConfig): String {
+    private fun buildAnchors(
+        config: NetworkTrustConfig,
+        entries: List<CustomCaRawEntry>
+    ): String {
         val certs = mutableListOf<String>()
         if (config.trustSystemCa) certs += """            <certificates src="system" />"""
         if (config.trustUserCa) certs += """            <certificates src="user" />"""
-        config.customCaCertificates.forEachIndexed { index, _ ->
-            certs += """            <certificates src="@raw/${NetworkTrustStorage.rawResourceName(index)}" />"""
+        entries.forEach { entry ->
+            certs += """            <certificates src="@raw/${entry.resourceName}" />"""
         }
         val body = if (certs.isEmpty()) {
             """            <certificates src="system" />"""

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2386,6 +2386,8 @@ object Strings {
     val saveNetworkPresetTitle: String get() = StringsC.saveNetworkPresetTitle
     val presetName: String get() = StringsC.presetName
     val invalidCertificate: String get() = StringsC.invalidCertificate
+    val invalidCertificatePrivateKey: String get() = StringsC.invalidCertificatePrivateKey
+    val invalidCertificateUnrecognized: String get() = StringsC.invalidCertificateUnrecognized
     val preflightPackageAutoTitle: String get() = StringsC.preflightPackageAutoTitle
     val preflightPackageAutoMessage: String get() = StringsC.preflightPackageAutoMessage
     val preflightIconMissingTitle: String get() = StringsC.preflightIconMissingTitle
@@ -34726,16 +34728,16 @@ object StringsC {
     }
 
     val networkTrustTemplateLimitHint: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "源码项目导出会写入自定义 CA。模板 APK 构建会继续信任系统和用户安装 CA；如需任意导入 CA 进入模板 APK，需要二进制资源表级支持。"
-        AppLanguage.ENGLISH -> "Source project export writes imported custom CAs. Template APK builds still rely on system and user-installed CAs; arbitrary imported CAs in template APKs need binary resource-table support."
-        AppLanguage.ARABIC -> "تقوم صادرات المشروع المصدري بكتابة شهادات CA المخصصة المستوردة. ما تزال بنية APK القالب تعتمد على شهادات النظام والمستخدم، وإدخال أي CA مخصصة إلى APK القالب يحتاج إلى دعم على مستوى جدول الموارد الثنائي."
-        AppLanguage.PORTUGUESE -> "A exportação do projeto fonte grava CAs personalizadas importadas. Builds de APK de modelo ainda dependem de CAs do sistema e instaladas pelo usuário; CAs importadas arbitrárias em APKs de modelo precisam de suporte no nível da tabela de recursos binários."
-        AppLanguage.SPANISH -> "La exportación del proyecto fuente escribe CAs personalizadas importadas. Las builds de APK de plantilla aún dependen de CAs del sistema e instaladas por el usuario; las CAs importadas arbitrarias en APKs de plantilla necesitan soporte a nivel de tabla de recursos binarios."
-        AppLanguage.FRENCH -> "L'export du projet source écrit les CA personnalisés importés. Les builds d'APK de modèle s'appuient toujours sur les CA système et installés par l'utilisateur ; les CA importés arbitraires dans les APK de modèle nécessitent un support au niveau de la table de ressources binaires."
-        AppLanguage.GERMAN -> "Der Quellprojekt-Export schreibt importierte benutzerdefinierte CAs. Template-APK-Builds verlassen sich weiterhin auf System- und benutzerinstallierte CAs; beliebig importierte CAs in Template-APKs benötigen Unterstützung auf Binär-Ressourcentabellenebene."
-        AppLanguage.RUSSIAN -> "Экспорт исходного проекта записывает импортированные пользовательские CA. Сборки APK-шаблонов по-прежнему полагаются на системные и пользовательские CA; произвольные импортированные CA в APK-шаблонах требуют поддержки на уровне бинарной таблицы ресурсов."
-        AppLanguage.JAPANESE -> "ソースプロジェクトのエクスポートはインポートされたカスタムCAを書き込みます。テンプレートAPKビルドは引き続きシステムおよびユーザーインストールCAに依存します。テンプレートAPKに任意のCAをインポートするには、バイナリリソーステーブルレベルのサポートが必要です。"
-        AppLanguage.KOREAN -> "소스 프로젝트 내보내기는 가져온 사용자 지정 CA를 기록합니다. 템플릿 APK 빌드는 여전히 시스템 및 사용자 설치 CA에 의존합니다. 템플릿 APK에 임의의 CA를 가져오려면 바이너리 리소스 테이블 수준의 지원이 필요합니다."
+        AppLanguage.CHINESE -> "导入的自定义 CA 会在构建出的 APK 内生效:由该 CA 直接签发的证书将被信任。完整的证书链校验(根 CA + 中间 CA)请使用源码项目导出。"
+        AppLanguage.ENGLISH -> "Imported custom CAs take effect inside built APKs: certificates directly signed by an imported CA are trusted. For full chain validation (root + intermediate), use source-project export."
+        AppLanguage.ARABIC -> "شهادات CA المخصصة المستوردة تسري داخل ملفات APK المبنية: الشهادات الموقعة مباشرة من CA مستورد موثوقة. للتحقق الكامل من السلسلة (جذر + وسيط)، استخدم تصدير المشروع المصدري."
+        AppLanguage.PORTUGUESE -> "CAs personalizadas importadas passam a valer dentro dos APKs gerados: certificados assinados diretamente por uma CA importada são confiáveis. Para validação completa da cadeia (raiz + intermediária), use a exportação do projeto fonte."
+        AppLanguage.SPANISH -> "Las CAs personalizadas importadas funcionan dentro de los APK generados: los certificados firmados directamente por una CA importada son de confianza. Para validación completa de cadena (raíz + intermedia), usa la exportación del proyecto fuente."
+        AppLanguage.FRENCH -> "Les CA personnalisés importés prennent effet dans les APK générés : les certificats signés directement par un CA importé sont approuvés. Pour une validation complète de chaîne (racine + intermédiaire), utilisez l'export du projet source."
+        AppLanguage.GERMAN -> "Importierte benutzerdefinierte CAs wirken in erstellten APKs: Zertifikate, die direkt von einer importierten CA signiert sind, werden vertraut. Für volle Kettenvalidierung (Root + Intermediate) verwenden Sie den Quellprojekt-Export."
+        AppLanguage.RUSSIAN -> "Импортированные пользовательские CA действуют в собранных APK: сертификаты, напрямую подписанные импортированной CA, считаются доверенными. Для полной проверки цепочки (корень + промежуточный) используйте экспорт исходного проекта."
+        AppLanguage.JAPANESE -> "インポートしたカスタムCAは生成されたAPK内で有効になり、そのCAで直接署名された証明書は信頼されます。完全なチェーン検証(ルート+中間)にはソースプロジェクトのエクスポートを使用してください。"
+        AppLanguage.KOREAN -> "가져온 사용자 지정 CA는 빌드된 APK에서 적용되며, 해당 CA로 직접 서명된 인증서는 신뢰됩니다. 전체 체인 검증(루트 + 중간)이 필요하면 소스 프로젝트 내보내기를 사용하세요."
     }
 
     val saveNetworkPresetTitle: String get() = when (Strings.lang) {
@@ -34775,6 +34777,32 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Недействительный сертификат"
         AppLanguage.JAPANESE -> "無効な証明書"
         AppLanguage.KOREAN -> "잘못된 인증서"
+    }
+
+    val invalidCertificatePrivateKey: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "这是私钥,不是证书。请只导出证书部分(.crt/.cer/.pem)"
+        AppLanguage.ENGLISH -> "This is a private key, not a certificate. Export only the certificate (.crt/.cer/.pem)"
+        AppLanguage.ARABIC -> "هذا مفتاح خاص وليس شهادة. صدّر الشهادة فقط (.crt/.cer/.pem)"
+        AppLanguage.PORTUGUESE -> "Esta é uma chave privada, não um certificado. Exporte apenas o certificado (.crt/.cer/.pem)"
+        AppLanguage.SPANISH -> "Esta es una clave privada, no un certificado. Exporta solo el certificado (.crt/.cer/.pem)"
+        AppLanguage.FRENCH -> "Ceci est une clé privée, pas un certificat. Exportez uniquement le certificat (.crt/.cer/.pem)"
+        AppLanguage.GERMAN -> "Dies ist ein privater Schlüssel, kein Zertifikat. Exportieren Sie nur das Zertifikat (.crt/.cer/.pem)"
+        AppLanguage.RUSSIAN -> "Это закрытый ключ, а не сертификат. Экспортируйте только сертификат (.crt/.cer/.pem)"
+        AppLanguage.JAPANESE -> "これは証明書ではなく秘密鍵です。証明書のみをエクスポートしてください(.crt/.cer/.pem)"
+        AppLanguage.KOREAN -> "인증서가 아니라 개인 키입니다. 인증서만 내보내세요(.crt/.cer/.pem)"
+    }
+
+    val invalidCertificateUnrecognized: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "无法识别该证书格式。常见原因:PKCS#12/.pfx 密钥库、证书签名请求(CSR)、缺少 PEM 头的 Base64、或编码异常。请导出为 X.509 证书(PEM 或 DER)"
+        AppLanguage.ENGLISH -> "Unrecognized certificate format. Common causes: a PKCS#12/.pfx keystore, a signing request (CSR), Base64 without PEM headers, or an odd encoding. Export it as an X.509 certificate (PEM or DER)"
+        AppLanguage.ARABIC -> "تنسيق شهادة غير معروف. الأسباب الشائعة: مستودع مفاتيح PKCS#12/.pfx، أو طلب توقيع (CSR)، أو Base64 بدون ترويسات PEM، أو ترميز غير معتاد. صدّرها كشهادة X.509 (PEM أو DER)"
+        AppLanguage.PORTUGUESE -> "Formato de certificado não reconhecido. Causas comuns: keystore PKCS#12/.pfx, solicitação de assinatura (CSR), Base64 sem cabeçalhos PEM ou codificação incomum. Exporte como certificado X.509 (PEM ou DER)"
+        AppLanguage.SPANISH -> "Formato de certificado no reconocido. Causas comunes: almacén PKCS#12/.pfx, solicitud de firma (CSR), Base64 sin cabeceras PEM o codificación inusual. Expórtalo como certificado X.509 (PEM o DER)"
+        AppLanguage.FRENCH -> "Format de certificat non reconnu. Causes courantes : keystore PKCS#12/.pfx, requête de signature (CSR), Base64 sans en-têtes PEM ou encodage inhabituel. Exportez-le comme certificat X.509 (PEM ou DER)"
+        AppLanguage.GERMAN -> "Unbekanntes Zertifikatsformat. Häufige Ursachen: PKCS#12/.pfx-Keystore, Signing-Request (CSR), Base64 ohne PEM-Header oder unübliche Codierung. Exportieren Sie es als X.509-Zertifikat (PEM oder DER)"
+        AppLanguage.RUSSIAN -> "Формат сертификата не распознан. Частые причины: хранилище ключей PKCS#12/.pfx, запрос на подпись (CSR), Base64 без PEM-заголовков или необычная кодировка. Экспортируйте как сертификат X.509 (PEM или DER)"
+        AppLanguage.JAPANESE -> "証明書フォーマットを認識できません。よくある原因: PKCS#12/.pfx キーストア、署名要求(CSR)、PEMヘッダーのないBase64、特異なエンコーディング。X.509証明書(PEMまたはDER)としてエクスポートしてください"
+        AppLanguage.KOREAN -> "인증서 형식을 인식할 수 없습니다. 흔한 원인: PKCS#12/.pfx 키스토어, 서명 요청(CSR), PEM 헤더가 없는 Base64, 잘못된 인코딩. X.509 인증서(PEM 또는 DER)로 내보내세요"
     }
 
     val preflightPackageAutoTitle: String get() = when (Strings.lang) {
@@ -34895,16 +34923,16 @@ object StringsC {
     }
 
     val preflightTemplateCaLimitMessage: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "源码项目导出会写入导入的 CA；当前模板 APK 构建仍主要依赖系统 CA 和用户安装 CA。"
-        AppLanguage.ENGLISH -> "Source project export writes imported CAs; current template APK builds still mainly rely on system and user-installed CAs."
-        AppLanguage.ARABIC -> "تقوم صادرات المشروع المصدري بكتابة شهادات CA المستوردة؛ وما تزال بنية APK القالب الحالية تعتمد أساسًا على شهادات النظام والمستخدم."
-        AppLanguage.PORTUGUESE -> "A exportação do projeto fonte grava CAs importadas; as builds de APK de modelo atuais ainda dependem principalmente de CAs do sistema e instaladas pelo usuário."
-        AppLanguage.SPANISH -> "La exportación del proyecto fuente escribe CAs importadas; las builds de APK de plantilla actuales aún dependen principalmente de CAs del sistema e instaladas por el usuario."
-        AppLanguage.FRENCH -> "L'export du projet source écrit les CA importés ; les builds d'APK de modèle actuels s'appuient encore principalement sur les CA système et installés par l'utilisateur."
-        AppLanguage.GERMAN -> "Der Quellprojekt-Export schreibt importierte CAs; aktuelle Template-APK-Builds verlassen sich weiterhin hauptsächlich auf System- und benutzerinstallierte CAs."
-        AppLanguage.RUSSIAN -> "Экспорт исходного проекта записывает импортированные CA; текущие сборки APK-шаблонов по-прежнему в основном полагаются на системные и пользовательские CA."
-        AppLanguage.JAPANESE -> "ソースプロジェクトのエクスポートはインポートされたCAを書き込みます。現在のテンプレートAPKビルドは引き続き主にシステムCAとユーザーインストールCAに依存しています。"
-        AppLanguage.KOREAN -> "소스 프로젝트 내보내기는 가져온 CA를 기록합니다. 현재 템플릿 APK 빌드는 여전히 주로 시스템 및 사용자 설치 CA에 의존합니다."
+        AppLanguage.CHINESE -> "导入的 CA 会在构建出的 APK 内生效:由该 CA 直接签发的证书会被信任。完整证书链(根+中间)请用源码项目导出。"
+        AppLanguage.ENGLISH -> "Imported CAs take effect in built APKs: certificates directly signed by an imported CA are trusted. For full chain (root + intermediate), use source-project export."
+        AppLanguage.ARABIC -> "شهادات CA المستوردة تسري داخل APK المبني: الشهادات الموقعة مباشرة من CA مستورد موثوقة. للسلسلة الكاملة (جذر + وسيط) استخدم تصدير المشروع المصدري."
+        AppLanguage.PORTUGUESE -> "CAs importadas passam a valer nos APKs gerados: certificados assinados diretamente por uma CA importada são confiáveis. Para cadeia completa (raiz + intermediária), use a exportação do projeto fonte."
+        AppLanguage.SPANISH -> "Las CAs importadas funcionan en los APK generados: los certificados firmados directamente por una CA importada son de confianza. Para cadena completa (raíz + intermedia), usa la exportación del proyecto fuente."
+        AppLanguage.FRENCH -> "Les CA importés prennent effet dans les APK générés : les certificats signés directement par un CA importé sont approuvés. Pour la chaîne complète (racine + intermédiaire), utilisez l'export du projet source."
+        AppLanguage.GERMAN -> "Importierte CAs wirken in erstellten APKs: direkt von einer importierten CA signierte Zertifikate werden vertraut. Für volle Kette (Root + Intermediate) verwenden Sie den Quellprojekt-Export."
+        AppLanguage.RUSSIAN -> "Импортированные CA действуют в собранных APK: сертификаты, напрямую подписанные импортированной CA, считаются доверенными. Для полной цепочки (корень + промежуточный) используйте экспорт исходного проекта."
+        AppLanguage.JAPANESE -> "インポートしたCAは生成されたAPK内で有効になり、そのCAで直接署名された証明書は信頼されます。完全なチェーン(ルート+中間)にはソースプロジェクトのエクスポートを使用してください。"
+        AppLanguage.KOREAN -> "가져온 CA는 빌드된 APK에서 적용되며, 해당 CA로 직접 서명된 인증서는 신뢰됩니다. 전체 체인(루트 + 중간)이 필요하면 소스 프로젝트 내보내기를 사용하세요."
     }
 
     val preflightCleartextTitle: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/webview/CustomCaTrustStore.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/CustomCaTrustStore.kt
@@ -1,0 +1,139 @@
+package com.webtoapp.core.webview
+
+import android.content.Context
+import com.webtoapp.core.logging.AppLogger
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Trust anchors the user imported via the editor's "Network trust → Import custom CA" panel.
+ *
+ * At export time [com.webtoapp.core.apkbuilder.ApkBuilder] writes each imported certificate's
+ * canonical DER bytes under `assets/wta_custom_ca/` inside the generated APK. At runtime this
+ * store scans that directory once, loads every certificate into a KeyStore, and exposes
+ * [isServerCertTrusted] for the WebView SSL error handler.
+ *
+ * The built template APK otherwise pins a `network_security_config.xml` that trusts only the
+ * system store (editing the compiled binary resource table per-app is fragile and high blast
+ * radius). This store is the additive, safe channel that lets a generated app honor the user's
+ * imported CAs without touching the template's resource table: an empty asset directory means
+ * no anchors, and [isServerCertTrusted] returns false with zero behavior change.
+ *
+ * Limitation: WebView's [android.net.http.SslError] exposes only the server leaf, not the chain,
+ * so we validate the leaf directly against the imported anchors (the common case: the imported
+ * CA is the direct issuer of the server's certificate). Full PKIX path building across an
+ * intermediate the server did not send is not possible from this hook; source-project export
+ * remains the path for that.
+ */
+object CustomCaTrustStore {
+    private const val TAG = "CustomCaTrustStore"
+    private const val ASSET_DIR = "wta_custom_ca"
+
+    @Volatile private var validator: CustomCaValidator? = null
+    @Volatile private var initialized = false
+
+    @Synchronized
+    fun init(context: Context) {
+        if (initialized) return
+        val anchors = loadFromAssets(context)
+        validator = CustomCaValidator(anchors)
+        initialized = true
+        if (anchors.isNotEmpty()) {
+            AppLogger.i(TAG, "Loaded ${anchors.size} custom CA anchor(s) from assets/$ASSET_DIR")
+        }
+    }
+
+    /** Test/host entry point: build directly from in-memory DER blobs, bypassing the asset scan. */
+    @Synchronized
+    fun initFromDer(certBytes: List<ByteArray>) {
+        val factory = CertificateFactory.getInstance("X.509")
+        val anchors = certBytes.mapNotNull { bytes ->
+            runCatching {
+                factory.generateCertificates(bytes.inputStream())
+                    .filterIsInstance<X509Certificate>()
+            }.getOrDefault(emptyList())
+        }.flatten()
+        validator = CustomCaValidator(anchors)
+        initialized = true
+    }
+
+    @Synchronized
+    fun reset() {
+        validator = null
+        initialized = false
+    }
+
+    fun hasAnchors(): Boolean = validator?.hasAnchors() == true
+
+    /** True iff [leaf] cryptographically validates against an imported anchor. Fail-closed. */
+    fun isServerCertTrusted(leaf: X509Certificate): Boolean =
+        validator?.isServerCertTrusted(leaf) == true
+
+    private fun loadFromAssets(context: Context): List<X509Certificate> {
+        val names = runCatching { context.assets.list(ASSET_DIR) }.getOrNull()
+        if (names.isNullOrEmpty()) return emptyList()
+        val factory = CertificateFactory.getInstance("X.509")
+        val out = mutableListOf<X509Certificate>()
+        names.sorted().forEach { name ->
+            runCatching {
+                context.assets.open("$ASSET_DIR/$name").use { input ->
+                    out.addAll(
+                        factory.generateCertificates(input).filterIsInstance<X509Certificate>()
+                    )
+                }
+            }.onFailure { e ->
+                AppLogger.w(TAG, "Failed to load custom CA asset $name: ${e.message}")
+            }
+        }
+        return out
+    }
+}
+
+/**
+ * Pure-JVM (unit-testable) validator backed by a PKIX [X509TrustManager] seeded with the imported
+ * anchors. Every public method is fail-closed: any unexpected exception yields `false`, never a
+ * crash — this object sits on the WebView SSL error hot path.
+ */
+class CustomCaValidator(private val anchors: List<X509Certificate>) {
+    private val trustManager: X509TrustManager? = buildTrustManager()
+
+    fun hasAnchors(): Boolean = anchors.isNotEmpty()
+
+    fun isServerCertTrusted(leaf: X509Certificate): Boolean {
+        if (anchors.isEmpty()) return false
+
+        // 1. Real PKIX path validation with the imported anchors as trust roots. Handles the case
+        //    where the imported CA is the direct issuer of the server leaf.
+        val tm = trustManager
+        if (tm != null) {
+            runCatching {
+                tm.checkServerTrusted(arrayOf(leaf), "ECDHE_RSA")
+                return true
+            }
+        }
+
+        // 2. Signature fallback for cases where PKIX is picky (e.g. the anchor lacks basicConstraints
+        //    CA:true, or a critical extension Android dislikes): accept the leaf if its issuer DN
+        //    matches an anchor and the leaf's signature actually verifies against that anchor's key.
+        val issuer = leaf.issuerX500Principal
+        return anchors.any { anchor ->
+            anchor.subjectX500Principal == issuer &&
+                runCatching { leaf.verify(anchor.publicKey); true }.getOrDefault(false)
+        }
+    }
+
+    private fun buildTrustManager(): X509TrustManager? = runCatching {
+        if (anchors.isEmpty()) return null
+        val ks = KeyStore.getInstance(KeyStore.getDefaultType())
+        ks.load(null, null)
+        anchors.forEachIndexed { i, cert -> ks.setCertificateEntry("wta_custom_ca_$i", cert) }
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(ks)
+        tmf.trustManagers.firstOrNull { it is X509TrustManager } as? X509TrustManager
+    }.onFailure { e ->
+        AppLogger.w("CustomCaValidator", "TrustManager build failed: ${e.message}")
+    }.getOrNull()
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -2529,6 +2529,29 @@ class WebViewManager(
                     return
                 }
 
+                // Imported custom CA: if the only problem is an untrusted chain and the server
+                // leaf cryptographically validates against an anchor the user imported in the
+                // editor, honor it. Applies to both main-frame and sub-resource requests so that
+                // CSS/JS/XHR served over the same custom-CA HTTPS also load.
+                if (error != null &&
+                    error.primaryError == android.net.http.SslError.SSL_UNTRUSTED) {
+                    runCatching { CustomCaTrustStore.init(context) }
+                    if (CustomCaTrustStore.hasAnchors()) {
+                        val trustedCert = extractServerCert(error)
+                        if (trustedCert != null &&
+                            runCatching { CustomCaTrustStore.isServerCertTrusted(trustedCert) }
+                                .getOrDefault(false)) {
+                            AppLogger.i(
+                                "WebViewManager",
+                                "Proceeding with custom-CA-trusted certificate for: $errorUrl " +
+                                    "(subject=${trustedCert.subjectX500Principal})"
+                            )
+                            handler?.proceed()
+                            return
+                        }
+                    }
+                }
+
                 if (!isMainFrameSslError) {
 
                     handler?.cancel()
@@ -2835,15 +2858,7 @@ class WebViewManager(
 
     private fun isMitmSslError(error: android.net.http.SslError?): Boolean {
         if (error == null) return false
-        val cert = error.certificate?.let { sslCert ->
-            try {
-                val certField = sslCert.javaClass.getDeclaredField("mX509Certificate")
-                certField.isAccessible = true
-                certField.get(sslCert) as? java.security.cert.X509Certificate
-            } catch (_: Exception) {
-                null
-            }
-        }
+        val cert = extractServerCert(error)
         if (cert != null) {
             return TlsMitmCaManager.isSignedByLocalCa(cert)
         }
@@ -2853,6 +2868,15 @@ class WebViewManager(
             error.primaryError == android.net.http.SslError.SSL_NOTYETVALID ||
             error.primaryError == android.net.http.SslError.SSL_IDMISMATCH
         )
+    }
+
+    private fun extractServerCert(error: android.net.http.SslError?): java.security.cert.X509Certificate? {
+        val sslCert = error?.certificate ?: return null
+        return runCatching {
+            val field = sslCert.javaClass.getDeclaredField("mX509Certificate")
+            field.isAccessible = true
+            field.get(sslCert) as? java.security.cert.X509Certificate
+        }.getOrNull()
     }
 
     private fun refetchWithHeaderModifications(

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppApkSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppApkSection.kt
@@ -55,15 +55,24 @@ fun ApkExportSection(
     ) { uri: Uri? ->
         if (uri == null) return@rememberLauncherForActivityResult
         runCatching {
-            NetworkTrustStorage.importCertificate(context, uri)
-        }.onSuccess { cert ->
-            val next = config.networkTrustConfig.copy(
-                customCaCertificates = config.networkTrustConfig.customCaCertificates + cert
-            )
-            caImportError = null
-            onConfigChange(config.copy(networkTrustConfig = next))
+            NetworkTrustStorage.importCertificates(context, uri)
+        }.onSuccess { certs ->
+            if (certs.isEmpty()) {
+                caImportError = Strings.invalidCertificate
+            } else {
+                val next = config.networkTrustConfig.copy(
+                    customCaCertificates = config.networkTrustConfig.customCaCertificates + certs
+                )
+                caImportError = null
+                onConfigChange(config.copy(networkTrustConfig = next))
+            }
         }.onFailure { error ->
-            caImportError = error.message ?: Strings.invalidCertificate
+            val reason = (error as? NetworkTrustStorage.InvalidCertificateException)?.reason
+            caImportError = when (reason) {
+                NetworkTrustStorage.InvalidReason.PRIVATE_KEY -> Strings.invalidCertificatePrivateKey
+                NetworkTrustStorage.InvalidReason.UNRECOGNIZED -> Strings.invalidCertificateUnrecognized
+                null -> error.message ?: Strings.invalidCertificate
+            }
         }
     }
 

--- a/app/src/main/java/com/webtoapp/util/NetworkTrustStorage.kt
+++ b/app/src/main/java/com/webtoapp/util/NetworkTrustStorage.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.net.Uri
 import com.webtoapp.data.model.CustomCaCertificate
 import java.io.File
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.util.Base64
 import java.util.Locale
 import java.util.UUID
 
@@ -14,39 +17,103 @@ object NetworkTrustStorage {
     private const val CERT_DIR = "custom_ca"
     private const val MAX_CERT_BYTES = 256 * 1024
 
-    fun importCertificate(
+    /**
+     * Why a certificate blob was rejected. Maps to a localized user message at the call site.
+     * [PrivateKey] is detected reliably (the blob carries a private key, not a certificate);
+     * [Unrecognized] covers everything else (PKCS#12/.pfx keystores, CSRs, raw text, wrong
+     * encoding, truncated files) — the message hints at the most common causes.
+     */
+    enum class InvalidReason { PRIVATE_KEY, UNRECOGNIZED }
+
+    class InvalidCertificateException(val reason: InvalidReason) : Exception(reason.name)
+
+    /**
+     * Parse one or more X.509 certificates from a user-supplied blob. Accepts the formats users
+     * actually export from Windows / OpenSSL / enterprise CAs:
+     *  - PEM (single or chain), incl. `-----BEGIN TRUSTED CERTIFICATE-----` and
+     *    `-----BEGIN X509 CERTIFICATE-----` variants produced by `openssl x509 -trustout`
+     *    and some Linux trust stores,
+     *  - DER (single),
+     *  - PKCS#7 `.p7b` / `.pkcs7` (PEM-armored or binary, possibly a chain),
+     *  - raw Base64 with no PEM armor (some CA portals hand this out),
+     *  - UTF-8/UTF-16/UTF-32 BOMs and UTF-16 transcoding (Windows "Unicode" save).
+     *
+     * Returns every certificate found, de-duplicated. Throws [InvalidCertificateException] with a
+     * typed reason if nothing parseable is present. Never throws the raw platform
+     * `ParsingException` ("No certificate found") at the caller — that is what users were seeing.
+     */
+    fun parseCertificates(bytes: ByteArray): List<X509Certificate> {
+        require(bytes.isNotEmpty()) { "Certificate is empty" }
+        require(bytes.size <= MAX_CERT_BYTES) { "Certificate is too large" }
+
+        val factory = CertificateFactory.getInstance("X.509")
+        val normalized = normalizeEncoding(bytes)
+
+        // 1. Standard path covers PEM chains, PEM-PKCS#7, DER X.509, and DER PKCS#7.
+        normalized.tryGenerate(factory)?.let { if (it.isNotEmpty()) return it }
+
+        // 2. OpenSSL "TRUSTED CERTIFICATE" / "X509 CERTIFICATE" labels trip up generateCertificate,
+        //    which only accepts the plain CERTIFICATE PEM type. Rewrite and retry.
+        rewritePemLabels(normalized)?.let { rewritten ->
+            rewritten.tryGenerate(factory)?.let { if (it.isNotEmpty()) return it }
+        }
+
+        // 3. Raw Base64 (no armor). Re-wrap and retry.
+        armorBase64IfApplicable(normalized)?.let { armored ->
+            armored.tryGenerate(factory)?.let { if (it.isNotEmpty()) return it }
+        }
+
+        throw InvalidCertificateException(diagnose(normalized))
+    }
+
+    /**
+     * Import every certificate reachable from [uri]. A single file may contribute multiple
+     * certificates (full chain, PKCS#7 bundle); each becomes its own [CustomCaCertificate].
+     * Already-imported certificates (by SHA-256) are skipped.
+     */
+    fun importCertificates(
         context: Context,
         uri: Uri,
         displayNameHint: String? = null
-    ): CustomCaCertificate {
+    ): List<CustomCaCertificate> {
         val bytes = context.contentResolver.openInputStream(uri)?.use { input ->
             input.readBytes()
         } ?: throw IllegalArgumentException("Unable to read certificate")
 
-        require(bytes.isNotEmpty()) { "Certificate is empty" }
-        require(bytes.size <= MAX_CERT_BYTES) { "Certificate is too large" }
+        val certificates = parseCertificates(bytes)
+        val dir = certDirectory(context)
+        var existingShaPrefixes = dir.listFiles().orEmpty()
+            .mapNotNull { it.name.substringAfterLast('_', "").takeIf { s -> s.isNotEmpty() } }
+            .toSet()
 
-        val certificate = parseX509(bytes)
-        val encoded = certificate.encoded
-        val sha256 = encoded.sha256Hex()
-        val id = UUID.randomUUID().toString()
-        val safeName = sanitizeResourceName(displayNameHint ?: certificate.subjectX500Principal.name)
-        val file = certDirectory(context).resolve("${safeName}_${sha256.take(12)}.cer")
-        file.writeBytes(encoded)
+        val imported = mutableListOf<CustomCaCertificate>()
+        certificates.forEachIndexed { index, cert ->
+            val encoded = cert.encoded
+            val sha256 = encoded.sha256Hex()
+            val shaPrefix = sha256.take(12)
+            if (shaPrefix in existingShaPrefixes) return@forEachIndexed
 
-        return CustomCaCertificate(
-            id = id,
-            displayName = displayNameHint?.trim()?.takeIf { it.isNotBlank() }
-                ?: certificate.subjectX500Principal.name,
-            filePath = file.absolutePath,
-            sha256 = sha256
-        )
+            val label = if (certificates.size == 1) displayNameHint else null
+            val safeName = sanitizeResourceName(label ?: cert.subjectX500Principal.name)
+            val file = dir.resolve("${safeName}_${shaPrefix}.cer")
+            file.writeBytes(encoded)
+            existingShaPrefixes = existingShaPrefixes + shaPrefix
+
+            imported += CustomCaCertificate(
+                id = UUID.randomUUID().toString(),
+                displayName = (label?.trim()?.takeIf { it.isNotBlank() }
+                    ?: cert.subjectX500Principal.name),
+                filePath = file.absolutePath,
+                sha256 = sha256
+            )
+        }
+        return imported
     }
 
     fun validateCertificateFile(path: String): Boolean {
         val file = File(path)
         if (!file.isFile || !file.canRead() || file.length() <= 0L) return false
-        return runCatching { parseX509(file.readBytes()) }.isSuccess
+        return runCatching { parseCertificates(file.readBytes()).isNotEmpty() }.getOrDefault(false)
     }
 
     fun rawResourceName(index: Int): String = "wta_custom_ca_${index + 1}"
@@ -59,9 +126,92 @@ object NetworkTrustStorage {
         return if (base.first().isLetter()) base.take(32) else "ca_${base.take(29)}"
     }
 
-    fun parseX509(bytes: ByteArray): X509Certificate {
-        val factory = CertificateFactory.getInstance("X.509")
-        return factory.generateCertificate(bytes.inputStream()) as X509Certificate
+    private fun ByteArray.tryGenerate(factory: CertificateFactory): List<X509Certificate>? =
+        runCatching {
+            factory.generateCertificates(inputStream())
+                .filterIsInstance<X509Certificate>()
+                .distinctBy { runCatching { it.encoded }.getOrDefault(it) }
+        }.getOrNull()
+
+    /**
+     * Strip BOMs and transcode UTF-16/UTF-32 to UTF-8 so the PEM markers become byte-matchable.
+     * Binary DER inputs are returned unchanged.
+     */
+    private fun normalizeEncoding(bytes: ByteArray): ByteArray {
+        // UTF-32 BOMs (4-byte). Java has no standard UTF-32 Charset; try by name, best-effort.
+        if (bytes.size >= 4) {
+            val utf32 = when {
+                bytes[0] == 0x00.toByte() && bytes[1] == 0x00.toByte() &&
+                    bytes[2] == 0xFE.toByte() && bytes[3] == 0xFF.toByte() -> "UTF-32BE"
+                bytes[0] == 0xFF.toByte() && bytes[1] == 0xFE.toByte() &&
+                    bytes[2] == 0x00.toByte() && bytes[3] == 0x00.toByte() -> "UTF-32LE"
+                else -> null
+            }
+            utf32?.let {
+                runCatching { Charset.forName(it) }.getOrNull()?.let { cs ->
+                    return String(bytes, cs).toByteArray(StandardCharsets.UTF_8)
+                }
+            }
+        }
+        // UTF-16 BOMs (2-byte). StandardCharsets.UTF_16 auto-detects endianness from the BOM and
+        // drops it. The 4-byte UTF-32LE prefix is handled above; a lone 0xFF 0xFE here is UTF-16LE.
+        if (bytes.size >= 2) {
+            val b0 = bytes[0]; val b1 = bytes[1]
+            val isUtf16Bom = (b0 == 0xFE.toByte() && b1 == 0xFF.toByte()) ||
+                (b0 == 0xFF.toByte() && b1 == 0xFE.toByte())
+            if (isUtf16Bom && bytes.size >= 4 && bytes[2] == 0x00.toByte() && bytes[3] == 0x00.toByte()) {
+                // UTF-32LE already consumed above; if we reach here UTF-32 was unavailable, skip.
+            } else if (isUtf16Bom) {
+                return String(bytes, StandardCharsets.UTF_16).toByteArray(StandardCharsets.UTF_8)
+            }
+        }
+        // UTF-8 BOM.
+        if (bytes.size >= 3 &&
+            bytes[0] == 0xEF.toByte() && bytes[1] == 0xBB.toByte() && bytes[2] == 0xBF.toByte()) {
+            return bytes.copyOfRange(3, bytes.size)
+        }
+        return bytes
+    }
+
+    /** Rewrite non-standard PEM CERTIFICATE labels to the plain type Conscrypt accepts. */
+    private fun rewritePemLabels(bytes: ByteArray): ByteArray? {
+        val text = runCatching { String(bytes, StandardCharsets.UTF_8) }.getOrNull() ?: return null
+        val hasTrusted = text.contains("-----BEGIN TRUSTED CERTIFICATE-----") ||
+            text.contains("-----BEGIN X509 CERTIFICATE-----")
+        if (!hasTrusted) return null
+        return text
+            .replace("-----BEGIN TRUSTED CERTIFICATE-----", "-----BEGIN CERTIFICATE-----")
+            .replace("-----END TRUSTED CERTIFICATE-----", "-----END CERTIFICATE-----")
+            .replace("-----BEGIN X509 CERTIFICATE-----", "-----BEGIN CERTIFICATE-----")
+            .replace("-----END X509 CERTIFICATE-----", "-----END CERTIFICATE-----")
+            .toByteArray(StandardCharsets.UTF_8)
+    }
+
+    /** If [bytes] is unarmored Base64 that decodes to a DER SEQUENCE, wrap it in PEM armor. */
+    private fun armorBase64IfApplicable(bytes: ByteArray): ByteArray? {
+        if (bytes.isEmpty()) return null
+        val first = bytes[0]
+        if (first == 0x30.toByte()) return null          // already DER
+        if (first == '-'.code.toByte()) return null           // already PEM-ish
+        val text = runCatching { String(bytes, StandardCharsets.US_ASCII) }.getOrNull() ?: return null
+        val compact = text.filterNot { it.isWhitespace() }
+        if (compact.length < 16) return null
+        if (!compact.all { it.isLetterOrDigit() || it == '+' || it == '/' || it == '=' }) return null
+        if (compact.count { it == '=' } > 2) return null
+        if (compact.length % 4 != 0) return null
+        val decoded = runCatching { Base64.getDecoder().decode(compact) }.getOrNull() ?: return null
+        if (decoded.isEmpty() || decoded[0] != 0x30.toByte()) return null
+        return ("-----BEGIN CERTIFICATE-----\n$compact\n-----END CERTIFICATE-----\n")
+            .toByteArray(StandardCharsets.US_ASCII)
+    }
+
+    private fun diagnose(bytes: ByteArray): InvalidReason {
+        val text = runCatching { String(bytes, StandardCharsets.UTF_8) }.getOrNull()
+        if (text != null) {
+            val upper = text.uppercase(Locale.US)
+            if (upper.contains("BEGIN") && upper.contains("PRIVATE KEY")) return InvalidReason.PRIVATE_KEY
+        }
+        return InvalidReason.UNRECOGNIZED
     }
 
     fun ByteArray.sha256Hex(): String {

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/NetworkSecurityConfigBuilderTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/NetworkSecurityConfigBuilderTest.kt
@@ -3,9 +3,13 @@ package com.webtoapp.core.apkbuilder
 import com.google.common.truth.Truth.assertThat
 import com.webtoapp.data.model.CustomCaCertificate
 import com.webtoapp.data.model.NetworkTrustConfig
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class NetworkSecurityConfigBuilderTest {
+
+    @get:Rule val tmp = TemporaryFolder()
 
     @Test
     fun `default config trusts system anchors only`() {
@@ -28,13 +32,14 @@ class NetworkSecurityConfigBuilderTest {
 
     @Test
     fun `custom ca certificates map to stable raw resources`() {
+        val caFile = tmp.newFile("dev-ca.cer")
         val xml = NetworkSecurityConfigBuilder.build(
             NetworkTrustConfig(
                 customCaCertificates = listOf(
                     CustomCaCertificate(
                         id = "one",
                         displayName = "Dev CA",
-                        filePath = "/tmp/dev-ca.pem",
+                        filePath = caFile.absolutePath,
                         sha256 = "abc"
                     )
                 )
@@ -43,4 +48,30 @@ class NetworkSecurityConfigBuilderTest {
 
         assertThat(xml).contains("""<certificates src="@raw/wta_custom_ca_1" />""")
     }
+
+    @Test
+    fun `missing middle cert does not desync anchor and raw entry indices`() {
+        // Three certs, the middle one's file is missing. The anchor list and the raw entries
+        // must both skip it and stay sequentially indexed (no @raw/wta_custom_ca_2 without a file).
+        val first = tmp.newFile("a.cer")
+        val third = tmp.newFile("c.cer")
+        val config = NetworkTrustConfig(
+            customCaCertificates = listOf(
+                CustomCaCertificate(id = "a", displayName = "A", filePath = first.absolutePath, sha256 = "1"),
+                CustomCaCertificate(id = "b", displayName = "B", filePath = "/does/not/exist.cer", sha256 = "2"),
+                CustomCaCertificate(id = "c", displayName = "C", filePath = third.absolutePath, sha256 = "3")
+            )
+        )
+
+        val xml = NetworkSecurityConfigBuilder.build(config)
+        val entries = NetworkSecurityConfigBuilder.customRawEntries(config)
+
+        // Missing cert dropped, remaining two re-indexed 1 and 2 — anchor list and entries agree.
+        assertThat(entries.map { it.resourceName })
+            .containsExactly("wta_custom_ca_1", "wta_custom_ca_2").inOrder()
+        assertThat(xml).contains("""<certificates src="@raw/wta_custom_ca_1" />""")
+        assertThat(xml).contains("""<certificates src="@raw/wta_custom_ca_2" />""")
+        assertThat(xml).doesNotContain("""<certificates src="@raw/wta_custom_ca_3" />""")
+    }
 }
+

--- a/app/src/test/java/com/webtoapp/core/webview/CustomCaValidatorTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/CustomCaValidatorTest.kt
@@ -1,0 +1,97 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.BasicConstraints
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.After
+import org.junit.Test
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.cert.X509Certificate
+import java.util.Date
+
+class CustomCaValidatorTest {
+
+    @After
+    fun tearDown() {
+        CustomCaTrustStore.reset()
+    }
+
+    @Test
+    fun `leaf signed by imported ca is trusted`() {
+        val (caCert, caKey) = newCa("CN=Imported Root")
+        val leaf = newLeaf("CN=server.example", caCert, caKey)
+        CustomCaTrustStore.initFromDer(listOf(caCert.encoded))
+
+        assertThat(CustomCaTrustStore.hasAnchors()).isTrue()
+        assertThat(CustomCaTrustStore.isServerCertTrusted(leaf)).isTrue()
+    }
+
+    @Test
+    fun `leaf signed by a different ca is not trusted`() {
+        val (caA, keyA) = newCa("CN=Trusted Root")
+        val (caB, keyB) = newCa("CN=Untrusted Root")
+        val leaf = newLeaf("CN=server.example", caB, keyB)
+        CustomCaTrustStore.initFromDer(listOf(caA.encoded))
+
+        assertThat(CustomCaTrustStore.isServerCertTrusted(leaf)).isFalse()
+    }
+
+    @Test
+    fun `empty store trusts nothing`() {
+        val (caCert, caKey) = newCa("CN=Root")
+        val leaf = newLeaf("CN=server.example", caCert, caKey)
+        CustomCaTrustStore.initFromDer(emptyList())
+
+        assertThat(CustomCaTrustStore.hasAnchors()).isFalse()
+        assertThat(CustomCaTrustStore.isServerCertTrusted(leaf)).isFalse()
+    }
+
+    @Test
+    fun `validator accepts leaf directly even when anchor lacks full pkix path`() {
+        // Self-signed cert presented as the server leaf AND imported as the anchor: a degenerate but
+        // common real case (a site serves its self-signed root directly).
+        val (selfSigned, _) = newCa("CN=Self Signed Site")
+        CustomCaTrustStore.initFromDer(listOf(selfSigned.encoded))
+
+        assertThat(CustomCaTrustStore.isServerCertTrusted(selfSigned)).isTrue()
+    }
+
+    // --- helpers (mirror NetworkTrustStorageParseTest) ---
+
+    private fun newKeyPair(): KeyPair =
+        KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+
+    private fun newCa(subject: String): Pair<X509Certificate, KeyPair> {
+        val kp = newKeyPair()
+        val name = X500Name(subject)
+        val now = Date()
+        val builder = JcaX509v3CertificateBuilder(
+            name, BigInteger.valueOf(System.currentTimeMillis()),
+            now, Date(now.time + 365L * 24 * 3600 * 1000),
+            name, kp.public
+        )
+        builder.addExtension(Extension.basicConstraints, true, BasicConstraints(true))
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(kp.private)
+        val cert = JcaX509CertificateConverter().getCertificate(builder.build(signer))
+        return cert to kp
+    }
+
+    private fun newLeaf(subject: String, issuer: X509Certificate, issuerKey: KeyPair): X509Certificate {
+        val kp = newKeyPair()
+        val issuerName = X500Name(issuer.subjectX500Principal.name)
+        val now = Date()
+        val builder = JcaX509v3CertificateBuilder(
+            issuerName, BigInteger.valueOf(System.currentTimeMillis() + 1),
+            now, Date(now.time + 365L * 24 * 3600 * 1000),
+            X500Name(subject), kp.public
+        )
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(issuerKey.private)
+        return JcaX509CertificateConverter().getCertificate(builder.build(signer))
+    }
+}

--- a/app/src/test/java/com/webtoapp/util/NetworkTrustStorageParseTest.kt
+++ b/app/src/test/java/com/webtoapp/util/NetworkTrustStorageParseTest.kt
@@ -1,0 +1,150 @@
+package com.webtoapp.util
+
+import com.google.common.truth.Truth.assertThat
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.BasicConstraints
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Test
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.cert.X509Certificate
+import java.util.Base64
+import java.util.Date
+
+class NetworkTrustStorageParseTest {
+
+    @Test
+    fun `parses single PEM certificate`() {
+        val (caCert, _) = newCa("CN=Test Root")
+        val parsed = NetworkTrustStorage.parseCertificates(caCert.toPem())
+        assertThat(parsed).hasSize(1)
+        assertThat(parsed[0].subjectX500Principal.name).contains("Test Root")
+    }
+
+    @Test
+    fun `parses PEM chain`() {
+        val (caCert, caKey) = newCa("CN=Chain Root")
+        val leaf = newLeaf("CN=leaf", caCert, caKey)
+        val chain = caCert.toPem() + leaf.toPem()
+        val parsed = NetworkTrustStorage.parseCertificates(chain)
+        assertThat(parsed).hasSize(2)
+    }
+
+    @Test
+    fun `parses DER certificate`() {
+        val (caCert, _) = newCa("CN=DER Root")
+        val parsed = NetworkTrustStorage.parseCertificates(caCert.encoded)
+        assertThat(parsed).hasSize(1)
+    }
+
+    @Test
+    fun `parses PEM with UTF-8 BOM`() {
+        val (caCert, _) = newCa("CN=BOM Root")
+        val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        val pem = caCert.toPem()
+        val withBom = bom + pem
+        val parsed = NetworkTrustStorage.parseCertificates(withBom)
+        assertThat(parsed).hasSize(1)
+    }
+
+    @Test
+    fun `parses UTF-16LE encoded PEM`() {
+        val (caCert, _) = newCa("CN=UTF16 Root")
+        val pem = caCert.toPem()
+        // Windows "Unicode" save: UTF-16LE with BOM.
+        val utf16 = (String(pem, StandardCharsets.US_ASCII))
+            .toByteArray(StandardCharsets.UTF_16LE)
+        val withBom = byteArrayOf(0xFF.toByte(), 0xFE.toByte()) + utf16
+        val parsed = NetworkTrustStorage.parseCertificates(withBom)
+        assertThat(parsed).hasSize(1)
+    }
+
+    @Test
+    fun `parses TRUSTED CERTIFICATE pem label`() {
+        val (caCert, _) = newCa("CN=Trusted Label")
+        val pem = String(caCert.toPem(), StandardCharsets.US_ASCII)
+            .replace("BEGIN CERTIFICATE", "BEGIN TRUSTED CERTIFICATE")
+            .replace("END CERTIFICATE", "END TRUSTED CERTIFICATE")
+        val parsed = NetworkTrustStorage.parseCertificates(pem.toByteArray(StandardCharsets.US_ASCII))
+        assertThat(parsed).hasSize(1)
+    }
+
+    @Test
+    fun `parses raw base64 without pem armor`() {
+        val (caCert, _) = newCa("CN=Bare Base64")
+        val b64 = Base64.getMimeEncoder().encodeToString(caCert.encoded).replace("\r", "").replace("\n", "")
+        val parsed = NetworkTrustStorage.parseCertificates(b64.toByteArray(StandardCharsets.US_ASCII))
+        assertThat(parsed).hasSize(1)
+    }
+
+    @Test
+    fun `private key blob reports private key reason`() {
+        val keyPair = newKeyPair()
+        val pkcs8 = keyPair.private.encoded
+        val pem = "-----BEGIN PRIVATE KEY-----\n" +
+            Base64.getMimeEncoder().encodeToString(pkcs8) +
+            "\n-----END PRIVATE KEY-----\n"
+        val ex = runCatching { NetworkTrustStorage.parseCertificates(pem.toByteArray()) }.exceptionOrNull()
+        assertThat(ex).isInstanceOf(NetworkTrustStorage.InvalidCertificateException::class.java)
+        assertThat((ex as NetworkTrustStorage.InvalidCertificateException).reason)
+            .isEqualTo(NetworkTrustStorage.InvalidReason.PRIVATE_KEY)
+    }
+
+    @Test
+    fun `unrecognized blob reports unrecognized reason`() {
+        val ex = runCatching {
+            NetworkTrustStorage.parseCertificates("not a certificate at all".toByteArray())
+        }.exceptionOrNull()
+        assertThat(ex).isInstanceOf(NetworkTrustStorage.InvalidCertificateException::class.java)
+        assertThat((ex as NetworkTrustStorage.InvalidCertificateException).reason)
+            .isEqualTo(NetworkTrustStorage.InvalidReason.UNRECOGNIZED)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `empty blob throws`() {
+        NetworkTrustStorage.parseCertificates(ByteArray(0))
+    }
+
+    // --- helpers ---
+
+    private fun X509Certificate.toPem(): ByteArray =
+        ("-----BEGIN CERTIFICATE-----\n" +
+            Base64.getMimeEncoder().encodeToString(encoded) +
+            "\n-----END CERTIFICATE-----\n").toByteArray(StandardCharsets.US_ASCII)
+
+    private fun newKeyPair(): KeyPair =
+        KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+
+    private fun newCa(subject: String): Pair<X509Certificate, KeyPair> {
+        val kp = newKeyPair()
+        val name = X500Name(subject)
+        val now = Date()
+        val builder = JcaX509v3CertificateBuilder(
+            name, BigInteger.valueOf(System.currentTimeMillis()),
+            now, Date(now.time + 365L * 24 * 3600 * 1000),
+            name, kp.public
+        )
+        builder.addExtension(Extension.basicConstraints, true, BasicConstraints(true))
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(kp.private)
+        val cert = JcaX509CertificateConverter().getCertificate(builder.build(signer))
+        return cert to kp
+    }
+
+    private fun newLeaf(subject: String, issuer: X509Certificate, issuerKey: KeyPair): X509Certificate {
+        val kp = newKeyPair()
+        val issuerName = X500Name(issuer.subjectX500Principal.name)
+        val now = Date()
+        val builder = JcaX509v3CertificateBuilder(
+            issuerName, BigInteger.valueOf(System.currentTimeMillis() + 1),
+            now, Date(now.time + 365L * 24 * 3600 * 1000),
+            X500Name(subject), kp.public
+        )
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(issuerKey.private)
+        return JcaX509CertificateConverter().getCertificate(builder.build(signer))
+    }
+}

--- a/scripts/config_field_drift_allowlist.json
+++ b/scripts/config_field_drift_allowlist.json
@@ -2,11 +2,11 @@
   "_doc": "Drift allowlist for scripts/check_config_field_drift.py. Every entry MUST have a non-empty 'reason'. Two valid exemption categories: (1) nested-object serialization — payload assigns a data class instance as a value, Gson recursively serializes its property names as JSON keys, so the field name only appears in the source class definition, not in ApkConfigJsonFactory.kt; (2) legitimately dead payload — written by payload but runtime path uses a different channel (e.g. networkSecurityConfig.xml) so ShellConfig intentionally does not declare it; (3) preview-only fields injected by ShellPreviewLauncher that exported APKs never populate. If a key here becomes stale (neither side references it) the script warns.",
   "allowlist": [
     {"key": "schemaVersion", "reason": "Payload metadata written by toShellPayload header; ShellConfig does not version-track, runtime ignores it."},
-    {"key": "networkTrustConfig", "reason": "Dead payload subtree — network trust config is embedded as networkSecurityConfig.xml by NetworkSecurityConfigBuilder at export, ShellConfig never reads it."},
-    {"key": "trustSystemCa", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
-    {"key": "trustUserCa", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
-    {"key": "customCaCertificates", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
-    {"key": "cleartextTrafficPermitted", "reason": "Dead payload subtree — see networkTrustConfig; real runtime path is networkSecurityConfig.xml."},
+    {"key": "networkTrustConfig", "reason": "Dead payload subtree — ShellConfig never reads it. Real runtime paths: (1) source-project export writes res/xml/network_security_config.xml via NetworkSecurityConfigBuilder; (2) built APK embeds custom CA DERs at assets/wta_custom_ca/ (written by ApkBuilder), consumed at runtime by CustomCaTrustStore, NOT via JSON."},
+    {"key": "trustSystemCa", "reason": "Dead payload subtree — see networkTrustConfig."},
+    {"key": "trustUserCa", "reason": "Dead payload subtree — see networkTrustConfig."},
+    {"key": "customCaCertificates", "reason": "Dead payload subtree — see networkTrustConfig; the cert bytes themselves ride assets/wta_custom_ca/, not this JSON."},
+    {"key": "cleartextTrafficPermitted", "reason": "Dead payload subtree — see networkTrustConfig; built APK cleartext is governed by the shell manifest's usesCleartextTraffic, not this JSON."},
     {"key": "displayName", "reason": "Nested object field of CustomCaCertificate, serialized via customCaCertificates.map{...} in networkTrustConfigPayload. Dead payload subtree (see networkTrustConfig)."},
     {"key": "sha256", "reason": "Nested object field of CustomCaCertificate, serialized via customCaCertificates.map{...} in networkTrustConfigPayload. Dead payload subtree (see networkTrustConfig)."},
 


### PR DESCRIPTION
Closes #492.

## Problem

Two issues with the custom-CA feature, both surfaced by the reporter hitting `com.android.org.conscrypt.OpenSSLX509CertificateFactory$ParsingException: No certificate found`:

1. **Import crash.** `NetworkTrustStorage.parseX509()` called `CertificateFactory.generateCertificate()` directly and rethrew the platform exception. Conscrypt only accepts a narrow input there (single DER, or a PEM block labelled exactly `-----BEGIN CERTIFICATE-----`), so it threw `No certificate found` for the formats enterprise CAs actually hand out: PKCS#7 `.p7b` chains, UTF-8/UTF-16/UTF-32 BOMs, `-----BEGIN TRUSTED CERTIFICATE-----` (from `openssl x509 -trustout` / some Linux trust stores), raw Base64 without PEM armor, and multi-cert chains (only the first was ever taken).

2. **Built APK ignored imported CAs.** Imported CAs took effect only on **source-project export**. The standard **Build APK** path wrote nothing — the template `network_security_config.xml` was pinned to system-only and `networkTrustConfig` was a dead payload on that path. (The prior reply on the issue overstated this; corrected there too.)

## Fix

**Robust importer** (`NetworkTrustStorage`)
- New `parseCertificates(bytes): List<X509Certificate>`: normalises BOM/UTF-16/UTF-32, rewrites `TRUSTED`/`X509 CERTIFICATE` PEM labels, re-wraps raw Base64 in PEM armor, and uses `generateCertificates` (plural) so PEM chains and PKCS#7 bundles import every cert.
- `importCertificates(uri): List<CustomCaCertificate>` — one file can contribute multiple certs; de-dupes by SHA-256.
- On failure, throws a typed `InvalidCertificateException(reason)` mapping to localised messages (`invalidCertificatePrivateKey`, `invalidCertificateUnrecognized`) — no more raw Conscrypt stacktrace in the UI banner. All strings added for 10 languages.

**Honor imported CAs in built APKs**
- `ApkBuilder.addCustomCaCertsToAssets()` writes each imported CA as canonical DER under `assets/wta_custom_ca/` into the generated APK (all export paths, including encrypted builds — CA certs are public, stored unencrypted).
- New shell-synced `CustomCaTrustStore`: scans `assets/wta_custom_ca/` once at runtime, builds a PKIX `KeyStore` from the anchors, and exposes `isServerCertTrusted(leaf)`.
- `WebViewManager.onReceivedSslError`: after the MITM-bridge check, if the error is `SSL_UNTRUSTED` and the leaf cryptographically validates against an imported anchor, `handler.proceed()`. Applies to main frame **and** sub-resources. Guarded by real PKIX validation + signature fallback, and fail-closed — empty anchor set = zero behavior change, no MITM surface added.

**Honest limitation:** `SslError` exposes only the server leaf, so this validates the leaf directly against the imported anchor (the common case: the imported CA is the direct issuer). For a root + un-sent intermediate chain, source-project export still does full PKIX. The preflight hint strings were reworded to state this accurately instead of the old "template APK does not support imported CAs".

**Drive-by:** fixed a `NetworkSecurityConfigBuilder` index-drift bug — a missing middle cert left a `<certificates src="@raw/wta_custom_ca_N">` referencing a `res/raw` file that was never written, failing the source-export aapt build. Anchors and raw entries now share one filtered, sequentially-indexed list.

## Verification

- `:app:compileStandardDebugKotlin` + `:shell:assembleRelease` + `:app:syncShellTemplateApk` green; rebuilt template DEX contains `CustomCaTrustStore` / `wta_custom_ca`.
- `:app:checkConfigFieldDrift` + `scripts/check_config_field_drift.py` green (allowlist reasons refreshed to document the `assets/wta_custom_ca/` runtime path).
- New/extended unit tests green: `NetworkTrustStorageParseTest` (PEM chain / DER / BOM / UTF-16LE / TRUSTED label / raw Base64 / private-key / unrecognized), `NetworkSecurityConfigBuilderTest` (+ missing-middle index regression), `CustomCaValidatorTest` (leaf trusted / untrusted-CA rejected / empty store / self-signed).
- Regression: `BuildInputPreflightTest`, i18n consistency tests green.

## Security note

The proceed path fires **only** when `primaryError == SSL_UNTRUSTED` and the leaf verifies against an imported anchor (PKIX, with a signature-verification fallback). It never auto-proceeds on `SSL_IDMISMATCH` / `SSL_EXPIRED` / `SSL_NOTYETVALID`. An app with no imported CAs behaves identically to before.