### PR TITLE
build(gplay): ship the Play channel under shiaho.webtoapp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,11 @@ android {
             // NOTE: native fork+exec runtimes (esp. Node.js V8 JIT, Go memfd exec) may fail
             // under the stricter SELinux policy of high targetSdk; runtime launch is guarded
             // to degrade gracefully (see BuildConfig.GPLAY_CHANNEL) rather than crash.
+            //
+            // `com.webtoapp` is already registered on Google Play by another party, so the
+            // Play build ships under a distinct applicationId. The standard flavor (GitHub
+            // releases) keeps `com.webtoapp` so existing users keep their update path.
+            applicationId = "shiaho.webtoapp"
             targetSdk = 35
             buildConfigField("boolean", "GPLAY_CHANNEL", "true")
         }


### PR DESCRIPTION
## Summary

`com.webtoapp` is already registered on Google Play by another party, so the Play/AAB channel needs a distinct applicationId. This sets `applicationId = "shiaho.webtoapp"` on the **gplay flavor only** (5 added lines, one of them a comment).

- **GitHub release distribution is unchanged**: the `standard` flavor keeps the default `com.webtoapp`, so existing users' in-place upgrade (覆盖安装) path is untouched.
- **No Play users are broken**: our app never shipped on Play under `com.webtoapp` (the name was unavailable), so the rename has no legacy install base to break.
- **No runtime impact**: verified that `FileProvider` authorities use the `${applicationId}` manifest placeholder and every Kotlin call site builds authorities from `context.packageName`; broadcast actions (`com.webtoapp.action.*`) and the custom URI scheme are constant strings matched on both the manifest and code sides, independent of applicationId; `WtaAppPortDiscovery` targets dynamically resolved package names.

Fixes #537

## Test plan

- [x] Verified only `gplay` overrides the id: `defaultConfig` keeps `applicationId = "com.webtoapp"`; `standard` has no override.
- [x] Grepped manifest + Kotlin sources for hardcoded authority/package references (all dynamic or constant strings).
- [ ] CI: `Android CI Build / check` green (both flavors compile through the unit-test task's standard variant).