### PR TITLE
fix(python): progress-driven startup budget so slow Flask servers are not killed

### DIFF
--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -22,10 +22,22 @@ class PythonRuntime(private val context: Context) {
 
     companion object {
         private const val TAG = "PythonRuntime"
-        private const val MAX_HEALTH_CHECK_RETRIES = 60
+
+        // Progress-driven startup budget (#534): the base window resets on every
+        // progress signal (process output line, bound socket, probe response) so
+        // slow-but-alive servers keep waiting, while the hard cap bounds the
+        // total wait. Replaces the old fixed 30s cutoff that killed Flask
+        // servers which bound just after the deadline.
+        internal const val HEALTH_CHECK_BASE_BUDGET_MS = 90_000L
+        internal const val HEALTH_CHECK_HARD_CAP_MS = 300_000L
         private const val HEALTH_CHECK_INTERVAL_MS = 500L
         private const val HEALTH_CHECK_STABILITY_DELAY_MS = 150L
         private const val REQUIRED_HEALTHY_RESPONSES = 2
+
+        // Consecutive bound-socket polls (without an HTTP probe success) that
+        // alone count as ready — covers apps whose probe paths never answer
+        // 2xx-499 (e.g. a user handler returning 500 on /).
+        private const val REQUIRED_BOUND_SOCKET_SUCCESSES = 6
     }
 
     sealed class ServerState {
@@ -214,6 +226,10 @@ class PythonRuntime(private val context: Context) {
 
             pythonOutputBuffer.setLength(0)
             pythonStderrBuffer.setLength(0)
+            val readinessBudget = ReadinessBudget(
+                baseMs = HEALTH_CHECK_BASE_BUDGET_MS,
+                hardCapMs = HEALTH_CHECK_HARD_CAP_MS
+            )
             pythonProcess = processBuilder.start()
             attachProcessExitWatcher(pythonProcess!!, framework, serverPort)
 
@@ -223,6 +239,7 @@ class PythonRuntime(private val context: Context) {
                         stream.bufferedReader().forEachLine { line ->
                             AppLogger.d(TAG, "[Python] $line")
                             ShellLogger.d(TAG, "[Python] $line")
+                            readinessBudget.markProgress()
                             if (pythonOutputBuffer.length < 4096) pythonOutputBuffer.appendLine(line)
                         }
                     } catch (e: Exception) { AppLogger.d(TAG, "Python stdout reader ended", e) }
@@ -235,13 +252,14 @@ class PythonRuntime(private val context: Context) {
                         stream.bufferedReader().forEachLine { line ->
                             AppLogger.w(TAG, "[Python-ERR] $line")
                             ShellLogger.w(TAG, "[Python-ERR] $line")
+                            readinessBudget.markProgress()
                             if (pythonStderrBuffer.length < 4096) pythonStderrBuffer.appendLine(line)
                         }
                     } catch (e: Exception) { AppLogger.d(TAG, "Python stderr reader ended", e) }
                 }.apply { isDaemon = true; start() }
             }
 
-            val ready = waitForServerReady(serverPort, framework)
+            val ready = waitForServerReady(serverPort, framework, readinessBudget)
             if (ready) {
                 val pid = getProcessPid(pythonProcess)
                 pythonProcess?.let { PortManager.registerProcess(serverPort, it, pid) }
@@ -254,7 +272,10 @@ class PythonRuntime(private val context: Context) {
                 val stderr = pythonStderrBuffer.toString().trim().take(500)
                 val processAlive = pythonProcess?.isAliveCompat() == true
                 val exitCode = if (!processAlive) try { pythonProcess?.exitValue() } catch (_: Exception) { null } else null
-                val detail = "processAlive=$processAlive, exitCode=$exitCode\nstdout: ${stdout.ifEmpty { "(无)" }}\nstderr: ${stderr.ifEmpty { "(无)" }}"
+                val detail = "processAlive=$processAlive, exitCode=$exitCode" +
+                    ", startupElapsedMs=${readinessBudget.elapsedMs()}" +
+                    ", msSinceProgress=${readinessBudget.msSinceProgress()}" +
+                    "\nstdout: ${stdout.ifEmpty { "(无)" }}\nstderr: ${stderr.ifEmpty { "(无)" }}"
                 AppLogger.e(TAG, "Python server startup timed out, $detail")
                 val errorMsg = if (stderr.isNotEmpty()) {
                     "Python 服务器启动超时\n$stderr"
@@ -684,14 +705,35 @@ else:
         return "config.settings"
     }
 
-    private suspend fun waitForServerReady(port: Int, framework: String): Boolean {
+    /**
+     * True when something is listening on the loopback port. A bound socket is
+     * both a progress signal (imports finished, server loop starting) and —
+     * when stable — readiness on its own, covering apps whose HTTP handlers
+     * never answer 2xx-499 on the probe paths.
+     */
+    internal fun isPortBound(port: Int): Boolean {
+        if (port <= 0) return false
+        return try {
+            java.net.Socket().use { socket ->
+                socket.connect(java.net.InetSocketAddress("127.0.0.1", port), 500)
+                true
+            }
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    internal suspend fun waitForServerReady(port: Int, framework: String, budget: ReadinessBudget): Boolean {
         val probePaths = when (framework.lowercase()) {
             "flask" -> listOf("/__w2a_health", "/")
             else -> listOf("/__w2a_health", "/__health", "/")
         }
         var consecutiveSuccesses = 0
+        var consecutiveBound = 0
+        var attempt = 0
 
-        repeat(MAX_HEALTH_CHECK_RETRIES) { attempt ->
+        while (true) {
+            attempt++
             var successfulPath: String? = null
             var successfulCode = -1
             for (path in probePaths) {
@@ -719,6 +761,8 @@ else:
 
             if (successfulPath != null) {
                 consecutiveSuccesses++
+                consecutiveBound = 0
+                budget.markProgress()
                 AppLogger.i(
                     TAG,
                     "Python health check passed (attempt ${attempt + 1}, path=$successfulPath, code=$successfulCode, consecutive=$consecutiveSuccesses/$REQUIRED_HEALTHY_RESPONSES)"
@@ -740,12 +784,26 @@ else:
                         return false
                     }
                 }
-                return@repeat
+                continue
             }
 
             if (consecutiveSuccesses > 0) {
                 AppLogger.d(TAG, "Python health check stability reset: attempt=${attempt + 1}, previousConsecutive=$consecutiveSuccesses")
                 consecutiveSuccesses = 0
+            }
+
+            if (isPortBound(port)) {
+                consecutiveBound++
+                budget.markProgress()
+                if (consecutiveBound >= REQUIRED_BOUND_SOCKET_SUCCESSES) {
+                    AppLogger.i(
+                        TAG,
+                        "Python server socket stable without HTTP probe success (attempt=${attempt + 1}, consecutiveBound=$consecutiveBound); treating as ready"
+                    )
+                    return true
+                }
+            } else {
+                consecutiveBound = 0
             }
 
             pythonProcess?.let { process ->
@@ -757,10 +815,17 @@ else:
                     return false
                 }
             }
+
+            if (budget.expired()) {
+                AppLogger.e(
+                    TAG,
+                    "Python server startup timed out (elapsedMs=${budget.elapsedMs()}, msSinceProgress=${budget.msSinceProgress()})"
+                )
+                return false
+            }
+
             delay(HEALTH_CHECK_INTERVAL_MS)
         }
-        AppLogger.e(TAG, "Python server startup timed out (${MAX_HEALTH_CHECK_RETRIES * HEALTH_CHECK_INTERVAL_MS}ms)")
-        return false
     }
 
     private fun attachProcessExitWatcher(process: Process, framework: String, port: Int) {

--- a/app/src/main/java/com/webtoapp/core/python/ReadinessBudget.kt
+++ b/app/src/main/java/com/webtoapp/core/python/ReadinessBudget.kt
@@ -1,0 +1,42 @@
+package com.webtoapp.core.python
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Time budget for server startup readiness polling (#534).
+ *
+ * A fixed window (the old 30s cutoff) killed servers that were still slowly
+ * importing dependencies on flash storage — the Werkzeug bind banner often
+ * arrived just after the deadline. Instead the budget is progress-driven:
+ *
+ *  - a base window measured from the *last observed progress signal* (process
+ *    output line, bound socket, probe response), and
+ *  - a hard cap measured from start,
+ *
+ * so an alive-and-progressing server keeps waiting while a silent failure
+ * still ends after the base window.
+ */
+internal class ReadinessBudget(
+    private val baseMs: Long,
+    private val hardCapMs: Long,
+    private val clock: () -> Long = System::currentTimeMillis
+) {
+
+    private val startAt = AtomicLong(clock())
+    private val lastProgressAt = AtomicLong(clock())
+
+    /** Records a progress signal; resets the base window. */
+    fun markProgress() {
+        lastProgressAt.set(clock())
+    }
+
+    /** True when polling should give up: hard cap reached or progress went silent. */
+    fun expired(): Boolean {
+        val now = clock()
+        return now - startAt.get() >= hardCapMs || now - lastProgressAt.get() >= baseMs
+    }
+
+    fun elapsedMs(): Long = clock() - startAt.get()
+
+    fun msSinceProgress(): Long = clock() - lastProgressAt.get()
+}

--- a/app/src/test/java/com/webtoapp/core/python/PythonRuntimeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/PythonRuntimeTest.kt
@@ -1,0 +1,113 @@
+package com.webtoapp.core.python
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PythonRuntimeTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+
+    /** Minimal HTTP responder: answers 404 to every request, like an app with no matching route. */
+    private fun startHttp404Server(): Pair<ServerSocket, Thread> {
+        val server = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        val acceptor = thread(isDaemon = true) {
+            while (!server.isClosed) {
+                try {
+                    val client = server.accept()
+                    client.use { c ->
+                        BufferedReader(InputStreamReader(c.getInputStream())).readLine()
+                        c.getOutputStream().apply {
+                            write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+                            flush()
+                        }
+                    }
+                } catch (_: Exception) {
+                    return@thread
+                }
+            }
+        }
+        return server to acceptor
+    }
+
+    @Test
+    fun `isPortBound reflects the listening state`() {
+        val runtime = PythonRuntime(context)
+        assertThat(runtime.isPortBound(-1)).isFalse()
+
+        val server = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        val port = server.localPort
+        try {
+            assertThat(runtime.isPortBound(port)).isTrue()
+        } finally {
+            server.close()
+        }
+        assertThat(runtime.isPortBound(port)).isFalse()
+    }
+
+    @Test
+    fun `waitForServerReady passes against a plain HTTP server`() {
+        // Every path answers 404, which counts as healthy (2xx-499) just like
+        // an unhandled /__w2a_health would.
+        val (server, acceptor) = startHttp404Server()
+        try {
+            val runtime = PythonRuntime(context)
+            val budget = ReadinessBudget(baseMs = 5_000L, hardCapMs = 15_000L)
+            val ready = runBlocking { runtime.waitForServerReady(server.localPort, "flask", budget) }
+            assertThat(ready).isTrue()
+        } finally {
+            server.close()
+            acceptor.join(1_000)
+        }
+    }
+
+    @Test
+    fun `waitForServerReady treats a stable bound socket as ready`() {
+        // A listening socket that accepts and immediately closes connections:
+        // HTTP probes fail fast (connection reset), but the port is bound, so
+        // consecutive bound-socket polls alone must declare readiness.
+        val server = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        val acceptor = thread(isDaemon = true) {
+            while (!server.isClosed) {
+                try {
+                    server.accept().close()
+                } catch (_: Exception) {
+                    return@thread
+                }
+            }
+        }
+        try {
+            val runtime = PythonRuntime(context)
+            val budget = ReadinessBudget(baseMs = 10_000L, hardCapMs = 30_000L)
+            val ready = runBlocking { runtime.waitForServerReady(server.localPort, "flask", budget) }
+            assertThat(ready).isTrue()
+        } finally {
+            server.close()
+            acceptor.join(1_000)
+        }
+    }
+
+    @Test
+    fun `waitForServerReady expires when nothing listens`() {
+        val runtime = PythonRuntime(context)
+        val server = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        val port = server.localPort
+        server.close()
+
+        val budget = ReadinessBudget(baseMs = 1_000L, hardCapMs = 3_000L)
+        val ready = runBlocking { runtime.waitForServerReady(port, "flask", budget) }
+        assertThat(ready).isFalse()
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/python/ReadinessBudgetTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/ReadinessBudgetTest.kt
@@ -1,0 +1,63 @@
+package com.webtoapp.core.python
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicLong
+
+class ReadinessBudgetTest {
+
+    private class FakeClock : () -> Long {
+        val now = AtomicLong(1_000_000L)
+        override fun invoke(): Long = now.get()
+        fun advance(ms: Long) = now.addAndGet(ms)
+    }
+
+    @Test
+    fun `expires after the base window with no progress`() {
+        val clock = FakeClock()
+        val budget = ReadinessBudget(baseMs = 90_000L, hardCapMs = 300_000L, clock = clock)
+
+        assertThat(budget.expired()).isFalse()
+        clock.advance(89_999L)
+        assertThat(budget.expired()).isFalse()
+        clock.advance(1L)
+        assertThat(budget.expired()).isTrue()
+    }
+
+    @Test
+    fun `markProgress resets the base window`() {
+        val clock = FakeClock()
+        val budget = ReadinessBudget(baseMs = 90_000L, hardCapMs = 300_000L, clock = clock)
+
+        // 60s of silent startup, then an output line arrives.
+        clock.advance(60_000L)
+        assertThat(budget.expired()).isFalse()
+        budget.markProgress()
+        clock.advance(89_999L)
+        assertThat(budget.expired()).isFalse()
+
+        // The window is measured from the last progress, not from start.
+        clock.advance(1L)
+        assertThat(budget.expired()).isTrue()
+        assertThat(budget.msSinceProgress()).isEqualTo(90_000L)
+        assertThat(budget.elapsedMs()).isEqualTo(150_000L)
+    }
+
+    @Test
+    fun `hard cap wins over repeated progress`() {
+        val clock = FakeClock()
+        val budget = ReadinessBudget(baseMs = 90_000L, hardCapMs = 300_000L, clock = clock)
+
+        // Keep marking progress every 10s forever: never base-expired...
+        repeat(29) {
+            clock.advance(10_000L)
+            budget.markProgress()
+            assertThat(budget.expired()).isFalse()
+        }
+
+        // ...but the hard cap from start still applies.
+        clock.advance(10_000L)
+        assertThat(budget.elapsedMs()).isEqualTo(300_000L)
+        assertThat(budget.expired()).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Implements #534. `PythonRuntime.waitForServerReady()` used a fixed 60 × 500ms ≈ 30s window and then called `stopServer()`, killing Flask servers that had just finished their (slow) import phase — users saw the startup-timeout error with the Werkzeug `Running on http://127.0.0.1:…` banner visible inside the captured stderr.

- **`ReadinessBudget`** replaces the fixed retry count: a 90s base window measured from the *last progress signal* and a 5-minute hard cap from start. Progress signals: any process output line (stdout/stderr readers now mark the budget), a bound loopback socket, and any probe response. Slow-but-alive servers keep waiting; silent failures still end after the base window; process-exit checks still fail fast.
- **Direct socket probing** (`isPortBound`): a bound socket is a progress signal, and six consecutive bound polls without an HTTP probe success count as ready on their own — covering apps whose probe paths never answer 2xx–499 (e.g. a handler returning 500 on `/`, since only `/__w2a_health` is injected and only for `app.run()` apps).
- Timeout diagnostics now include `startupElapsedMs` / `msSinceProgress` in both the log and the failure detail.

Fixes #534

## Test plan

- [x] `ReadinessBudgetTest` (3): base-window expiry, `markProgress` resetting the window (measured from last progress, not start), hard cap winning over repeated progress — with a fake clock.
- [x] `PythonRuntimeTest` (4, new): `isPortBound` against a live/closed `ServerSocket`; `waitForServerReady` green against a plain 404 HTTP responder; stable-bound-socket readiness against a raw listener that resets connections; expiry when nothing listens.
- [x] Full `:app:testStandardDebugUnitTest`: 808 tests, 0 failures; `:app:checkConfigFieldDrift` green.
- [x] `core/python` is shell-synced: template rebuilt via `:shell:assembleRelease` + `:app:syncShellTemplateApk`, synced copies verified.
- [ ] CI: `Android CI Build / check` green.