### PR TITLE
fix(signing): read imported keystores with full BouncyCastle + specific import errors

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/JarSigner.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/JarSigner.kt
@@ -10,6 +10,7 @@ import com.android.apksig.ApkSigner
 import com.android.apksig.ApkVerifier
 import com.webtoapp.util.GsonProvider
 import com.webtoapp.util.threadLocalCompat
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.*
 import java.math.BigInteger
 import java.security.*
@@ -63,6 +64,30 @@ class JarSigner(private val context: Context) {
         PKCS12_AUTO,
         PKCS12_CUSTOM
     }
+
+    /**
+     * Structured outcome of a keystore import so the UI can tell the user *which* step failed
+     * (store password / key password / no key entry / unsupported format) instead of one generic
+     * "check your password" message.
+     */
+    sealed class KeystoreImportResult {
+        data class Success(val alias: String, val sourceFormat: String) : KeystoreImportResult()
+
+        /** The file format was recognized, but the keystore (store) password was rejected on load. */
+        object StorePasswordRejected : KeystoreImportResult()
+
+        /** The store loaded, but the private key could not be recovered with the given passwords. */
+        data class KeyPasswordRejected(val keyPasswordFieldUsed: Boolean) : KeystoreImportResult()
+
+        /** The keystore parsed but contains no private key entry (certificate-only or empty). */
+        object NoKeyEntry : KeystoreImportResult()
+
+        /** No supported format (PKCS12 / JKS / JCEKS / BKS) could parse the file at all. */
+        object UnsupportedFormat : KeystoreImportResult()
+    }
+
+    /** Keystore container format detected from the file's magic bytes, independent of any password. */
+    private enum class KeystoreFileFormat { PKCS12, JKS, JCEKS, UNKNOWN }
 
     data class SigningSchemeOptions(
         val v1Enabled: Boolean = true,
@@ -426,6 +451,79 @@ class JarSigner(private val context: Context) {
         return password
     }
 
+    /**
+     * Full BouncyCastle (bundled dependency), used explicitly for *reading* keystores.
+     * The platform's stripped BC provider on many Android versions cannot decrypt PKCS12
+     * files written by modern keytool / Android Studio (PBES2 with AES-256), which is exactly
+     * the `.jks`-named file most users import. We never register it globally — instance-scoped
+     * lookups keep every other crypto path untouched.
+     */
+    private val bcProvider: Provider? by lazy {
+        runCatching { BouncyCastleProvider() }.getOrNull()
+    }
+
+    /**
+     * Detect the keystore container format from magic bytes. Works on fully-encrypted files
+     * because container headers are plaintext: JKS starts with 0xFEEDFEED, JCEKS with
+     * 0xCECECECE, and PKCS12 is DER ASN.1 starting with a SEQUENCE tag (0x30).
+     */
+    private fun detectKeystoreFormat(file: File): KeystoreFileFormat {
+        return try {
+            FileInputStream(file).use { fis ->
+                val magic = ByteArray(4)
+                var read = 0
+                while (read < 4) {
+                    val n = fis.read(magic, read, 4 - read)
+                    if (n < 0) return KeystoreFileFormat.UNKNOWN
+                    read += n
+                }
+                when {
+                    magic[0] == 0xFE.toByte() && magic[1] == 0xED.toByte() &&
+                        magic[2] == 0xFE.toByte() && magic[3] == 0xED.toByte() ->
+                        KeystoreFileFormat.JKS
+
+                    magic[0] == 0xCE.toByte() && magic[1] == 0xCE.toByte() &&
+                        magic[2] == 0xCE.toByte() && magic[3] == 0xCE.toByte() ->
+                        KeystoreFileFormat.JCEKS
+
+                    magic[0] == 0x30.toByte() -> KeystoreFileFormat.PKCS12
+                    else -> KeystoreFileFormat.UNKNOWN
+                }
+            }
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "Keystore format detection failed: ${e.message}")
+            KeystoreFileFormat.UNKNOWN
+        }
+    }
+
+    /**
+     * Load a keystore file, preferring the full BC provider (understands PBES2, JCEKS)
+     * and falling back to the platform provider. Returns null when neither can load it.
+     */
+    private fun openKeyStore(type: String, file: File, password: CharArray): KeyStore? {
+        val providers: List<Provider?> =
+            if (bcProvider != null) listOf(bcProvider, null) else listOf<Provider?>(null)
+        for (provider in providers) {
+            try {
+                val keyStore = if (provider != null) {
+                    KeyStore.getInstance(type, provider)
+                } else {
+                    KeyStore.getInstance(type)
+                }
+                FileInputStream(file).use { fis ->
+                    keyStore.load(fis, password.copyOf())
+                }
+                return keyStore
+            } catch (e: Exception) {
+                AppLogger.w(
+                    TAG,
+                    "Keystore '$type' load via ${provider?.name ?: "platform"} failed: ${e.message}"
+                )
+            }
+        }
+        return null
+    }
+
     private fun loadPkcs12(
         file: File,
         password: CharArray,
@@ -433,11 +531,7 @@ class JarSigner(private val context: Context) {
         keyPassword: CharArray? = null
     ): Boolean {
         return try {
-            val keyStore = KeyStore.getInstance("PKCS12")
-            FileInputStream(file).use { fis ->
-
-                keyStore.load(fis, password.copyOf())
-            }
+            val keyStore = openKeyStore("PKCS12", file, password.copyOf()) ?: return false
 
             val keyAlias = alias?.takeIf { keyStore.isKeyEntry(it) }
                 ?: keyStore.aliases().toList().firstOrNull { keyStore.isKeyEntry(it) }
@@ -449,11 +543,21 @@ class JarSigner(private val context: Context) {
 
             val effectiveKeyPass = keyPassword?.copyOf() ?: password.copyOf()
             privateKey = try {
-                keyStore.getKey(keyAlias, effectiveKeyPass) as? PrivateKey
+                keyStore.getKey(keyAlias, effectiveKeyPass.copyOf()) as? PrivateKey
             } catch (e: java.security.UnrecoverableKeyException) {
-
                 AppLogger.w(TAG, "getKey($keyAlias) failed — keypass might differ from storepass: ${e.message}")
-                throw e
+
+                // JDK/keytool-generated PKCS12 ignores a separate key password; retry with the
+                // store password before giving up (also covers users who filled the wrong field).
+                if (!effectiveKeyPass.contentEquals(password)) {
+                    try {
+                        keyStore.getKey(keyAlias, password.copyOf()) as? PrivateKey
+                    } catch (e2: java.security.UnrecoverableKeyException) {
+                        null
+                    }
+                } else {
+                    null
+                }
             }
             certificate = keyStore.getCertificate(keyAlias) as? X509Certificate
 
@@ -566,129 +670,143 @@ class JarSigner(private val context: Context) {
     }
 
     @JvmOverloads
-    fun importPkcs12(sourceFile: File, password: String, keyPassword: String? = null): Boolean {
-        return try {
-            val storePassChars = password.toCharArray()
-            val keyPassChars = keyPassword
-                ?.takeIf { it.isNotEmpty() }
-                ?.toCharArray()
-
-            val keyStore = KeyStore.getInstance("PKCS12")
-            FileInputStream(sourceFile).use { fis ->
-                keyStore.load(fis, storePassChars.copyOf())
-            }
-
-            val keyAlias = keyStore.aliases().toList().firstOrNull { keyStore.isKeyEntry(it) }
-            if (keyAlias == null) {
-                AppLogger.e(TAG, "Import failed: no key entry in PKCS12")
-                return false
-            }
-
-            val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
-            sourceFile.copyTo(targetFile, overwrite = true)
-
-            File(context.filesDir, CUSTOM_PASSWORD_FILE).writeText(password)
-            File(context.filesDir, CUSTOM_ALIAS_FILE).writeText(keyAlias)
-            val keypassSidecar = File(context.filesDir, CUSTOM_KEYPASS_FILE)
-            if (keyPassChars != null) {
-                keypassSidecar.writeText(keyPassword)
-            } else if (keypassSidecar.exists()) {
-
-                keypassSidecar.delete()
-            }
-
-            if (loadPkcs12(targetFile, storePassChars, keyAlias, keyPassChars)) {
-                currentSignerType = SignerType.PKCS12_CUSTOM
-                AppLogger.d(TAG, "Custom PKCS12 import successful (alias=$keyAlias, separateKeyPass=${keyPassChars != null})")
-                return true
-            }
-
-            false
-        } catch (e: Exception) {
-            AppLogger.e(TAG, "PKCS12 import failed", e)
-            false
-        }
-    }
-
-    @JvmOverloads
-    fun importKeystore(sourceFile: File, password: String, keyPassword: String? = null): Boolean {
+    fun importKeystore(
+        sourceFile: File,
+        password: String,
+        keyPassword: String? = null
+    ): KeystoreImportResult {
         val storePassChars = password.toCharArray()
         val keyPassChars = keyPassword
             ?.takeIf { it.isNotEmpty() }
             ?.toCharArray()
-            ?: storePassChars
 
-        val keystoreTypes = listOf("PKCS12", "BKS", "JKS")
+        val detected = detectKeystoreFormat(sourceFile)
 
-        for (type in keystoreTypes) {
-            try {
-                val keyStore = KeyStore.getInstance(type)
-                FileInputStream(sourceFile).use { fis ->
-                    keyStore.load(fis, storePassChars.copyOf())
-                }
-
-                val keyAlias = keyStore.aliases().toList().firstOrNull { keyStore.isKeyEntry(it) }
-                if (keyAlias == null) {
-                    AppLogger.w(TAG, "$type has no key entry, skipping")
-                    continue
-                }
-
-                AppLogger.d(TAG, "Successfully parsed signature file as $type, alias=$keyAlias")
-
-                if (type == "PKCS12") {
-
-                    val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
-                    sourceFile.copyTo(targetFile, overwrite = true)
-                } else {
-
-                    val key = try {
-                        keyStore.getKey(keyAlias, keyPassChars.copyOf()) as? PrivateKey
-                    } catch (e: java.security.UnrecoverableKeyException) {
-                        AppLogger.w(TAG, "$type getKey($keyAlias) failed — keypass might differ from storepass: ${e.message}")
-
-                        null
-                    }
-                    val cert = keyStore.getCertificate(keyAlias) as? java.security.cert.X509Certificate
-                    if (key == null || cert == null) {
-                        AppLogger.w(TAG, "$type has empty key or certificate（alias=$keyAlias）")
-                        continue
-                    }
-
-                    val p12KeyStore = KeyStore.getInstance("PKCS12")
-                    p12KeyStore.load(null, storePassChars.copyOf())
-                    p12KeyStore.setKeyEntry(keyAlias, key, storePassChars.copyOf(), arrayOf(cert))
-
-                    val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
-                    FileOutputStream(targetFile).use { fos ->
-                        p12KeyStore.store(fos, storePassChars.copyOf())
-                    }
-                    AppLogger.d(TAG, "Converted $type converted to a unified-password PKCS12 (storepass==keypass) and saved")
-                }
-
-                File(context.filesDir, CUSTOM_PASSWORD_FILE).writeText(password)
-                File(context.filesDir, CUSTOM_ALIAS_FILE).writeText(keyAlias)
-                val keypassSidecar = File(context.filesDir, CUSTOM_KEYPASS_FILE)
-                if (type == "PKCS12" && keyPassword != null && keyPassword.isNotEmpty() && keyPassword != password) {
-
-                    keypassSidecar.writeText(keyPassword)
-                } else if (keypassSidecar.exists()) {
-                    keypassSidecar.delete()
-                }
-
-                val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
-                val effectiveKeyPass = if (type == "PKCS12") keyPassChars else storePassChars
-                if (loadPkcs12(targetFile, storePassChars, keyAlias, effectiveKeyPass)) {
-                    currentSignerType = SignerType.PKCS12_CUSTOM
-                    AppLogger.d(TAG, "Custom signature file imported (original format: $type, alias=$keyAlias)")
-                    return true
-                }
-            } catch (e: Exception) {
-                AppLogger.w(TAG, "Attempting to parse as $type failed: ${e.message}")
-            }
+        // A confidently-detected format gets a single specific parse attempt; unknown magic
+        // (e.g. BKS) falls back to the historical brute-force list, now including JCEKS via BC.
+        val candidates: List<String> = when (detected) {
+            KeystoreFileFormat.PKCS12 -> listOf("PKCS12")
+            KeystoreFileFormat.JKS -> listOf("JKS")
+            KeystoreFileFormat.JCEKS -> listOf("JCEKS")
+            KeystoreFileFormat.UNKNOWN -> listOf("PKCS12", "JKS", "BKS", "JCEKS")
         }
 
+        var sawRecognizedLoadFailure = false
+
+        for (type in candidates) {
+            val keyStore = openKeyStore(type, sourceFile, storePassChars.copyOf())
+            if (keyStore == null) {
+                // Load failure on a recognized container is a store-password rejection: the
+                // container parses, but its integrity/MAC check fails with the wrong password.
+                if (detected != KeystoreFileFormat.UNKNOWN) {
+                    sawRecognizedLoadFailure = true
+                    break
+                }
+                continue
+            }
+
+            val keyAlias = keyStore.aliases().toList().firstOrNull { keyStore.isKeyEntry(it) }
+            if (keyAlias == null) {
+                AppLogger.w(TAG, "$type has no key entry, skipping")
+                if (detected != KeystoreFileFormat.UNKNOWN) {
+                    return KeystoreImportResult.NoKeyEntry
+                }
+                continue
+            }
+
+            AppLogger.d(TAG, "Successfully parsed signature file as $type, alias=$keyAlias")
+
+            // Recover the private key up front so a wrong key password surfaces as its own
+            // error instead of a failed verification load much later.
+            val key = recoverPrivateKey(keyStore, keyAlias, storePassChars, keyPassChars)
+            if (key == null) {
+                AppLogger.w(TAG, "$type key recovery failed（alias=$keyAlias）")
+                if (detected != KeystoreFileFormat.UNKNOWN) {
+                    return KeystoreImportResult.KeyPasswordRejected(keyPassChars != null)
+                }
+                continue
+            }
+            val cert = keyStore.getCertificate(keyAlias) as? java.security.cert.X509Certificate
+            if (cert == null) {
+                AppLogger.w(TAG, "$type has empty certificate（alias=$keyAlias）")
+                if (detected != KeystoreFileFormat.UNKNOWN) {
+                    return KeystoreImportResult.NoKeyEntry
+                }
+                continue
+            }
+
+            if (type == "PKCS12") {
+
+                val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
+                sourceFile.copyTo(targetFile, overwrite = true)
+            } else {
+
+                // JKS/JCEKS/BKS: re-store into a unified-password PKCS12 so the app's own
+                // loading path (and any later export) works with storepass == keypass.
+                // Written through the platform provider on purpose: legacy algorithms that
+                // every consumer (including AabSigner and desktop keytool) can read.
+                val p12KeyStore = KeyStore.getInstance("PKCS12")
+                p12KeyStore.load(null, storePassChars.copyOf())
+                p12KeyStore.setKeyEntry(keyAlias, key, storePassChars.copyOf(), arrayOf(cert))
+
+                val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
+                FileOutputStream(targetFile).use { fos ->
+                    p12KeyStore.store(fos, storePassChars.copyOf())
+                }
+                AppLogger.d(TAG, "Converted $type converted to a unified-password PKCS12 (storepass==keypass) and saved")
+            }
+
+            File(context.filesDir, CUSTOM_PASSWORD_FILE).writeText(password)
+            File(context.filesDir, CUSTOM_ALIAS_FILE).writeText(keyAlias)
+            val keypassSidecar = File(context.filesDir, CUSTOM_KEYPASS_FILE)
+            if (type == "PKCS12" && keyPassword != null && keyPassword.isNotEmpty() && keyPassword != password) {
+
+                keypassSidecar.writeText(keyPassword)
+            } else if (keypassSidecar.exists()) {
+                keypassSidecar.delete()
+            }
+
+            val targetFile = File(context.filesDir, CUSTOM_PKCS12_FILE)
+            val effectiveKeyPass = if (type == "PKCS12") keyPassChars else storePassChars
+            if (loadPkcs12(targetFile, storePassChars.copyOf(), keyAlias, effectiveKeyPass?.copyOf())) {
+                currentSignerType = SignerType.PKCS12_CUSTOM
+                AppLogger.d(TAG, "Custom signature file imported (original format: $type, alias=$keyAlias)")
+                return KeystoreImportResult.Success(keyAlias, type)
+            }
+            AppLogger.w(TAG, "$type imported but verification load failed")
+        }
+
+        if (sawRecognizedLoadFailure) {
+            return KeystoreImportResult.StorePasswordRejected
+        }
         AppLogger.e(TAG, "Couldn't parse signature file in any supported format")
-        return false
+        return KeystoreImportResult.UnsupportedFormat
+    }
+
+    /**
+     * Get the private key from a loaded keystore, trying the user-provided key password
+     * first and the store password as fallback (JDK-generated PKCS12 ignores a separate
+     * key password, and users often fill the wrong field).
+     */
+    private fun recoverPrivateKey(
+        keyStore: KeyStore,
+        alias: String,
+        storePass: CharArray,
+        keyPass: CharArray?
+    ): PrivateKey? {
+        val attempts = ArrayList<CharArray>(2)
+        keyPass?.let { attempts.add(it.copyOf()) }
+        if (keyPass == null || !keyPass.contentEquals(storePass)) {
+            attempts.add(storePass.copyOf())
+        }
+        for (pass in attempts) {
+            try {
+                return keyStore.getKey(alias, pass.copyOf()) as? PrivateKey
+            } catch (e: java.security.UnrecoverableKeyException) {
+                AppLogger.w(TAG, "getKey($alias) with candidate passwords failed: ${e.message}")
+            }
+        }
+        return null
     }
 
     fun createCustomKeystore(spec: CertificateSpec): Boolean {

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2561,6 +2561,10 @@ object Strings {
     val exportPasswordHint: String get() = StringsC.exportPasswordHint
     val keystoreImportSuccess: String get() = StringsC.keystoreImportSuccess
     val keystoreImportFailed: String get() = StringsC.keystoreImportFailed
+    val keystoreStorePasswordRejected: String get() = StringsC.keystoreStorePasswordRejected
+    val keystoreKeyPasswordRejected: String get() = StringsC.keystoreKeyPasswordRejected
+    val keystoreNoKeyEntry: String get() = StringsC.keystoreNoKeyEntry
+    val keystoreUnsupportedFormat: String get() = StringsC.keystoreUnsupportedFormat
     val keystoreExportSuccess: String get() = StringsC.keystoreExportSuccess
     val keystoreExportFailed: String get() = StringsC.keystoreExportFailed
     val keystoreRemoveSuccess: String get() = StringsC.keystoreRemoveSuccess
@@ -37037,6 +37041,58 @@ object StringsC {
         AppLanguage.RUSSIAN -> "Ошибка импорта keystore. Проверьте пароль keystore; если ваш keystore — JKS с отдельным паролем ключа, также заполните поле «Пароль ключа»"
         AppLanguage.JAPANESE -> "Keystoreのインポートに失敗しました。keystoreパスワードを確認してください。JKSでキーパスワードが別の場合は、「キーパスワード」欄も入力してください"
         AppLanguage.KOREAN -> "Keystore 가져오기 실패. keystore 비밀번호를 확인하세요. JKS이고 키 비밀번호가 다른 경우, \"키 비밀번호\" 필드도 입력하세요"
+    }
+
+    val keystoreStorePasswordRejected: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "Keystore 密码被拒绝。文件格式已识别，请仔细核对「Keystore 密码」是否输入正确"
+        AppLanguage.ENGLISH -> "The keystore password was rejected. The file format was recognized — double-check the Keystore Password field for typos"
+        AppLanguage.ARABIC -> "تم رفض كلمة مرور مخزن المفاتيح. تم التعرّف على تنسيق الملف — تحقق من حقل كلمة مرور مخزن المفاتيح بحثًا عن أخطاء كتابية"
+        AppLanguage.PORTUGUESE -> "A senha do keystore foi rejeitada. O formato do arquivo foi reconhecido — verifique erros de digitação no campo Senha do Keystore"
+        AppLanguage.SPANISH -> "La contraseña del keystore fue rechazada. El formato del archivo se reconoció correctamente — revisa si hay errores en el campo Contraseña del Keystore"
+        AppLanguage.FRENCH -> "Le mot de passe du keystore a été rejeté. Le format du fichier a été reconnu — vérifiez les fautes de frappe dans le champ Mot de passe du Keystore"
+        AppLanguage.GERMAN -> "Das Keystore-Passwort wurde abgelehnt. Das Dateiformat wurde erkannt — prüfe das Feld Keystore-Passwort auf Tippfehler"
+        AppLanguage.RUSSIAN -> "Пароль keystore отклонён. Формат файла распознан — проверьте опечатки в поле «Пароль keystore»"
+        AppLanguage.JAPANESE -> "keystoreパスワードが拒否されました。ファイル形式は認識できています。「keystoreパスワード」欄の入力ミスをご確認ください"
+        AppLanguage.KOREAN -> "keystore 비밀번호가 거부되었습니다. 파일 형식은 정상적으로 인식되었습니다. \"keystore 비밀번호\" 필드에 오타가 없는지 확인하세요"
+    }
+
+    val keystoreKeyPasswordRejected: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "密钥密码被拒绝。该 keystore 的 key 密码与 store 密码不同——请正确填写或修正「密钥密码」字段"
+        AppLanguage.ENGLISH -> "The key password was rejected. This keystore's key password differs from the store password — correct the Key Password field"
+        AppLanguage.ARABIC -> "تم رفض كلمة مرور المفتاح. كلمة مرور المفتاح في هذا المخزن تختلف عن كلمة مرور المخزن — صحّح حقل كلمة مرور المفتاح"
+        AppLanguage.PORTUGUESE -> "A senha da chave foi rejeitada. A senha de chave deste keystore é diferente da senha do keystore — corrija o campo Senha da Chave"
+        AppLanguage.SPANISH -> "La contraseña de la clave fue rechazada. La contraseña de clave de este keystore difiere de la del keystore — corrige el campo Contraseña de Clave"
+        AppLanguage.FRENCH -> "Le mot de passe de la clé a été rejeté. Le mot de passe de clé de ce keystore diffère de celui du magasin — corrigez le champ Mot de passe de la Clé"
+        AppLanguage.GERMAN -> "Das Schlüsselpasswort wurde abgelehnt. Das Schlüsselpasswort dieses Keystores weicht vom Keystore-Passwort ab — korrigiere das Feld Schlüsselpasswort"
+        AppLanguage.RUSSIAN -> "Пароль ключа отклонён. Пароль ключа в этом keystore отличается от пароля хранилища — исправьте поле «Пароль ключа»"
+        AppLanguage.JAPANESE -> "キーパスワードが拒否されました。このkeystoreのキーパスワードはstoreパスワードと異なります。「キーパスワード」欄を修正してください"
+        AppLanguage.KOREAN -> "키 비밀번호가 거부되었습니다. 이 keystore의 키 비밀번호는 store 비밀번호와 다릅니다. \"키 비밀번호\" 필드를 수정하세요"
+    }
+
+    val keystoreNoKeyEntry: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "keystore 中没有找到私钥条目。请导入包含密钥对的 keystore（例如通过 Android Studio 签名向导创建），而不是仅含证书的文件"
+        AppLanguage.ENGLISH -> "No private key entry was found in this keystore. Import a keystore that contains a key pair (e.g. one created via Android Studio's signed-APK wizard), not a certificate-only file"
+        AppLanguage.ARABIC -> "لم يتم العثور على إدخال مفتاح خاص في مخزن المفاتيح هذا. استورد مخزن مفاتيح يحتوي على زوج مفاتيح (مثل الذي ينشئه معالج التوقيع في Android Studio)، وليس ملف شهادات فقط"
+        AppLanguage.PORTUGUESE -> "Nenhuma entrada de chave privada foi encontrada neste keystore. Importe um keystore que contenha um par de chaves (ex.: criado pelo assistente de APK assinado do Android Studio), não um arquivo só de certificados"
+        AppLanguage.SPANISH -> "No se encontró ninguna entrada de clave privada en este keystore. Importa un keystore que contenga un par de claves (p. ej., uno creado con el asistente de APK firmado de Android Studio), no un archivo de solo certificados"
+        AppLanguage.FRENCH -> "Aucune entrÉe de clé privée n'a été trouvée dans ce keystore. Importez un keystore contenant une paire de clés (p. ex. créée via l'assistant APK signé d'Android Studio), et non un fichier de certificats seuls"
+        AppLanguage.GERMAN -> "In diesem Keystore wurde kein privater Schlüssel-Eintrag gefunden. Importiere einen Keystore mit einem Schlüsselpaar (z. B. über den Signierungs-Assistenten von Android Studio erstellt), keine reine Zertifikatsdatei"
+        AppLanguage.RUSSIAN -> "В этом keystore не найдена запись с приватным ключом. Импортируйте keystore с парой ключей (например, созданный мастером подписи Android Studio), а не файл только с сертификатами"
+        AppLanguage.JAPANESE -> "このkeystoreに秘密鍵エントリが見つかりません。証明書のみのファイルではなく、鍵ペアを含むkeystore（例：Android Studioの署名ウィザードで作成）をインポートしてください"
+        AppLanguage.KOREAN -> "이 keystore에서 개인 키 항목을 찾을 수 없습니다. 인증서만 포함된 파일이 아니라 키 쌍이 포함된 keystore(예: Android Studio 서명 마법사로 생성)를 가져오세요"
+    }
+
+    val keystoreUnsupportedFormat: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "无法识别的 keystore 格式。支持 PKCS12、JKS、JCEKS 和 BKS；若问题持续，请用原工具重新导出"
+        AppLanguage.ENGLISH -> "Unrecognized keystore format. Supported types: PKCS12, JKS, JCEKS and BKS. If the problem persists, re-export the keystore from your original tool"
+        AppLanguage.ARABIC -> "تنسيق مخزن مفاتيح غير معروف. الأنواع المدعومة: PKCS12 و JKS و JCEKS و BKS. إذا استمرت المشكلة، أعد تصدير مخزن المفاتيح من الأداة الأصلية"
+        AppLanguage.PORTUGUESE -> "Formato de keystore não reconhecido. Tipos suportados: PKCS12, JKS, JCEKS e BKS. Se o problema persistir, exporte novamente o keystore a partir da ferramenta original"
+        AppLanguage.SPANISH -> "Formato de keystore no reconocido. Tipos admitidos: PKCS12, JKS, JCEKS y BKS. Si el problema continúa, vuelve a exportar el keystore desde tu herramienta original"
+        AppLanguage.FRENCH -> "Format de keystore non reconnu. Types pris en charge : PKCS12, JKS, JCEKS et BKS. Si le problème persiste, réexportez le keystore depuis votre outil d'origine"
+        AppLanguage.GERMAN -> "Unbekanntes Keystore-Format. Unterstützte Typen: PKCS12, JKS, JCEKS und BKS. Falls das Problem weiterhin besteht, exportiere den Keystore mit dem ursprünglichen Tool neu"
+        AppLanguage.RUSSIAN -> "Неизвестный формат keystore. Поддерживаются: PKCS12, JKS, JCEKS и BKS. Если проблема не исчезнет, повторно экспортируйте keystore из исходного инструмента"
+        AppLanguage.JAPANESE -> "認識できないkeystore形式です。対応形式：PKCS12、JKS、JCEKS、BKS。問題が続く場合は、元のツールでkeystoreを再エクスポートしてください"
+        AppLanguage.KOREAN -> "인식할 수 없는 keystore 형식입니다. 지원 형식: PKCS12, JKS, JCEKS, BKS. 문제가 계속되면 원래 도구에서 keystore를 다시 내보내세요"
     }
 
     val keystoreExportSuccess: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppApkSection.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppApkSection.kt
@@ -837,21 +837,33 @@ fun CustomSigningSection() {
                                 }
 
                                 val keyPassParam = keyPasswordInput.takeIf { it.isNotEmpty() }
-                                val success = signer.importKeystore(tempFile, passwordInput, keyPassParam)
+                                val result = signer.importKeystore(tempFile, passwordInput, keyPassParam)
                                 tempFile.delete()
 
                                 kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
-                                    if (success) {
-                                        signerType = signer.getSignerType()
-                                        certInfo = signer.getCertificateInfo()
-                                        showImportPasswordDialog = false
-                                        pendingKeystoreUri = null
-                                        passwordInput = ""
-                                        keyPasswordInput = ""
-                                        importError = null
-                                        snackbarMessage = Strings.keystoreImportSuccess
-                                    } else {
-                                        importError = Strings.keystoreImportFailed
+                                    when (result) {
+                                        is com.webtoapp.core.apkbuilder.JarSigner.KeystoreImportResult.Success -> {
+                                            signerType = signer.getSignerType()
+                                            certInfo = signer.getCertificateInfo()
+                                            showImportPasswordDialog = false
+                                            pendingKeystoreUri = null
+                                            passwordInput = ""
+                                            keyPasswordInput = ""
+                                            importError = null
+                                            snackbarMessage = Strings.keystoreImportSuccess
+                                        }
+
+                                        com.webtoapp.core.apkbuilder.JarSigner.KeystoreImportResult.StorePasswordRejected ->
+                                            importError = Strings.keystoreStorePasswordRejected
+
+                                        is com.webtoapp.core.apkbuilder.JarSigner.KeystoreImportResult.KeyPasswordRejected ->
+                                            importError = Strings.keystoreKeyPasswordRejected
+
+                                        com.webtoapp.core.apkbuilder.JarSigner.KeystoreImportResult.NoKeyEntry ->
+                                            importError = Strings.keystoreNoKeyEntry
+
+                                        com.webtoapp.core.apkbuilder.JarSigner.KeystoreImportResult.UnsupportedFormat ->
+                                            importError = Strings.keystoreUnsupportedFormat
                                     }
                                 }
                             } catch (e: Exception) {

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/JarSignerKeystoreImportTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/JarSignerKeystoreImportTest.kt
@@ -1,0 +1,182 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.Date
+import javax.security.auth.x500.X500Principal
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class JarSignerKeystoreImportTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun forceModernPkcs12Algorithms() {
+            // Write PKCS12 exactly like modern keytool / Android Studio does (PBES2 + AES-256).
+            // The stripped platform BouncyCastle on many Android versions cannot decrypt these,
+            // which is the root cause of issue #523: a `.jks`-named file that is actually
+            // PKCS12 fails to import with a generic "wrong password" error.
+            System.setProperty("keystore.pkcs12.certProtectionAlgorithm", "PBEWithHmacSHA256AndAES_256")
+            System.setProperty("keystore.pkcs12.keyProtectionAlgorithm", "PBEWithHmacSHA256AndAES_256")
+            System.setProperty("keystore.pkcs12.macAlgorithm", "HmacPBESHA256")
+        }
+    }
+
+    private val app get() = RuntimeEnvironment.getApplication()
+
+    private fun generateKeyPair(): KeyPair =
+        KeyPairGenerator.getInstance("RSA").apply {
+            initialize(2048, SecureRandom())
+        }.generateKeyPair()
+
+    private fun selfSignedCertificate(keyPair: KeyPair): X509Certificate {
+        val subject = X500Principal("CN=WebToApp Keystore Import Test")
+        val now = System.currentTimeMillis()
+        val holder = JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(now),
+            Date(now),
+            Date(now + 365L * 24L * 60L * 60L * 1000L),
+            subject,
+            keyPair.public
+        ).build(JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private))
+        return JcaX509CertificateConverter().getCertificate(holder)
+    }
+
+    private fun tempKeystore(name: String): File =
+        File(app.cacheDir, name).apply { parentFile?.mkdirs() }
+
+    @Test
+    fun `modern PBES2 pkcs12 keystore imports successfully`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("PKCS12")
+        ks.load(null, null)
+        ks.setKeyEntry("release", keyPair.private, "store123".toCharArray(), arrayOf(selfSignedCertificate(keyPair)))
+        val file = tempKeystore("modern.p12")
+        file.outputStream().use { ks.store(it, "store123".toCharArray()) }
+
+        val signer = JarSigner(app)
+        val result = signer.importKeystore(file, "store123", null)
+
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.Success("release", "PKCS12"))
+        assertThat(signer.getSignerType()).isEqualTo(JarSigner.SignerType.PKCS12_CUSTOM)
+        assertThat(signer.getCertificateInfo()).isNotNull()
+    }
+
+    @Test
+    fun `jceks keystore imports via full bouncy castle provider`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("JCEKS")
+        ks.load(null, null)
+        ks.setKeyEntry("release", keyPair.private, "store123".toCharArray(), arrayOf(selfSignedCertificate(keyPair)))
+        val file = tempKeystore("legacy.jceks")
+        file.outputStream().use { ks.store(it, "store123".toCharArray()) }
+
+        val signer = JarSigner(app)
+        val result = signer.importKeystore(file, "store123", null)
+
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.Success("release", "JCEKS"))
+    }
+
+    @Test
+    fun `jks with separate key password imports when key password provided`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("JKS")
+        ks.load(null, null)
+        ks.setKeyEntry(
+            "suvoutsav",
+            keyPair.private,
+            "keypass".toCharArray(),
+            arrayOf(selfSignedCertificate(keyPair))
+        )
+        val file = tempKeystore("separate.jks")
+        file.outputStream().use { ks.store(it, "storepass".toCharArray()) }
+
+        val signer = JarSigner(app)
+        val result = signer.importKeystore(file, "storepass", "keypass")
+
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.Success("suvoutsav", "JKS"))
+    }
+
+    @Test
+    fun `jks separate key password reports key password rejected when missing or wrong`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("JKS")
+        ks.load(null, null)
+        ks.setKeyEntry(
+            "suvoutsav",
+            keyPair.private,
+            "keypass".toCharArray(),
+            arrayOf(selfSignedCertificate(keyPair))
+        )
+        val file = tempKeystore("separate2.jks")
+        file.outputStream().use { ks.store(it, "storepass".toCharArray()) }
+
+        val signer = JarSigner(app)
+
+        val missing = signer.importKeystore(file, "storepass", null)
+        assertThat(missing)
+            .isEqualTo(JarSigner.KeystoreImportResult.KeyPasswordRejected(keyPasswordFieldUsed = false))
+
+        val wrong = signer.importKeystore(file, "storepass", "wrongkey")
+        assertThat(wrong)
+            .isEqualTo(JarSigner.KeystoreImportResult.KeyPasswordRejected(keyPasswordFieldUsed = true))
+    }
+
+    @Test
+    fun `wrong store password reports store password rejected`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("JKS")
+        ks.load(null, null)
+        ks.setKeyEntry("k", keyPair.private, "storepass".toCharArray(), arrayOf(selfSignedCertificate(keyPair)))
+        val file = tempKeystore("storepass.jks")
+        file.outputStream().use { ks.store(it, "storepass".toCharArray()) }
+
+        val signer = JarSigner(app)
+        val result = signer.importKeystore(file, "typo-password", null)
+
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.StorePasswordRejected)
+    }
+
+    @Test
+    fun `certificate-only keystore reports no key entry`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("JKS")
+        ks.load(null, null)
+        ks.setCertificateEntry("cert0", selfSignedCertificate(keyPair))
+        val file = tempKeystore("certonly.jks")
+        file.outputStream().use { ks.store(it, "storepass".toCharArray()) }
+
+        val signer = JarSigner(app)
+        val result = signer.importKeystore(file, "storepass", null)
+
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.NoKeyEntry)
+    }
+
+    @Test
+    fun `garbage file reports unsupported format`() {
+        val file = tempKeystore("garbage.bin")
+        file.writeBytes(byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07))
+
+        val signer = JarSigner(app)
+        val result = signer.importKeystore(file, "whatever", null)
+
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.UnsupportedFormat)
+    }
+}


### PR DESCRIPTION
## Summary

Keystore import failed with a generic "check the keystore password" error even when both the store and key passwords were correct.

**Root cause:** Android Studio's signed-APK wizard writes PKCS12 (PBES2 / AES-256) by default — even for `.jks`-named files — and the stripped platform BouncyCastle shipped on many Android versions cannot decrypt those containers. Every parse attempt (PKCS12 → BKS → JKS) failed regardless of the passwords entered, and the single-`Boolean` return collapsed all causes into one message.

**Changes**

- Parse imported keystores with the bundled full BC 1.78.1 provider first (instance-scoped `KeyStore.getInstance(type, provider)` — no global `Security.addProvider`, other crypto paths untouched), falling back to the platform provider; `loadPkcs12` reads the same way.
- Detect the container format from magic bytes (JKS `FEEDFEED`, JCEKS `CECECECE`, PKCS12 ASN.1 `0x30`) so a recognized container that fails to load maps to a store-password rejection, not a format brute-force.
- New sealed `KeystoreImportResult` (`Success` / `StorePasswordRejected` / `KeyPasswordRejected` / `NoKeyEntry` / `UnsupportedFormat`); the import dialog shows a dedicated message per outcome (all 10 languages).
- Private-key recovery tries the key password, then the store password (JDK-generated PKCS12 ignores a separate key password, and users often fill the wrong field).
- Unified-password PKCS12 conversion is still written via the platform provider, so `AabSigner` and desktop keytool interop are unchanged.
- Dropped dead `importPkcs12()`; added JCEKS as an explicit parse candidate.

This also answers the feature requests in the issue: the error message now says exactly which step failed, and the import dialog itself validates (parse + key recovery) before anything is persisted.

## Fixes

Fixes #523

## Test plan

- [x] `JarSignerKeystoreImportTest` (new, 7 cases): modern PBES2 PKCS12 import, JCEKS via BC, JKS with separate key password (success / missing / wrong), wrong store password, certificate-only keystore, garbage file — all pass
- [x] `StringsKtTranslationParityTest` + `AppStringsResourceConsistencyTest` (i18n gates) pass
- [x] `:app:compileStandardDebugKotlin` clean
- [ ] Manual on-device: import an Android Studio-generated keystore on an older Android version (platform BC without PBES2 support) — reporter's device is the ideal case