### PR TITLE
chore: bump version to 2.4.5 (versionCode 55)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.4.3** (`versionCode 54`).
+This guide targets **WebToApp 2.4.5** (`versionCode 55`).
 
 ---
 
@@ -218,7 +218,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.4.3**（`versionCode 54`）。
+本指南对应 **WebToApp 2.4.5**（`versionCode 55`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 54
-        versionName = "2.4.3"
+        versionCode = 55
+        versionName = "2.4.5"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/modules/README.md
+++ b/modules/README.md
@@ -201,7 +201,7 @@ entry mirrors the module manifest plus a `path` (folder name) and a
 
 `minAppVersion` lets you ship a module that needs APIs only present from a
 specific WebToApp `versionCode` onwards — older clients hide the entry.
-The current `versionCode` is **54** (`v2.4.3`); set this only if you
+The current `versionCode` is **55** (`v2.4.5`); set this only if you
 genuinely depend on a newer build.
 
 `iconUrl` is optional. Either a relative path (`"icon.png"`, `"icon.svg"`,

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 54
-        versionName = "2.4.3"
+        versionCode = 55
+        versionName = "2.4.5"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## Summary

Version bump for the v2.4.5 release, following the same pattern as previous bumps (7dde5885):

- `app/build.gradle.kts` + `shell/build.gradle.kts`: versionCode 54 → 55, versionName 2.4.3 → 2.4.5
- `.github/CONTRIBUTING.md`: guide version markers (EN + ZH)
- `modules/README.md`: module-market `minAppVersion` reference value

## Release scope

All 24 commits on `main` since v2.4.3 (see #527 for the summary).

## Test plan

- [x] `:app:assembleStandardRelease` builds clean; APK verified `versionCode=55` / `versionName=2.4.5` via `aapt2 dump badging`
- [x] APK signed with the release keystore (SHA-256 digest matches)