### PR TITLE
fix(market): point GreasyFork client at api.greasyfork.org so search/sort/category work

### DIFF
--- a/app/src/main/java/com/webtoapp/core/market/GreasyForkSearch.kt
+++ b/app/src/main/java/com/webtoapp/core/market/GreasyForkSearch.kt
@@ -66,7 +66,10 @@ enum class GfBrowseCategory(val apiQuery: String?) {
 object GreasyForkSearch {
 
     private const val TAG = "GfSearch"
-    private const val BASE = "https://greasyfork.org"
+
+    // Must be the api subdomain: greasyfork.org 308-redirects here and drops the whole
+    // query string, which silently turned every search/sort/category into the default hot list.
+    private const val BASE = "https://api.greasyfork.org"
     private const val MAX_SCRIPT_SIZE = 4L * 1024 * 1024
 
     private const val BROWSER_UA =
@@ -102,13 +105,9 @@ object GreasyForkSearch {
         return fetchScripts(query = category.apiQuery, locale = locale, sort = sort)
     }
 
-    private suspend fun fetchScripts(
-        query: String?,
-        locale: String,
-        sort: GfSort
-    ): Result<List<GfSearchResult>> = withContext(Dispatchers.IO) {
+    internal fun buildScriptsUrl(query: String?, locale: String, sort: GfSort): String {
         val pathLocale = mapLocale(locale)
-        val url = buildString {
+        return buildString {
             append(BASE)
             append('/')
             append(pathLocale)
@@ -122,6 +121,14 @@ object GreasyForkSearch {
             append("sort=")
             append(sort.apiValue)
         }
+    }
+
+    private suspend fun fetchScripts(
+        query: String?,
+        locale: String,
+        sort: GfSort
+    ): Result<List<GfSearchResult>> = withContext(Dispatchers.IO) {
+        val url = buildScriptsUrl(query, locale, sort)
         val label = query?.trim().orEmpty().ifBlank { "browse:${sort.apiValue}" }
 
         try {

--- a/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ModuleMarketScreen.kt
@@ -281,6 +281,8 @@ fun ModuleMarketScreen(
             gfSearching = false
             gfHasSearched = true
         }.onFailure {
+            // Clear stale hits so the error UI (shown only when results are empty) can appear.
+            gfResults = emptyList()
             gfSearching = false
             gfHasSearched = true
             gfError = it.message ?: Strings.gfSearchFailed

--- a/app/src/test/java/com/webtoapp/core/market/GreasyForkSearchTest.kt
+++ b/app/src/test/java/com/webtoapp/core/market/GreasyForkSearchTest.kt
@@ -1,0 +1,121 @@
+package com.webtoapp.core.market
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GreasyForkSearchTest {
+
+    @Test
+    fun `scripts url targets api host and keeps query and sort params`() {
+        val url = GreasyForkSearch.buildScriptsUrl("youtube downloader", "en", GfSort.TOTAL)
+
+        assertThat(url).isEqualTo(
+            "https://api.greasyfork.org/en/scripts.json?q=youtube+downloader&sort=total_installs"
+        )
+    }
+
+    @Test
+    fun `scripts url maps locale and omits q for browse`() {
+        val url = GreasyForkSearch.buildScriptsUrl(null, "zh", GfSort.DAILY)
+
+        assertThat(url).isEqualTo(
+            "https://api.greasyfork.org/zh-CN/scripts.json?sort=daily_installs"
+        )
+    }
+
+    @Test
+    fun `browse category rides along as q param`() {
+        val url = GreasyForkSearch.buildScriptsUrl(
+            GfBrowseCategory.AD_BLOCKING.apiQuery,
+            "en",
+            GfSort.SCORE
+        )
+
+        assertThat(url).isEqualTo(
+            "https://api.greasyfork.org/en/scripts.json?q=adblock&sort=fan_score"
+        )
+    }
+
+    @Test
+    fun `parses object-wrapped query array from the api`() {
+        val raw = """
+            {
+              "query": [
+                {
+                  "id": 473330,
+                  "name": "YouTube CPU Tamer by AnimationFrame",
+                  "description": "Reduce CPU usage",
+                  "version": "2.4.1",
+                  "code_url": "https://update.greasyfork.org/scripts/473330/script.user.js",
+                  "url": "https://greasyfork.org/en/scripts/473330-youtube-cpu-tamer-by-animationframe",
+                  "users": [
+                    {"id": 371179, "name": "𝖢𝖸 𝖥𝗎𝗇𝗀", "url": "https://greasyfork.org/users/371179"}
+                  ],
+                  "fan_score": 1.5,
+                  "total_installs": 57210,
+                  "daily_installs": 348,
+                  "good_ratings": 5,
+                  "ok_ratings": 0,
+                  "bad_ratings": 1,
+                  "code_updated_at": "2025-06-01T00:00:00.000Z",
+                  "license": "MIT",
+                  "locale": "en",
+                  "code_size": 12345
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val results = GreasyForkSearch.parseSearchResponse(raw)
+
+        assertThat(results).hasSize(1)
+        val script = results.first()
+        assertThat(script.id).isEqualTo(473330L)
+        assertThat(script.name).isEqualTo("YouTube CPU Tamer by AnimationFrame")
+        assertThat(script.author).isEqualTo("𝖢𝖸 𝖥𝗎𝗇𝗀")
+        assertThat(script.codeUrl)
+            .isEqualTo("https://update.greasyfork.org/scripts/473330/script.user.js")
+        assertThat(script.totalInstalls).isEqualTo(57210L)
+        assertThat(script.ratingsTotal).isEqualTo(6L)
+        assertThat(script.license).isEqualTo("MIT")
+    }
+
+    @Test
+    fun `parses legacy bare array response`() {
+        val raw = """
+            [
+              {"id": 1, "name": "Legacy entry", "code_url": "https://example.org/a.user.js"}
+            ]
+        """.trimIndent()
+
+        val results = GreasyForkSearch.parseSearchResponse(raw)
+
+        assertThat(results).hasSize(1)
+        assertThat(results.first().name).isEqualTo("Legacy entry")
+    }
+
+    @Test
+    fun `empty query payloads parse to empty lists`() {
+        assertThat(GreasyForkSearch.parseSearchResponse("""{"query": []}""")).isEmpty()
+        assertThat(GreasyForkSearch.parseSearchResponse("[]")).isEmpty()
+    }
+
+    @Test
+    fun `garbage input parses to empty list without throwing`() {
+        assertThat(GreasyForkSearch.parseSearchResponse("not json at all")).isEmpty()
+    }
+
+    @Test
+    fun `search with blank query short-circuits to empty success`() {
+        val result = runBlocking { GreasyForkSearch.search("   ") }
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

- `greasyfork.org` now answers `/{locale}/scripts.json` with `HTTP 308` → `api.greasyfork.org` **and drops the whole query string**, so every keyword search, sort chip, and browse-category request silently resolved to the parameter-less default hot list (HTTP 200, parsed fine — nothing looked broken).
- Point `GreasyForkSearch.BASE` at `https://api.greasyfork.org`. The new host's `{"query": […]}` payload and item field names are compatible with the existing parser; `sort`, locale paths (`zh-CN`, …) and script `code_url` fetching keep working. Verified against the live API (search hits, nonsense query → 0 results, sort changes ordering).
- Extract URL building into `internal fun buildScriptsUrl()` (behavior unchanged) and cover it with unit tests.
- `ModuleMarketScreen`: the keyword-search `onFailure` branch now clears `gfResults`, matching the browse branch — otherwise a genuine network failure renders as "the list never changes" because the error UI only shows when the list is empty.

Fixes #532

## Test plan

- [x] New `GreasyForkSearchTest` (8 tests): URL building (api host, `q`/`sort` params, `zh` → `zh-CN` locale path, browse category as `q`), object-wrapped and legacy-array parsing, empty/garbage payloads, blank-query short-circuit — all green locally via `:app:testStandardDebugUnitTest`.
- [x] Live endpoint checks with curl before/after the host switch (documented in #532).
- [ ] CI: `Android CI Build / check` green (compiles + full standard unit tests + config drift gate).
- Host-only change: `core/market` and `ui/screens` are not shell-synced, no template rebuild needed.