### PR TITLE
fix(signing): load imported custom keystores at startup again (bcProvider init order)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/JarSigner.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/JarSigner.kt
@@ -47,6 +47,22 @@ class JarSigner(private val context: Context) {
 
         private const val V1_SIGNER_NAME_MAX_LEN = 8
 
+        /**
+         * Full BouncyCastle (bundled dependency), used explicitly for *reading* keystores.
+         * The platform's stripped BC provider on many Android versions cannot decrypt PKCS12
+         * files written by modern keytool / Android Studio (PBES2 with AES-256), which is exactly
+         * the `.jks`-named file most users import. We never register it globally — instance-scoped
+         * lookups keep every other crypto path untouched.
+         *
+         * Must live in the companion, not as an instance `by lazy`: the `init` block runs
+         * `initializeKey()` before properties declared later in the class body are
+         * initialized, and the startup load of an already-imported custom keystore
+         * touches this provider during construction (#531).
+         */
+        private val bcProvider: Provider? by lazy {
+            runCatching { BouncyCastleProvider() }.getOrNull()
+        }
+
         private val GENERALIZED_TIME_FORMAT = threadLocalCompat {
             java.text.SimpleDateFormat("yyyyMMddHHmmss'Z'", Locale.US).apply {
                 timeZone = TimeZone.getTimeZone("UTC")
@@ -449,17 +465,6 @@ class JarSigner(private val context: Context) {
         }
 
         return password
-    }
-
-    /**
-     * Full BouncyCastle (bundled dependency), used explicitly for *reading* keystores.
-     * The platform's stripped BC provider on many Android versions cannot decrypt PKCS12
-     * files written by modern keytool / Android Studio (PBES2 with AES-256), which is exactly
-     * the `.jks`-named file most users import. We never register it globally — instance-scoped
-     * lookups keep every other crypto path untouched.
-     */
-    private val bcProvider: Provider? by lazy {
-        runCatching { BouncyCastleProvider() }.getOrNull()
     }
 
     /**

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/JarSignerRestartTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/JarSignerRestartTest.kt
@@ -1,0 +1,130 @@
+package com.webtoapp.core.apkbuilder
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.Date
+import javax.security.auth.x500.X500Principal
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Simulates an app restart between import and the next startup load: a fresh
+ * [JarSigner] instance re-runs initializeKey -> tryLoadCustomPkcs12 against the
+ * persisted keystore + sidecar files (issue #531: "custom signing certificate
+ * keeps being removed").
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class JarSignerRestartTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun forceModernPkcs12Algorithms() {
+            System.setProperty("keystore.pkcs12.certProtectionAlgorithm", "PBEWithHmacSHA256AndAES_256")
+            System.setProperty("keystore.pkcs12.keyProtectionAlgorithm", "PBEWithHmacSHA256AndAES_256")
+            System.setProperty("keystore.pkcs12.macAlgorithm", "HmacPBESHA256")
+        }
+    }
+
+    private val app get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun cleanPersistedSigningState() {
+        // Each test must start from a pristine filesDir: a leftover custom
+        // keystore from a previous test would flip the signer type.
+        listOf(
+            "custom_keystore.p12",
+            "custom_keystore_password.txt",
+            "custom_keystore_alias.txt",
+            "custom_keystore_keypass.txt",
+            "webtoapp_keystore.p12",
+            ".ks_credential"
+        ).forEach { File(app.filesDir, it).delete() }
+    }
+
+    private fun generateKeyPair(): KeyPair =
+        KeyPairGenerator.getInstance("RSA").apply { initialize(2048, SecureRandom()) }.generateKeyPair()
+
+    private fun selfSignedCertificate(keyPair: KeyPair): X509Certificate {
+        val subject = X500Principal("CN=Restart Test")
+        val now = System.currentTimeMillis()
+        val holder = JcaX509v3CertificateBuilder(
+            subject, BigInteger.valueOf(now), Date(now),
+            Date(now + 365L * 24L * 60L * 60L * 1000), subject, keyPair.public
+        ).build(JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private))
+        return JcaX509CertificateConverter().getCertificate(holder)
+    }
+
+    private fun tempKeystore(name: String): File =
+        File(app.cacheDir, name).apply { parentFile?.mkdirs() }
+
+    @Test
+    fun `imported PBES2 pkcs12 survives a restart`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("PKCS12")
+        ks.load(null, null)
+        ks.setKeyEntry("release", keyPair.private, "store123".toCharArray(), arrayOf(selfSignedCertificate(keyPair)))
+        val file = tempKeystore("restart-modern.p12")
+        file.outputStream().use { ks.store(it, "store123".toCharArray()) }
+
+        val importer = JarSigner(app)
+        val result = importer.importKeystore(file, "store123", null)
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.Success("release", "PKCS12"))
+
+        val restarted = JarSigner(app)
+        assertThat(restarted.getSignerType()).isEqualTo(JarSigner.SignerType.PKCS12_CUSTOM)
+        assertThat(restarted.getCertificateInfo()).isNotNull()
+    }
+
+    @Test
+    fun `converted jks survives a restart`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("JKS")
+        ks.load(null, null)
+        ks.setKeyEntry("suvoutsav", keyPair.private, "keypass".toCharArray(), arrayOf(selfSignedCertificate(keyPair)))
+        val file = tempKeystore("restart-separate.jks")
+        file.outputStream().use { ks.store(it, "storepass".toCharArray()) }
+
+        val importer = JarSigner(app)
+        val result = importer.importKeystore(file, "storepass", "keypass")
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.Success("suvoutsav", "JKS"))
+
+        val restarted = JarSigner(app)
+        assertThat(restarted.getSignerType()).isEqualTo(JarSigner.SignerType.PKCS12_CUSTOM)
+    }
+
+    @Test
+    fun `pkcs12 with user-entered separate key password survives a restart`() {
+        val keyPair = generateKeyPair()
+        val ks = KeyStore.getInstance("PKCS12")
+        ks.load(null, null)
+        ks.setKeyEntry("release", keyPair.private, "store123".toCharArray(), arrayOf(selfSignedCertificate(keyPair)))
+        val file = tempKeystore("restart-keypass.p12")
+        file.outputStream().use { ks.store(it, "store123".toCharArray()) }
+
+        // User fills the (meaningless for PKCS12) key password field — the
+        // sidecar persists it and the startup load must still recover via the
+        // store-password retry.
+        val importer = JarSigner(app)
+        val result = importer.importKeystore(file, "store123", "notTheStorePass")
+        assertThat(result).isEqualTo(JarSigner.KeystoreImportResult.Success("release", "PKCS12"))
+
+        val restarted = JarSigner(app)
+        assertThat(restarted.getSignerType()).isEqualTo(JarSigner.SignerType.PKCS12_CUSTOM)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #531 — "Custom signing certificate keeps being removed in the latest version".

**Root cause (regression from #526, shipped in 2.4.5):** the full-BouncyCastle provider added for reading imported keystores was declared as an instance `by lazy` property *after* the `init { initializeKey() }` block in the class body. Kotlin runs initializers in declaration order, so on devices with an already-imported custom keystore the constructor's startup load chain (`initializeKey → tryLoadCustomPkcs12 → loadPkcs12 → openKeyStore`) touched the lazy delegate **before it was initialized** → `NullPointerException` → swallowed by `loadPkcs12`'s catch → silent fallback to `PKCS12_AUTO`. The UI showed the auto-generated signer and built APKs were signed with the wrong key.

Why it looked like "removal": importing appeared to work (by the time `importKeystore` runs, construction has finished and the lazy is initialized — the in-process verification passes), but the next app start hit the NPE again, so the certificate "kept being removed" after every restart. Users who imported their keystore on 2.4.4 and upgraded — or anyone who restarted after importing on 2.4.5 — were affected.

**Fix:** move `bcProvider` into the companion object, whose initialization is independent of instance construction order (the provider is stateless, so sharing is safe), with a comment documenting why it must stay there.

**Test coverage added** (`JarSignerRestartTest`) — the dimension #526's matrix missed: a *fresh* `JarSigner` instance after import (simulated restart) must come back as `PKCS12_CUSTOM`:
- PBES2 PKCS12 (the Android Studio `.jks`-named file from #523)
- converted JKS with separate key password
- PKCS12 with a user-entered (meaningless for PKCS12) key password — exercises the store-password retry across restarts

All three failed with `expected: PKCS12_CUSTOM but was: PKCS12_AUTO` before the fix and pass after.

Fixes #531

## Test plan

- [x] `JarSignerRestartTest` (3, new): 3/3 red on `main`, 3/3 green with the fix.
- [x] `JarSignerKeystoreImportTest` (7, from #526): still green.
- [x] Full `:app:testStandardDebugUnitTest`: 811 tests, 0 failures; `:app:checkConfigFieldDrift` green.
- [x] `core/apkbuilder` is host-only (not shell-synced) — no template rebuild needed.
- [ ] CI: `Android CI Build / check` green.
- User-facing: after updating, an already-imported custom keystore survives restarts without re-importing.