### PR TITLE
fix(python): heal stale musl runtimes in place so pip installs work after app updates

### DIFF
--- a/app/src/main/java/com/webtoapp/core/python/ElfInterpPatcher.kt
+++ b/app/src/main/java/com/webtoapp/core/python/ElfInterpPatcher.kt
@@ -6,21 +6,30 @@ import java.io.RandomAccessFile
 import java.nio.charset.StandardCharsets
 
 /**
- * Rewrites the PT_INTERP (ELF program interpreter) of executables so the
- * kernel can locate the musl dynamic linker without relying on `/lib`, which
- * does not exist on Android.
+ * Rewrites the PT_INTERP (ELF program interpreter) of executables so direct
+ * kernel execs resolve the on-device musl dynamic linker.
  *
  * The python-build-standalone musl builds ship with an absolute interpreter
- * path such as `/lib/ld-musl-aarch64.so.1`. Launching them through the explicit
- * loader (`ld-musl-* --library-path ... python3`) works, but **any subprocess
- * spawned by Python itself** (e.g. pip's PEP 517 build-isolation venv pythons)
- * is exec'd directly by the kernel, which resolves PT_INTERP verbatim and
- * fails with `ENOENT` on Android.
+ * path such as `/lib/ld-musl-aarch64.so.1`, which does not exist on Android.
+ * Launching through the explicit loader (`ld-musl-* --library-path ... python3`)
+ * works, but **any subprocess spawned by Python itself** (pip's PEP 517
+ * build-isolation venv pythons) is exec'd directly by the kernel, which
+ * resolves PT_INTERP verbatim and fails with `ENOENT`.
  *
- * Patching the interpreter to an `$ORIGIN`-relative path
- * (`$ORIGIN/../lib/ld-musl-<arch>.so.1`) makes direct kernel execs resolve the
- * bundled loader, which is exactly how relocatable musl toolchains work on
- * regular Linux.
+ * The interpreter is therefore patched to the **absolute path of the bundled
+ * loader on this device** (`<pythonHome>/lib/ld-musl-<arch>.so.1`). An
+ * absolute path is required rather than an `$ORIGIN`-relative one because:
+ *
+ *  - the kernel does not expand `$ORIGIN` in PT_INTERP (it would be resolved
+ *    as a literal relative path against the process CWD), and
+ *  - `packaging`'s musl version probe reads PT_INTERP of `sys.executable` and
+ *    executes that string verbatim (`subprocess.run([ld])`) to compute the
+ *    `musllinux_*` platform tags — an absolute, existing path makes the probe
+ *    succeed so compiled wheels match without any source build.
+ *
+ * The baked path lives under the app's `filesDir`, which is stable across app
+ * updates (unlike `nativeLibraryDir`, which is randomized per install and
+ * must never be embedded).
  */
 object ElfInterpPatcher {
 
@@ -45,21 +54,21 @@ object ElfInterpPatcher {
     private const val SIZEOF_EHDR32 = 52
     private const val SIZEOF_PHDR32 = 32
 
-    /** The interpreter path of an Android-incompatible absolute musl loader. */
-    private val ABSOLUTE_MUSL_INTERP = Regex("^/lib/ld-musl-[^/]+\\.so\\.1$")
+    private const val ORIGIN_PREFIX = "\$ORIGIN/"
 
     /**
-     * The `$ORIGIN`-relative interpreter path that resolves to the on-device
-     * musl loader bundled under `<pythonHome>/lib/`.
-     *
-     * @param linkerName e.g. `ld-musl-aarch64.so.1` (see
-     * [PythonDependencyManager.getMuslLinkerName]).
+     * True when [interp] points at a musl dynamic loader that this device
+     * cannot resolve verbatim: the stock absolute `/lib/ld-musl-<arch>.so.1`,
+     * the `$ORIGIN`-relative form written by the 2.4.5 patcher (the kernel
+     * does not expand `$ORIGIN` in PT_INTERP), or a stale absolute path baked
+     * by an earlier heal after the runtime moved.
      */
-    fun relocatableInterp(linkerName: String): String = "\$ORIGIN/../lib/$linkerName"
-
-    /** True when [interp] is an absolute musl loader path that Android cannot resolve. */
-    fun isAbsoluteMuslInterp(interp: String): Boolean =
-        ABSOLUTE_MUSL_INTERP.matches(interp)
+    fun isUnresolvedMuslInterp(interp: String, resolvedInterp: String): Boolean {
+        if (interp == resolvedInterp) return false
+        if (!interp.startsWith("/") && !interp.startsWith(ORIGIN_PREFIX)) return false
+        val base = interp.substringAfterLast('/')
+        return base.startsWith("ld-musl-") && base.endsWith(".so.1")
+    }
 
     /**
      * Reads the current PT_INTERP of [file], or null when the file is not a
@@ -190,32 +199,32 @@ object ElfInterpPatcher {
     }
 
     /**
-     * Patches [file] when its interpreter is an absolute musl path that cannot
-     * resolve on Android.
+     * Patches [file] when its interpreter is a musl loader path this device
+     * cannot resolve verbatim.
      *
+     * @param resolvedInterp absolute on-device loader path to bake in (see
+     * [PythonDependencyManager.resolvedMuslInterpPath]).
      * @return true when the file was modified.
      */
-    fun patchMuslInterp(file: File, linkerName: String): Boolean {
+    fun patchMuslInterp(file: File, resolvedInterp: String): Boolean {
         val current = currentInterp(file) ?: return false
-        if (!isAbsoluteMuslInterp(current)) return false
-        val newInterp = relocatableInterp(linkerName)
-        if (current == newInterp) return false
-        return rewriteInterp(file, newInterp)
+        if (!isUnresolvedMuslInterp(current, resolvedInterp)) return false
+        return rewriteInterp(file, resolvedInterp)
     }
 
     /**
-     * Patches every ELF executable under `<pythonHome>/bin/` that carries an
-     * absolute musl interpreter.
+     * Patches every ELF executable under `<pythonHome>/bin/` whose musl
+     * interpreter cannot be resolved on this device.
      *
      * @return number of binaries patched.
      */
-    fun patchPythonBinaries(pythonHome: File, linkerName: String): Int {
+    fun patchPythonBinaries(pythonHome: File, resolvedInterp: String): Int {
         val binDir = File(pythonHome, "bin")
         if (!binDir.isDirectory) return 0
         var patched = 0
         binDir.listFiles()?.forEach { file ->
             if (file.isFile && file.length() > 1024 * 1024) {
-                if (patchMuslInterp(file, linkerName)) patched++
+                if (patchMuslInterp(file, resolvedInterp)) patched++
             }
         }
         return patched

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -47,6 +47,12 @@ object PythonDependencyManager {
 
     private const val SITE_CUSTOMIZE_FILE_NAME = "sitecustomize.py"
 
+    /** Bump when [buildSitecustomizeScript] content changes so existing runtimes re-heal. */
+    internal const val SITE_CUSTOMIZE_VERSION = 2
+
+    /** Marker file under the runtime root recording the last applied heal. */
+    private const val HEAL_MARKER_FILE_NAME = ".w2a-musl-heal"
+
     /** Cap on pip output retained for failure analysis (pattern matching). */
     private const val MAX_PIP_OUTPUT_CHARS = 512 * 1024
 
@@ -261,6 +267,10 @@ object PythonDependencyManager {
             val pythonReady = resolvePythonBinary(context) != null
             val muslReady = resolveMuslLinker(context) != null
             if (pythonReady && muslReady) {
+                // Runtimes that persisted across an app update never received
+                // the on-device fixes (they only used to run after a fresh
+                // download) — heal them in place before declaring ready.
+                ensureRuntimePatched(context)
                 markComplete()
                 return@withContext true
             }
@@ -340,6 +350,11 @@ object PythonDependencyManager {
                 return@withContext false
             }
 
+            // Heal runtimes downloaded by older app versions before pip runs:
+            // pip's subprocess spawns and packaging's musl platform probe both
+            // depend on the patched interpreter / sitecustomize bridge.
+            ensureRuntimePatched(context)
+
             val result = runPipWithWrapper(context, projectDir, pythonBin, pythonHome, muslLinker,
                 sitePackages, installReqFile, extraEnv, onOutput)
 
@@ -359,6 +374,79 @@ object PythonDependencyManager {
             if (installReqFile != reqFile) {
                 installReqFile.delete()
             }
+        }
+    }
+
+    /**
+     * The absolute loader path to bake into PT_INTERP: the loader co-located
+     * with the runtime under `filesDir`, which is stable across app updates.
+     * The `nativeLibraryDir` loader is deliberately not used — that path is
+     * randomized on every app install/update, which would break embedded
+     * interpreters after the next update.
+     */
+    fun resolvedMuslInterpPath(context: Context): String? {
+        val linkerName = getMuslLinkerName(getDeviceAbi())
+        val coLocated = File(getPythonDir(context), "lib/$linkerName")
+        if (coLocated.isFile && coLocated.length() > 1024) return coLocated.absolutePath
+        return null
+    }
+
+    /**
+     * Idempotently applies the on-device compatibility fixes to an extracted
+     * Python runtime: patches musl PT_INTERP paths this device cannot resolve
+     * (the stock `/lib/ld-musl-*.so.1`, the `$ORIGIN` form written by the
+     * 2.4.5 patcher, or a stale absolute path) to [resolvedInterp], and
+     * refreshes the `sitecustomize.py` subprocess bridge. A marker file
+     * short-circuits repeated runs.
+     *
+     * @return true when the runtime exists and is (now) healed.
+     */
+    internal fun healRuntimeInPlace(pythonHome: File, resolvedInterp: String): Boolean {
+        val binDir = File(pythonHome, "bin")
+        if (!binDir.isDirectory) return false
+
+        val marker = File(pythonHome, HEAL_MARKER_FILE_NAME)
+        val markerValue = "$resolvedInterp|v$SITE_CUSTOMIZE_VERSION"
+        if (marker.isFile && marker.readText() == markerValue) {
+            AppLogger.d(TAG, "Python runtime already healed: ${marker.absolutePath}")
+            return true
+        }
+
+        val patchedCount = ElfInterpPatcher.patchPythonBinaries(pythonHome, resolvedInterp)
+        if (patchedCount > 0) {
+            AppLogger.i(TAG, "Patched $patchedCount Python ELF interpreter(s) to $resolvedInterp")
+        }
+
+        val siteCustomize = File(pythonHome, "lib/python$PYTHON_VERSION/$SITE_CUSTOMIZE_FILE_NAME")
+        siteCustomize.parentFile?.mkdirs()
+        siteCustomize.writeText(buildSitecustomizeScript())
+        AppLogger.i(TAG, "Installed/refreshed $SITE_CUSTOMIZE_FILE_NAME for subprocess loader bridging: ${siteCustomize.absolutePath}")
+
+        marker.writeText(markerValue)
+        return true
+    }
+
+    /**
+     * Heals a runtime installed by an older app version (or after a partially
+     * failed download): the interp patch and sitecustomize bridge used to run
+     * only right after a fresh download, so runtimes that persisted across an
+     * app update never received them and pip kept failing with
+     * `No such file or directory: '/lib/ld-musl-*.so.1'`.
+     *
+     * @return true when a runtime exists and is (now) healed.
+     */
+    fun ensureRuntimePatched(context: Context): Boolean {
+        return try {
+            val pythonHome = getPythonDir(context)
+            if (!File(pythonHome, "bin").isDirectory) return false
+            val resolvedInterp = resolvedMuslInterpPath(context) ?: run {
+                AppLogger.w(TAG, "musl loader not present yet; skipping runtime heal")
+                return false
+            }
+            healRuntimeInPlace(pythonHome, resolvedInterp)
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "Runtime heal failed: ${e.message}")
+            false
         }
     }
 
@@ -439,20 +527,28 @@ object PythonDependencyManager {
      * A `sitecustomize.py` installed into the Python runtime dir. It is imported
      * by *every* Python process (including pip subprocesses and PEP 517 build
      * isolation venv pythons) and routes any python-like executable through the
-     * on-device musl loader, because the ELF interpreter path
+     * on-device musl loader, because the stock ELF interpreter path
      * (`/lib/ld-musl-<arch>.so.1`) does not exist on Android. This is the safety
-     * net for subprocess spawns that bypass the explicit-loader launcher; the
-     * primary fix is patching PT_INTERP to an `$ORIGIN`-relative path.
+     * net for subprocess spawns on runtimes whose PT_INTERP patch did not apply;
+     * the primary fix is patching PT_INTERP to the on-device absolute loader
+     * path.
+     *
+     * It also rescues `packaging`'s musl version probe: the probe reads the
+     * PT_INTERP string of `sys.executable` and executes it verbatim
+     * (`subprocess.run([ld])`) to compute the `musllinux_*` platform tags. On
+     * Android that string is never directly executable, so it is re-routed to
+     * the bundled loader — without this, compiled wheels (e.g. MarkupSafe for
+     * Flask) never match and pip falls back to a source build that cannot work.
      */
     internal fun buildSitecustomizeScript(): String = """
 import os
 import sys
 
 # WebToApp: route python subprocesses through the on-device musl dynamic linker.
-# The python ELF interpreter (/lib/ld-musl-*.so.1) does not exist on Android,
-# so direct kernel execs of the binary fail. This module is imported by every
-# python process via the site machinery and rewrites subprocess/exec calls that
-# target python-like executables to go through the bundled loader instead.
+# The stock python ELF interpreter (/lib/ld-musl-*.so.1) does not exist on
+# Android, so direct kernel execs of the binary fail. This module is imported
+# by every python process via the site machinery and rewrites subprocess/exec
+# calls that target python-like executables to go through the bundled loader.
 
 _MUSL = os.environ.get('_WTA_MUSL_LINKER', '')
 _LIB = os.environ.get('_WTA_MUSL_LIB_PATH', '')
@@ -465,6 +561,11 @@ def _is_py(p):
     return bool(p) and (p == _PYBIN or os.path.basename(str(p)) in _PYNAMES)
 
 
+def _is_loader(p):
+    b = os.path.basename(str(p))
+    return b.startswith('ld-musl-') and '.so.' in b
+
+
 if _MUSL and _LIB:
     import subprocess
 
@@ -472,8 +573,15 @@ if _MUSL and _LIB:
 
     class _MPopen(_OrigPopen):
         def __init__(self, args, *a, **kw):
-            if isinstance(args, (list, tuple)) and len(args) > 0 and _is_py(str(args[0])):
-                args = [_MUSL, '--library-path', _LIB] + list(args)
+            if isinstance(args, (list, tuple)) and len(args) > 0:
+                head = str(args[0])
+                if _is_py(head):
+                    args = [_MUSL, '--library-path', _LIB] + list(args)
+                elif head != _MUSL and _is_loader(head):
+                    # packaging's musl probe executes the PT_INTERP string of
+                    # sys.executable verbatim; run the bundled loader instead
+                    # so the musllinux platform tags resolve.
+                    args = [_MUSL] + list(args)[1:]
             super().__init__(args, *a, **kw)
 
     subprocess.Popen = _MPopen
@@ -483,6 +591,9 @@ if _MUSL and _LIB:
     def _mexecv(p, a):
         if _is_py(p):
             a = [_MUSL, '--library-path', _LIB] + list(a)
+            p = _MUSL
+        elif p != _MUSL and _is_loader(p):
+            a = list(a)
             p = _MUSL
         return _oexecv(p, a)
 
@@ -494,6 +605,9 @@ if _MUSL and _LIB:
         def _mexecve(p, a, e):
             if _is_py(p):
                 a = [_MUSL, '--library-path', _LIB] + list(a)
+                p = _MUSL
+            elif p != _MUSL and _is_loader(p):
+                a = list(a)
                 p = _MUSL
             return _oexecve(p, a, e)
 
@@ -513,64 +627,72 @@ if _MUSL and _LIB:
     ): Boolean {
         val cacheDir = context.cacheDir
 
-        val wrapperScript = File(cacheDir, "python_wrapper.sh")
-        wrapperScript.writeText("""#!/system/bin/sh
-exec "$muslLinker" --library-path "$pythonHome/lib" "$pythonBin" "${'$'}@"
-""")
-        wrapperScript.setExecutable(true, false)
-        AppLogger.d(TAG, "Creating Python wrapper: ${wrapperScript.absolutePath}")
-
         val bootstrapScript = File(cacheDir, "pip_bootstrap.py")
         bootstrapScript.writeText("""
 import sys
 import os
 
-# ★ 核心: 将 sys.executable 设为 shell wrapper
-# pip 在内部调用子进程时使用 sys.executable，
-# 原始值指向 libpython3.so (musl ELF)，直接 exec 会失败
-# wrapper 脚本封装了 musl-linker 调用，确保子进程正确执行
-wrapper_path = os.environ.get('_PYTHON_WRAPPER')
-if wrapper_path and os.path.exists(wrapper_path):
-    sys.executable = wrapper_path
-    # 同时修改 _base_executable 确保 venv/pip 子组件也使用 wrapper
-    if hasattr(sys, '_base_executable'):
-        sys._base_executable = wrapper_path
+# ★ sys.executable 必须保持真实的 python ELF 路径，不能改写成 shell wrapper：
+# 1) 运行时 PT_INTERP 已被修补为设备上的绝对 musl loader 路径，pip 派生的
+#    子进程直接 exec 即可；
+# 2) packaging 的 musl 版本探测会读取 sys.executable 的 ELF 头，并把其
+#    PT_INTERP 字符串当命令执行，以计算 musllinux 平台标签。若指向非 ELF
+#    的 wrapper，探测静默失败 → 编译型 wheel（如 MarkupSafe）全部无法匹配
+#    → pip 退回源码构建并在 Android 上失败。补丁未生效的旧运行时由下面的
+#    subprocess/os.execv 劫持兜底。
 
-# 额外安全: monkey-patch subprocess.Popen 和 os.execv
-# 以防某些 pip 插件直接使用旧的 sys.executable 值
+# 安全网: monkey-patch subprocess.Popen 和 os.execv，把 python 目标的调用
+# 改道到 musl loader（覆盖 PT_INTERP 补丁未生效的情况）
 import subprocess
 _OrigPopen = subprocess.Popen
 _MUSL = os.environ.get('_WTA_MUSL_LINKER', '')
 _LIB = os.environ.get('_WTA_MUSL_LIB_PATH', '')
 _PYBIN = os.environ.get('_WTA_PYTHON_BIN', '')
-_PYNAMES = ('python3', '${getVersionedPythonBinaryName()}', 'libpython3.so')
+_PYNAMES = ('python', 'python3', '${getVersionedPythonBinaryName()}', 'libpython3.so')
 
 def _is_py(p):
     return p == _PYBIN or os.path.basename(str(p)) in _PYNAMES
 
+def _is_loader(p):
+    b = os.path.basename(str(p))
+    return b.startswith('ld-musl-') and '.so.' in b
+
 class _MPopen(_OrigPopen):
     def __init__(self, args, *a, **kw):
         if isinstance(args, (list, tuple)) and len(args) > 0 and _MUSL and _LIB:
-            if _is_py(str(args[0])):
+            head = str(args[0])
+            if _is_py(head):
                 args = [_MUSL, '--library-path', _LIB] + list(args)
+            elif head != _MUSL and _is_loader(head):
+                # packaging 的 musl 探测会把 PT_INTERP 字符串当命令执行，
+                # 改道到随包 loader 让 musllinux 标签可解析。
+                args = [_MUSL] + list(args)[1:]
         super().__init__(args, *a, **kw)
 
 subprocess.Popen = _MPopen
 
 _oexecv = os.execv
 def _mexecv(p, a):
-    if _MUSL and _LIB and _is_py(p):
-        a = [_MUSL, '--library-path', _LIB] + list(a)
-        p = _MUSL
+    if _MUSL and _LIB:
+        if _is_py(p):
+            a = [_MUSL, '--library-path', _LIB] + list(a)
+            p = _MUSL
+        elif p != _MUSL and _is_loader(p):
+            a = list(a)
+            p = _MUSL
     return _oexecv(p, a)
 os.execv = _mexecv
 
 if hasattr(os, 'execve'):
     _oexecve = os.execve
     def _mexecve(p, a, e):
-        if _MUSL and _LIB and _is_py(p):
-            a = [_MUSL, '--library-path', _LIB] + list(a)
-            p = _MUSL
+        if _MUSL and _LIB:
+            if _is_py(p):
+                a = [_MUSL, '--library-path', _LIB] + list(a)
+                p = _MUSL
+            elif p != _MUSL and _is_loader(p):
+                a = list(a)
+                p = _MUSL
         return _oexecve(p, a, e)
     os.execve = _mexecve
 
@@ -599,7 +721,7 @@ sys.exit(main())
         AppLogger.i(TAG, "Installing Python dependencies (wrapper mode): ${command.joinToString(" ")}")
 
         val firstResult = executeCommand(command, projectDir, pythonBin, pythonHome, muslLinker,
-            wrapperScript.absolutePath, context, extraEnv, onOutput)
+            context, extraEnv, onOutput)
 
         if (firstResult.exitCode == 0) return true
 
@@ -643,7 +765,7 @@ sys.exit(main())
         AppLogger.i(TAG, "Installing Python dependencies (wrapper-mode retry): ${retryCommand.joinToString(" ")}")
 
         val retryResult = executeCommand(retryCommand, projectDir, pythonBin, pythonHome, muslLinker,
-            wrapperScript.absolutePath, context, extraEnv, onOutput)
+            context, extraEnv, onOutput)
         if (retryResult.exitCode == 0) return true
 
         // The retry also failed: give an actionable hint when the cause is a
@@ -677,7 +799,7 @@ sys.exit(main())
             "-r", reqFile.absolutePath
         )
         AppLogger.i(TAG, "Installing Python dependencies (direct mode): ${command.joinToString(" ")}")
-        return executeCommand(command, projectDir, pythonBin, pythonHome, null, null,
+        return executeCommand(command, projectDir, pythonBin, pythonHome, null,
             context, emptyMap(), onOutput).exitCode == 0
     }
 
@@ -689,7 +811,6 @@ sys.exit(main())
         pythonBin: String,
         pythonHome: String,
         muslLinker: String?,
-        wrapperPath: String?,
         context: Context,
         extraEnv: Map<String, String>,
         onOutput: ((String) -> Unit)?
@@ -711,9 +832,6 @@ sys.exit(main())
             env["_WTA_MUSL_LIB_PATH"] = "$pythonHome/lib"
         }
         env["_WTA_PYTHON_BIN"] = pythonBin
-        if (wrapperPath != null) {
-            env["_PYTHON_WRAPPER"] = wrapperPath
-        }
 
         extraEnv.forEach { (k, v) -> env[k] = v }
 
@@ -876,30 +994,11 @@ sys.exit(main())
                 it.setExecutable(true, false)
             }
 
-            // The python binaries ship with an absolute ELF interpreter
-            // (/lib/ld-musl-<arch>.so.1) that does not exist on Android. Direct
-            // launches work because we exec through the explicit loader, but
-            // pip's PEP 517 build isolation spawns subprocesses (venv pythons)
-            // that the kernel execs directly. Patch PT_INTERP to an
-            // $ORIGIN-relative path so those execs resolve the bundled loader.
-            val linkerName = getMuslLinkerName(abi)
-            val patchedCount = ElfInterpPatcher.patchPythonBinaries(destDir, linkerName)
-            if (patchedCount > 0) {
-                AppLogger.i(TAG, "Patched $patchedCount Python ELF interpreter(s) to \$ORIGIN-relative musl loader")
-            } else {
-                AppLogger.w(TAG, "No Python ELF binaries needed interpreter patching")
-            }
-
-            // Fallback for any subprocess spawn that still bypasses the patched
-            // interpreter (e.g. older kernels without $ORIGIN expansion): every
-            // python process imports sitecustomize, which routes python-like
-            // executables through the musl loader.
-            val siteCustomize = File(destDir, "lib/python$PYTHON_VERSION/$SITE_CUSTOMIZE_FILE_NAME")
-            if (!siteCustomize.exists()) {
-                siteCustomize.writeText(buildSitecustomizeScript())
-                AppLogger.i(TAG, "Installed $SITE_CUSTOMIZE_FILE_NAME for subprocess loader bridging: ${siteCustomize.absolutePath}")
-            }
-
+            // The python binaries ship with an ELF interpreter the kernel
+            // cannot resolve on Android. The interp patch + sitecustomize
+            // bridge need the musl loader on disk, so they run as an
+            // idempotent heal after the loader download below (same path used
+            // for runtimes that persisted across an app update).
             archiveFile.delete()
         } catch (e: Exception) {
             AppLogger.e(TAG, "Python extraction failed", e)
@@ -915,6 +1014,10 @@ sys.exit(main())
         } else {
             AppLogger.w(TAG, "Current ABI ($abi) has no available musl linker")
         }
+
+        // Applies the interp patch + sitecustomize bridge now that the loader
+        // is on disk; no-ops safely when the loader download failed.
+        ensureRuntimePatched(context)
 
         return true
     }

--- a/app/src/test/java/com/webtoapp/core/python/ElfInterpPatcherTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/ElfInterpPatcherTest.kt
@@ -15,6 +15,7 @@ class ElfInterpPatcherTest {
 
     private val ABSOLUTE = "/lib/ld-musl-aarch64.so.1"
     private val RELATIVE = "\$ORIGIN/../lib/ld-musl-aarch64.so.1"
+    private val TARGET = "/data/user/0/com.webtoapp/files/python_deps/python/lib/ld-musl-aarch64.so.1"
 
     @Test
     fun `currentInterp reads the interp string`() {
@@ -40,39 +41,58 @@ class ElfInterpPatcherTest {
 
     @Test
     fun `rewriteInterp writes in place when the new path fits`() {
-        val file = writeElf(ABSOLUTE, pFilesz = 64)
-        assertThat(ElfInterpPatcher.rewriteInterp(file, RELATIVE)).isTrue()
-        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+        val file = writeElf(ABSOLUTE, pFilesz = 128)
+        assertThat(ElfInterpPatcher.rewriteInterp(file, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(TARGET)
     }
 
     @Test
     fun `rewriteInterp grows the segment when the new path is longer`() {
         val file = writeElf(ABSOLUTE) // p_filesz = 28
-        assertThat(ElfInterpPatcher.rewriteInterp(file, RELATIVE)).isTrue()
-        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+        assertThat(ElfInterpPatcher.rewriteInterp(file, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(TARGET)
     }
 
     @Test
-    fun `patchMuslInterp rewrites absolute musl interp and is idempotent`() {
+    fun `patchMuslInterp rewrites stock absolute interp and is idempotent`() {
         val file = writeElf(ABSOLUTE)
-        assertThat(ElfInterpPatcher.patchMuslInterp(file, "ld-musl-aarch64.so.1")).isTrue()
-        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
-        // Second pass: already relative, nothing to do.
-        assertThat(ElfInterpPatcher.patchMuslInterp(file, "ld-musl-aarch64.so.1")).isFalse()
-        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(RELATIVE)
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(TARGET)
+        // Second pass: already resolved, nothing to do.
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, TARGET)).isFalse()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(TARGET)
+    }
+
+    @Test
+    fun `patchMuslInterp migrates the ORIGIN-relative form written by 2_4_5`() {
+        val file = writeElf(RELATIVE)
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(TARGET)
+    }
+
+    @Test
+    fun `patchMuslInterp re-heals a stale absolute musl path`() {
+        val stale = "/data/user/0/com.webtoapp-old/files/python/lib/ld-musl-aarch64.so.1"
+        val file = writeElf(stale)
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo(TARGET)
     }
 
     @Test
     fun `patchMuslInterp leaves non-musl interps alone`() {
         val file = writeElf("/lib/ld-linux-aarch64.so.1")
-        assertThat(ElfInterpPatcher.patchMuslInterp(file, "ld-musl-aarch64.so.1")).isFalse()
+        assertThat(ElfInterpPatcher.patchMuslInterp(file, TARGET)).isFalse()
         assertThat(ElfInterpPatcher.currentInterp(file)).isEqualTo("/lib/ld-linux-aarch64.so.1")
     }
 
     @Test
-    fun `relocatableInterp builds an origin-relative path`() {
-        assertThat(ElfInterpPatcher.relocatableInterp("ld-musl-aarch64.so.1"))
-            .isEqualTo("\$ORIGIN/../lib/ld-musl-aarch64.so.1")
+    fun `isUnresolvedMuslInterp classifies resolvability`() {
+        assertThat(ElfInterpPatcher.isUnresolvedMuslInterp(ABSOLUTE, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.isUnresolvedMuslInterp(RELATIVE, TARGET)).isTrue()
+        assertThat(ElfInterpPatcher.isUnresolvedMuslInterp(TARGET, TARGET)).isFalse()
+        assertThat(ElfInterpPatcher.isUnresolvedMuslInterp("/lib/ld-linux-aarch64.so.1", TARGET)).isFalse()
+        // Relative paths without $ORIGIN are never kernel-resolvable to our loader.
+        assertThat(ElfInterpPatcher.isUnresolvedMuslInterp("lib/ld-musl-aarch64.so.1", TARGET)).isFalse()
     }
 
     @Test
@@ -86,9 +106,9 @@ class ElfInterpPatcherTest {
         // binaries are tens of MB, so pad to clear the >1MB binary filter.
         pythonBin.writeBytes(buildElfBytes(ABSOLUTE) + ByteArray(1024 * 1024))
 
-        val patched = ElfInterpPatcher.patchPythonBinaries(pythonHome, "ld-musl-aarch64.so.1")
+        val patched = ElfInterpPatcher.patchPythonBinaries(pythonHome, TARGET)
         assertThat(patched).isEqualTo(1)
-        assertThat(ElfInterpPatcher.currentInterp(pythonBin)).isEqualTo(RELATIVE)
+        assertThat(ElfInterpPatcher.currentInterp(pythonBin)).isEqualTo(TARGET)
         assertThat(other.readText()).contains("#!/bin/sh")
     }
 

--- a/app/src/test/java/com/webtoapp/core/python/PythonDependencyManagerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/PythonDependencyManagerTest.kt
@@ -204,7 +204,117 @@ class PythonDependencyManagerTest {
         assertThat(script).contains("--library-path")
     }
 
+    @Test
+    fun `sitecustomize script rescues the packaging musl probe`() {
+        // packaging executes the PT_INTERP string of sys.executable verbatim to
+        // compute musllinux tags; the bridge must re-route it to the loader.
+        val script = PythonDependencyManager.buildSitecustomizeScript()
+        assertThat(script).contains("def _is_loader(p)")
+        assertThat(script).contains("head != _MUSL and _is_loader(head)")
+        assertThat(script).contains("args = [_MUSL] + list(args)[1:]")
+    }
+
+    @Test
+    fun `ensureRuntimePatched heals a stale runtime downloaded by an older version`() {
+        val pythonHome = PythonDependencyManager.getPythonDir(context)
+        val binDir = File(pythonHome, "bin").apply { mkdirs() }
+        val pythonBin = File(binDir, "python3.14").apply {
+            writeBytes(buildTestElfBytes("/lib/ld-musl-aarch64.so.1") + ByteArray(1024 * 1024))
+            setExecutable(true)
+        }
+        val linkerName = PythonDependencyManager.getMuslLinkerName(PythonDependencyManager.getDeviceAbi())
+        val linker = File(pythonHome, "lib/$linkerName").apply {
+            parentFile?.mkdirs()
+            writeBytes(ByteArray(2048) { 1 })
+        }
+
+        assertThat(PythonDependencyManager.ensureRuntimePatched(context)).isTrue()
+
+        // The stock /lib interpreter was rewritten to the on-device loader path.
+        assertThat(ElfInterpPatcher.currentInterp(pythonBin)).isEqualTo(linker.absolutePath)
+
+        val siteCustomize = File(pythonHome, "lib/python${PythonDependencyManager.PYTHON_VERSION}/sitecustomize.py")
+        assertThat(siteCustomize.exists()).isTrue()
+        assertThat(siteCustomize.readText()).contains("_is_loader")
+
+        val marker = File(pythonHome, ".w2a-musl-heal")
+        assertThat(marker.exists()).isTrue()
+        assertThat(marker.readText())
+            .isEqualTo("${linker.absolutePath}|v${PythonDependencyManager.SITE_CUSTOMIZE_VERSION}")
+
+        // Second run short-circuits via the marker and stays healed.
+        assertThat(PythonDependencyManager.ensureRuntimePatched(context)).isTrue()
+        assertThat(ElfInterpPatcher.currentInterp(pythonBin)).isEqualTo(linker.absolutePath)
+    }
+
+    @Test
+    fun `ensureRuntimePatched re-heals when the marker is stale`() {
+        val pythonHome = PythonDependencyManager.getPythonDir(context)
+        val binDir = File(pythonHome, "bin").apply { mkdirs() }
+        val pythonBin = File(binDir, "python3.14").apply {
+            writeBytes(
+                buildTestElfBytes("\$ORIGIN/../lib/ld-musl-aarch64.so.1") + ByteArray(1024 * 1024)
+            )
+        }
+        val linkerName = PythonDependencyManager.getMuslLinkerName(PythonDependencyManager.getDeviceAbi())
+        val linker = File(pythonHome, "lib/$linkerName").apply {
+            parentFile?.mkdirs()
+            writeBytes(ByteArray(2048) { 1 })
+        }
+        // A marker from an older heal (different interp / script version).
+        File(pythonHome, ".w2a-musl-heal").writeText("/old/path/ld-musl-aarch64.so.1|v1")
+
+        assertThat(PythonDependencyManager.ensureRuntimePatched(context)).isTrue()
+        // The $ORIGIN form written by the 2.4.5 patcher migrates to the
+        // absolute on-device loader path.
+        assertThat(ElfInterpPatcher.currentInterp(pythonBin)).isEqualTo(linker.absolutePath)
+    }
+
+    @Test
+    fun `ensureRuntimePatched skips when no runtime is installed`() {
+        assertThat(PythonDependencyManager.ensureRuntimePatched(context)).isFalse()
+    }
+
     private fun tempDir(name: String): File {
         return File(context.cacheDir, "python-dep-test-$name-${System.nanoTime()}").apply { mkdirs() }
+    }
+
+    /** Minimal 64-bit little-endian ELF with a single PT_INTERP segment. */
+    private fun buildTestElfBytes(interp: String): ByteArray {
+        val interpBytes = interp.toByteArray(Charsets.UTF_8) + 0
+        val ehdr = ByteArray(64)
+        ehdr[0] = 0x7F.toByte()
+        ehdr[1] = 'E'.code.toByte()
+        ehdr[2] = 'L'.code.toByte()
+        ehdr[3] = 'F'.code.toByte()
+        ehdr[4] = 2 // ELFCLASS64
+        ehdr[5] = 1 // ELFDATA2LSB
+        putU16(ehdr, 16, 2) // e_type ET_EXEC
+        putU16(ehdr, 18, 183) // e_machine AArch64
+        putU64(ehdr, 32, 64) // e_phoff
+        putU16(ehdr, 54, 56) // e_phentsize
+        putU16(ehdr, 56, 1) // e_phnum
+
+        val phdr = ByteArray(56)
+        putU32(phdr, 0, 3) // PT_INTERP
+        putU64(phdr, 8, 120) // p_offset (after header + phdr)
+        putU64(phdr, 32, interpBytes.size.toLong()) // p_filesz
+
+        return ehdr + phdr + interpBytes
+    }
+
+    private fun putU16(bytes: ByteArray, offset: Int, value: Int) {
+        bytes[offset] = (value and 0xFF).toByte()
+        bytes[offset + 1] = ((value shr 8) and 0xFF).toByte()
+    }
+
+    private fun putU32(bytes: ByteArray, offset: Int, value: Int) {
+        putU16(bytes, offset, value and 0xFFFF)
+        putU16(bytes, offset + 2, (value shr 16) and 0xFFFF)
+    }
+
+    private fun putU64(bytes: ByteArray, offset: Int, value: Long) {
+        putU32(bytes, offset, value.toInt())
+        putU32(bytes, offset + 4, (value shr 32).toInt())
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `pip install flask` failure from #530 (`OSError: [Errno 2] No such file or directory: '/lib/ld-musl-aarch64.so.1'` → `Failed to build 'MarkupSafe' when installing build dependencies`).

Root cause chain:

1. `packaging`'s musl version probe reads the PT_INTERP string of `sys.executable` and **executes it verbatim** (`subprocess.run([ld])`) to compute the `musllinux_*` platform tags. On Android `/lib/ld-musl-*.so.1` never exists → `FileNotFoundError` (the exact reported message, filename included).
2. Without musllinux tags, compiled wheels (MarkupSafe for Flask — `cp314 musllinux_1_2_aarch64` wheels exist on PyPI) never match → pip falls back to a source build → the PEP 517 build-env subprocess dies on the same probe → the reported error.
3. The 2.4.5 fixes (#510) only ran **after a fresh runtime download**, so runtimes persisted across an app update were never patched — hence "still failing after updating". Additionally the `$ORIGIN`-relative interp it wrote is not kernel-resolvable (the kernel does not expand `$ORIGIN` in PT_INTERP), and the pip bootstrap rewrote `sys.executable` to a non-ELF shell wrapper, which silently killed the probe even on patched runtimes.

Changes:

- **Idempotent in-place heal** (`ensureRuntimePatched()` + marker file): wired into the download-flow early return, before every pip install, and after fresh downloads — stale runtimes from older app versions get fixed on the next "Run pip install".
- **PT_INTERP patched to the absolute on-device loader path** under `filesDir` (stable across app updates; `nativeLibraryDir` is randomized per install and never embedded). Migrates all three unresolved forms: stock `/lib/…`, the 2.4.5 `$ORIGIN` form, and stale absolute paths.
- **sitecustomize** now also re-routes loader-path subprocess targets (the packaging probe) to the bundled loader — fallback for runtimes whose ELF patch could not apply.
- **pip bootstrap** keeps `sys.executable` pointing at the real ELF (the wrapper rewrite broke the probe); Popen/execv hijacking stays as the safety net. Unused wrapper script / `_PYTHON_WRAPPER` plumbing removed.

Fixes #530 (pip install failure). The second symptom in #530 — the 30s startup health-check window killing a successfully bound Flask server — is tracked separately in #534.

## Test plan

- [x] `ElfInterpPatcherTest` (11): interp read/truncate recovery, in-place + grown rewrite, stock/`$ORIGIN`/stale-path migration, idempotency, non-musl untouched, bin-dir scan.
- [x] `PythonDependencyManagerTest` (16, incl. 4 new): end-to-end heal of a stale runtime (marker content, sitecustomize refresh, second-run short-circuit), stale-marker re-heal, skip when no runtime, packaging-probe rescue present in the sitecustomize script.
- [x] Full `:app:testStandardDebugUnitTest`: 801 tests, 0 failures; `:app:checkConfigFieldDrift` green.
- [x] `core/python` is shell-synced: `:shell:assembleRelease` + `:app:syncShellTemplateApk` rebuilt, synced copies verified to contain the new symbols.
- [ ] CI: `Android CI Build / check` green.
- On-device expectations after updating: next "Run pip install" heals the runtime, musllinux tags resolve, MarkupSafe installs from its wheel instead of triggering a source build.