### PR TITLE
fix: improve 16KB AppCompat symbol lookup for Android 16 Node.js laun…

### DIFF
--- a/app/src/main/cpp/node_bridge.cpp
+++ b/app/src/main/cpp/node_bridge.cpp
@@ -25,13 +25,24 @@ static void enable_16kb_app_compat_if_needed() {
     if (page_size < 16384L) {
         return;
     }
-    set_16kb_appcompat_fn fn =
-        (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__loader_android_set_16kb_appcompat_mode");
+
+    set_16kb_appcompat_fn fn = nullptr;
+
+    // Android 16+ loader 符号（首选）
+    fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__loader_android_set_16kb_appcompat_mode");
+
+    // Android 15/16 通用符号
     if (fn == nullptr) {
         fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "android_set_16kb_appcompat_mode");
     }
+
+    // 极端 fallback（防止符号被移除）
+    if (fn == nullptr) {
+        fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__android_set_16kb_appcompat_mode");
+    }
+
     if (fn != nullptr) {
-        fn(1);
+        fn(1);  // enable 16KB appcompat
     }
 }
 

--- a/app/src/main/cpp/node_launcher.c
+++ b/app/src/main/cpp/node_launcher.c
@@ -15,13 +15,24 @@ static void enable_16kb_app_compat_if_needed(void) {
     if (page_size < 16384L) {
         return;
     }
-    set_16kb_appcompat_fn fn =
-        (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__loader_android_set_16kb_appcompat_mode");
+
+    set_16kb_appcompat_fn fn = NULL;
+
+    // Android 16+ loader 符号（首选）
+    fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__loader_android_set_16kb_appcompat_mode");
+
+    // Android 15/16 通用符号
     if (fn == NULL) {
         fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "android_set_16kb_appcompat_mode");
     }
+
+    // 极端 fallback（防止符号被移除）
+    if (fn == NULL) {
+        fn = (set_16kb_appcompat_fn)dlsym(RTLD_DEFAULT, "__android_set_16kb_appcompat_mode");
+    }
+
     if (fn != NULL) {
-        fn(1);
+        fn(1);  // enable 16KB appcompat
     }
 }
 


### PR DESCRIPTION
…cher

Addresses Issue #517: Node.js APK fails on Android 16 due to libnode.so load error.

Improved multi-symbol fallback in enable_16kb_app_compat_if_needed() to support Android 16 loader symbols and general android_set_16kb_appcompat_mode.