### PR TITLE
fix(python): backend-first preview, raw-framework port coercion, auto server config

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -191,6 +191,9 @@ object Strings {
     val phpZipNoPhpFiles: String get() = StringsA.phpZipNoPhpFiles
     val pySelectProject: String get() = StringsA.pySelectProject
     val pyServerType: String get() = StringsA.pyServerType
+    val pyRuntimeModeAuto: String get() = StringsA.pyRuntimeModeAuto
+    val pyRuntimeModeAutoDesc: String get() = StringsA.pyRuntimeModeAutoDesc
+    val pythonStaticFallbackBanner: String get() = StringsA.pythonStaticFallbackBanner
     val pyProjectReady: String get() = StringsA.pyProjectReady
     val pyProjectNotFound: String get() = StringsA.pyProjectNotFound
     val pyStartingPreview: String get() = StringsA.pyStartingPreview
@@ -6711,6 +6714,45 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Тип сервера"
         AppLanguage.JAPANESE -> "サーバータイプ"
         AppLanguage.KOREAN -> "서버 유형"
+    }
+
+    val pyRuntimeModeAuto: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "自动配置（推荐）"
+        AppLanguage.ENGLISH -> "Auto-configured (recommended)"
+        AppLanguage.ARABIC -> "إعداد تلقائي (موصى به)"
+        AppLanguage.PORTUGUESE -> "Configuração automática (recomendado)"
+        AppLanguage.SPANISH -> "Configuración automática (recomendada)"
+        AppLanguage.FRENCH -> "Configuration automatique (recommandée)"
+        AppLanguage.GERMAN -> "Automatisch konfiguriert (empfohlen)"
+        AppLanguage.RUSSIAN -> "Автоматическая настройка (рекомендуется)"
+        AppLanguage.JAPANESE -> "自動設定（推奨）"
+        AppLanguage.KOREAN -> "자동 구성(권장)"
+    }
+
+    val pyRuntimeModeAutoDesc: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "已根据检测到的项目框架自动选择最兼容的运行方式，无需手动设置"
+        AppLanguage.ENGLISH -> "The most compatible runtime mode is selected automatically from the detected framework — no manual setup needed"
+        AppLanguage.ARABIC -> "يتم اختيار وضع التشغيل الأكثر توافقًا تلقائيًا حسب إطار العمل المكتشف — لا حاجة لإعداد يدوي"
+        AppLanguage.PORTUGUESE -> "O modo de execução mais compatível é escolhido automaticamente a partir do framework detectado — sem configuração manual"
+        AppLanguage.SPANISH -> "El modo de ejecución más compatible se selecciona automáticamente según el framework detectado; no requiere configuración manual"
+        AppLanguage.FRENCH -> "Le mode d'exécution le plus compatible est choisi automatiquement selon le framework détecté — aucune configuration manuelle"
+        AppLanguage.GERMAN -> "Der kompatibelste Laufzeitmodus wird automatisch anhand des erkannten Frameworks gewählt — keine manuelle Einrichtung nötig"
+        AppLanguage.RUSSIAN -> "Наиболее совместимый режим выполнения выбирается автоматически по обнаруженному фреймворку — ручная настройка не требуется"
+        AppLanguage.JAPANESE -> "検出されたフレームワークに基づいて最も互換性の高い実行モードが自動的に選択されます。手動設定は不要です"
+        AppLanguage.KOREAN -> "감지된 프레임워크에 따라 가장 호환되는 실행 모드가 자동으로 선택됩니다 — 수동 설정이 필요 없습니다"
+    }
+
+    val pythonStaticFallbackBanner: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "Python 后端未运行：当前为静态预览，接口请求不可用"
+        AppLanguage.ENGLISH -> "Python backend is not running — static preview only, API calls will fail"
+        AppLanguage.ARABIC -> "خادم Python لا يعمل — معاينة ثابتة فقط، ولن تعمل طلبات API"
+        AppLanguage.PORTUGUESE -> "O backend Python não está em execução — apenas visualização estática, chamadas de API falharão"
+        AppLanguage.SPANISH -> "El backend de Python no se está ejecutando: solo vista previa estática, las llamadas a la API fallarán"
+        AppLanguage.FRENCH -> "Le backend Python ne fonctionne pas — aperçu statique uniquement, les appels d'API échoueront"
+        AppLanguage.GERMAN -> "Python-Backend läuft nicht — nur statische Vorschau, API-Aufrufe schlagen fehl"
+        AppLanguage.RUSSIAN -> "Бэкенд Python не запущен — только статический предпросмотр, запросы к API не сработают"
+        AppLanguage.JAPANESE -> "Pythonバックエンドが実行されていません — 静的プレビューのみで、APIリクエストは失敗します"
+        AppLanguage.KOREAN -> "Python 백엔드가 실행 중이 아닙니다 — 정적 미리보기만 제공되며 API 요청은 실패합니다"
     }
 
     val pyProjectReady: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -621,7 +621,7 @@ ${if (escapedReqs.isNotBlank()) """<div class="section"><div class="section-titl
         return linkerPrefix + pythonArgs
     }
 
-    private fun createBootstrapScript(projectDir: File, port: Int) {
+    internal fun createBootstrapScript(projectDir: File, port: Int) {
         val bootstrapFile = File(projectDir, "_w2a_bootstrap.py")
         bootstrapFile.writeText("""#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -678,6 +678,33 @@ try:
         _orig_run(self, host='127.0.0.1', port=_w2a_port, **kwargs)
     flask.Flask.run = _patched_run
 except ImportError:
+    pass
+
+# === 2b. Force the allocated port for raw / http.server apps ===
+# Apps built on http.server / socketserver (raw framework) hardcode their own
+# port and never read PORT; rewrite TCPServer.__init__ so the bound port always
+# matches the one the WebView was loaded from and the health probe checks.
+try:
+    import socketserver as _w2a_socketserver
+    _w2a_orig_tcp_init = _w2a_socketserver.TCPServer.__init__
+    def _w2a_patched_tcp_init(self, server_address, *args, **kwargs):
+        if isinstance(server_address, tuple) and len(server_address) == 2:
+            host, port = server_address
+            if isinstance(port, int) and port != _w2a_port:
+                server_address = (host, _w2a_port)
+        _w2a_orig_tcp_init(self, server_address, *args, **kwargs)
+    _w2a_socketserver.TCPServer.__init__ = _w2a_patched_tcp_init
+except Exception:
+    pass
+
+# tornado listens through HTTPServer.listen(port), outside socketserver
+try:
+    import tornado.httpserver as _w2a_tornado_hs
+    _w2a_orig_t_listen = _w2a_tornado_hs.HTTPServer.listen
+    def _w2a_patched_t_listen(self, port, *args, **kwargs):
+        _w2a_orig_t_listen(self, _w2a_port, *args, **kwargs)
+    _w2a_tornado_hs.HTTPServer.listen = _w2a_patched_t_listen
+except Exception:
     pass
 
 # === 3. Execute the actual entry file ===

--- a/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreatePythonAppScreen.kt
@@ -64,7 +64,6 @@ fun CreatePythonAppScreen(
 
     var entryFile by remember { mutableStateOf("app.py") }
     var entryModule by remember { mutableStateOf("") }
-    var serverType by remember { mutableStateOf("builtin") }
     var serverPort by remember { mutableStateOf(0) }
     var portConflictMode by remember { mutableStateOf(com.webtoapp.data.model.PortConflictMode.AUTO_KILL) }
     var envVars by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
@@ -109,7 +108,6 @@ fun CreatePythonAppScreen(
                 app.pythonAppConfig?.let { config ->
                     entryFile = config.entryFile
                     entryModule = config.entryModule
-                    serverType = config.serverType
                     serverPort = config.serverPort
                     portConflictMode = config.portConflictMode
                     envVars = config.envVars.toMutableMap()
@@ -162,12 +160,6 @@ fun CreatePythonAppScreen(
 
                         val detected = runtime.detectEntryFile(copiedDir, framework)
                         entryFile = detected
-
-                        serverType = when (framework) {
-                            "fastapi" -> "uvicorn"
-                            "django" -> "gunicorn"
-                            else -> "builtin"
-                        }
 
                         val venvDirs = listOf("venv", ".venv", "env", ".env")
                         for (vDir in venvDirs) {
@@ -354,7 +346,11 @@ fun CreatePythonAppScreen(
                                 framework = detectedFramework ?: "raw",
                                 entryFile = entryFile,
                                 entryModule = entryModule,
-                                serverType = serverType,
+                                serverType = when (detectedFramework?.lowercase()) {
+                                    "fastapi" -> "uvicorn"
+                                    "django" -> "gunicorn"
+                                    else -> "builtin"
+                                },
                                 serverPort = serverPort,
                                 portConflictMode = portConflictMode,
                                 envVars = envVars,
@@ -405,11 +401,6 @@ fun CreatePythonAppScreen(
                                         val framework = runtime.detectFramework(projectDir)
                                         detectedFramework = framework
                                         entryFile = runtime.detectEntryFile(projectDir, framework)
-                                        serverType = when (framework) {
-                                            "fastapi" -> "uvicorn"
-                                            "django" -> "gunicorn"
-                                            else -> "builtin"
-                                        }
                                         appName = sample.name
                                         creationPhase = Strings.copyingProjectFiles
                                         val newProjectId = java.util.UUID.randomUUID().toString()
@@ -562,9 +553,7 @@ fun CreatePythonAppScreen(
                 }
 
                 PythonServerTypeCard(
-                    serverType = serverType,
                     detectedFramework = detectedFramework,
-                    onServerTypeChange = { serverType = it },
                     accentColor = accentColor
                 )
 
@@ -573,7 +562,7 @@ fun CreatePythonAppScreen(
                     onEntryFileChange = { entryFile = it },
                     entryModule = entryModule,
                     onEntryModuleChange = { entryModule = it },
-                    serverType = serverType
+                    detectedFramework = detectedFramework
                 )
 
                 if (detectedFramework == "django") {
@@ -842,16 +831,12 @@ private fun PythonRequirementsCard(
 
 @Composable
 private fun PythonServerTypeCard(
-    serverType: String,
     detectedFramework: String?,
-    onServerTypeChange: (String) -> Unit,
     accentColor: Color
 ) {
-    val recommendedServer = when (detectedFramework?.lowercase()) {
-        "fastapi" -> "uvicorn"
-        "django" -> "gunicorn"
-        "flask" -> "gunicorn"
-        else -> null
+    val serverMode = when (detectedFramework?.lowercase()) {
+        "fastapi" -> Strings.pyServerUvicorn
+        else -> Strings.pyServerBuiltin
     }
 
     EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
@@ -862,93 +847,31 @@ private fun PythonServerTypeCard(
             )
             Spacer(modifier = Modifier.height(12.dp))
 
-            PythonServerOption(
-                title = Strings.pyServerBuiltin,
-                description = Strings.pyServerBuiltinDesc,
-                selected = serverType == "builtin",
-                isRecommended = recommendedServer == null,
-                onClick = { onServerTypeChange("builtin") },
-                accentColor = accentColor
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            PythonServerOption(
-                title = Strings.pyServerGunicorn,
-                description = Strings.pyServerGunicornDesc,
-                selected = serverType == "gunicorn",
-                isRecommended = recommendedServer == "gunicorn",
-                onClick = { onServerTypeChange("gunicorn") },
-                accentColor = accentColor
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            PythonServerOption(
-                title = Strings.pyServerUvicorn,
-                description = Strings.pyServerUvicornDesc,
-                selected = serverType == "uvicorn",
-                isRecommended = recommendedServer == "uvicorn",
-                onClick = { onServerTypeChange("uvicorn") },
-                accentColor = accentColor
-            )
-        }
-    }
-}
-
-@Composable
-private fun PythonServerOption(
-    title: String,
-    description: String,
-    selected: Boolean,
-    isRecommended: Boolean,
-    onClick: () -> Unit,
-    accentColor: Color
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
-        color = if (selected) accentColor.copy(alpha = 0.08f)
-        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-        onClick = onClick
-    ) {
-        Row(
-            modifier = Modifier.padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            RadioButton(
-                selected = selected,
-                onClick = onClick,
-                colors = RadioButtonDefaults.colors(selectedColor = accentColor)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    shape = RoundedCornerShape(4.dp),
+                    color = accentColor.copy(alpha = 0.12f)
+                ) {
                     Text(
-                        title,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                        color = if (selected) accentColor else MaterialTheme.colorScheme.onSurface
+                        Strings.pyRuntimeModeAuto,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = accentColor
                     )
-                    if (isRecommended) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Surface(
-                            shape = RoundedCornerShape(4.dp),
-                            color = accentColor.copy(alpha = 0.12f)
-                        ) {
-                            Text(
-                                Strings.pyRecommended,
-                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = accentColor
-                            )
-                        }
-                    }
                 }
+                Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    description,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    serverMode,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold
                 )
             }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                Strings.pyRuntimeModeAutoDesc,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }
@@ -959,7 +882,7 @@ private fun PythonModuleConfigCard(
     onEntryFileChange: (String) -> Unit,
     entryModule: String,
     onEntryModuleChange: (String) -> Unit,
-    serverType: String
+    detectedFramework: String?
 ) {
     EnhancedElevatedCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -977,7 +900,7 @@ private fun PythonModuleConfigCard(
                 singleLine = true
             )
 
-            AnimatedVisibility(visible = serverType != "builtin") {
+            AnimatedVisibility(visible = detectedFramework?.lowercase() == "fastapi") {
                 Column {
                     Spacer(modifier = Modifier.height(8.dp))
                     PremiumTextField(
@@ -989,8 +912,7 @@ private fun PythonModuleConfigCard(
                         singleLine = true,
                         supportingText = {
                             Text(
-                                if (serverType == "gunicorn") "WSGI: module.wsgi:application"
-                                else "ASGI: module:app",
+                                "ASGI: module:app",
                                 style = MaterialTheme.typography.bodySmall,
                                 fontFamily = FontFamily.Monospace
                             )

--- a/app/src/main/java/com/webtoapp/ui/webview/PreviewStates.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/PreviewStates.kt
@@ -24,7 +24,11 @@ sealed class PythonAppPreviewState {
     object Starting : PythonAppPreviewState()
     object InstallingDeps : PythonAppPreviewState()
     object StartingServer : PythonAppPreviewState()
-    data class Ready(val url: String) : PythonAppPreviewState()
+    data class Ready(
+        val url: String,
+        /** True when the backend never started and only static files are served. */
+        val staticFallback: Boolean = false,
+    ) : PythonAppPreviewState()
     data class Error(val message: String, val throwable: Throwable? = null) : PythonAppPreviewState()
 }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/ServerPreviewOverlays.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/ServerPreviewOverlays.kt
@@ -3,6 +3,7 @@ package com.webtoapp.ui.webview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -241,4 +242,43 @@ private fun MirrorSourceInfo() {
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant
     )
+}
+
+@Composable
+fun PythonStaticFallbackBanner(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shadowElevation = 4.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Outlined.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                Strings.pythonStaticFallbackBanner,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onDismiss, modifier = Modifier.size(28.dp)) {
+                Icon(
+                    Icons.Outlined.Close,
+                    contentDescription = Strings.cdClose,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -1072,6 +1072,7 @@ fun WebViewScreen(
     val pythonRuntime = remember(webApp?.id) { com.webtoapp.core.python.PythonRuntime(context) }
     val pythonHttpServer = remember(webApp?.id) { com.webtoapp.core.webview.LocalHttpServer(context) }
     var pythonAppRetryTrigger by remember { mutableIntStateOf(0) }
+    var dismissedPythonFallbackBannerUrl by remember { mutableStateOf<String?>(null) }
 
     var nodeJsAppPreviewState by remember { mutableStateOf<NodeJsAppPreviewState>(NodeJsAppPreviewState.Idle) }
     val nodeRuntime = remember(webApp?.id) { com.webtoapp.core.nodejs.NodeRuntime(context) }
@@ -1769,26 +1770,9 @@ fun WebViewScreen(
         AppLogger.i("PythonAppPreview", "Final configuration: projectDir=${actualProjectDir.absolutePath}, framework=$actualFramework, entry=$actualEntryFile")
 
         try {
-            val candidates = listOf("dist", "build", "public", "static", "www", "templates", "")
-            var docRoot: File? = null
-            for (dir in candidates) {
-                val candidate = if (dir.isEmpty()) actualProjectDir else File(actualProjectDir, dir)
-                val hasIndex = File(candidate, "index.html").exists()
-                AppLogger.d("PythonAppPreview", "Checking candidate: '$dir' -> ${candidate.absolutePath}, isDir=${candidate.isDirectory}, hasIndex=$hasIndex")
-                if (candidate.isDirectory && hasIndex) {
-                    docRoot = candidate
-                    AppLogger.i("PythonAppPreview", "Found docRoot: ${candidate.absolutePath}")
-                    break
-                }
-            }
+            val entryFileExists = File(actualProjectDir, actualEntryFile).exists()
 
-            if (docRoot != null) {
-                val url = pythonHttpServer.start(docRoot)
-                AppLogger.i("PythonAppPreview", "LocalHttpServer started: $url")
-                pythonAppPreviewState = PythonAppPreviewState.Ready(url)
-                delay(200)
-                loadInBrowser(url)
-            } else if (pythonRuntime.isPythonAvailable()) {
+            if (pythonRuntime.isPythonAvailable() && entryFileExists) {
 
                 AppLogger.i("PythonAppPreview", "Python runtime available, starting backend server")
                 pythonAppPreviewState = PythonAppPreviewState.StartingServer
@@ -1833,7 +1817,10 @@ fun WebViewScreen(
                 }
             } else {
 
-                AppLogger.w("PythonAppPreview", "Python runtime unavailable, generating project preview page")
+                AppLogger.w(
+                    "PythonAppPreview",
+                    "Static fallback preview: pythonAvailable=${pythonRuntime.isPythonAvailable()}, entryExists=$entryFileExists"
+                )
                 val url = pythonHttpServer.start(actualProjectDir)
                 File(actualProjectDir, "_preview_.html").delete()
 
@@ -1841,7 +1828,7 @@ fun WebViewScreen(
                 if (htmlFiles.isNotEmpty()) {
                     val relPath = htmlFiles.first().relativeTo(actualProjectDir).path
                     val targetUrl = "$url/$relPath"
-                    pythonAppPreviewState = PythonAppPreviewState.Ready(targetUrl)
+                    pythonAppPreviewState = PythonAppPreviewState.Ready(targetUrl, staticFallback = true)
                     delay(200)
                     loadInBrowser(targetUrl)
                 } else {
@@ -1853,7 +1840,7 @@ fun WebViewScreen(
                     val previewFile = File(actualProjectDir, "_preview_.html")
                     previewFile.writeText(previewHtml)
                     val targetUrl = "$url/_preview_.html"
-                    pythonAppPreviewState = PythonAppPreviewState.Ready(targetUrl)
+                    pythonAppPreviewState = PythonAppPreviewState.Ready(targetUrl, staticFallback = true)
                     delay(200)
                     loadInBrowser(targetUrl)
                 }
@@ -3248,6 +3235,17 @@ fun WebViewScreen(
                 PythonAppLoadingOverlay(
                     state = pythonAppPreviewState,
                     onRetry = { pythonAppRetryTrigger++ }
+                )
+            }
+
+            val pythonReadyState = pythonAppPreviewState as? PythonAppPreviewState.Ready
+            if (webApp?.appType == com.webtoapp.data.model.AppType.PYTHON_APP &&
+                pythonReadyState?.staticFallback == true &&
+                pythonReadyState.url != dismissedPythonFallbackBannerUrl
+            ) {
+                PythonStaticFallbackBanner(
+                    onDismiss = { dismissedPythonFallbackBannerUrl = pythonReadyState.url },
+                    modifier = Modifier.align(Alignment.TopCenter)
                 )
             }
 

--- a/app/src/test/java/com/webtoapp/core/python/PythonRuntimeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/PythonRuntimeTest.kt
@@ -3,6 +3,7 @@ package com.webtoapp.core.python
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStreamReader
 import java.net.InetAddress
 import java.net.ServerSocket
@@ -109,5 +110,33 @@ class PythonRuntimeTest {
         val budget = ReadinessBudget(baseMs = 1_000L, hardCapMs = 3_000L)
         val ready = runBlocking { runtime.waitForServerReady(port, "flask", budget) }
         assertThat(ready).isFalse()
+    }
+
+    @Test
+    fun `bootstrap script forces the allocated port beyond Flask`() {
+        val runtime = PythonRuntime(context)
+        val dir = File(context.cacheDir, "bootstrap-test-${System.nanoTime()}").apply { mkdirs() }
+        try {
+            runtime.createBootstrapScript(dir, 19527)
+            val script = File(dir, "_w2a_bootstrap.py").readText()
+
+            // Flask patch (health endpoint + forced port) stays in place
+            assertThat(script).contains("flask.Flask.run")
+            assertThat(script).contains("__w2a_health")
+
+            // raw / http.server apps hardcode their port and never read PORT;
+            // TCPServer.__init__ must rewrite it to the allocated one
+            assertThat(script).contains("TCPServer.__init__")
+            assertThat(script).contains("_w2a_port")
+            assertThat(script).contains("os.environ['PORT'] = str(_w2a_port)")
+
+            // tornado listens through HTTPServer.listen, outside socketserver
+            assertThat(script).contains("HTTPServer.listen")
+
+            // the entry file still runs as __main__ with clean argv
+            assertThat(script).contains("'__name__': '__main__'")
+        } finally {
+            dir.deleteRecursively()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #545

Python apps whose project directory contains `index.html` were never actually starting Python in the host preview: a docRoot check served the project statically via `LocalHttpServer` and every backend API call 404'd with no error surfaced — the exact failure in the user feedback behind #545 (`http.server` demo app, page rendered at 18000, `Unexpected token < in JSON`).

- **Backend-first preview** (`WebViewActivity`): start the Python server whenever the runtime is available and an entry file exists. Static serving is now strictly a fallback (runtime unavailable / startup failed / no entry) and shows a dismissible banner; startup failures keep the existing error-report page with stderr.
- **Raw-framework port coercion** (`PythonRuntime` bootstrap, shell-synced): patch `socketserver.TCPServer.__init__` (covers `http.server` raw apps and Flask/werkzeug as a second net) and tornado `HTTPServer.listen` so hardcoded listen ports are rewritten onto the PortManager-allocated port. No user code changes required.
- **Auto server config** (`CreatePythonAppScreen`): the server-type picker was never consumed at runtime (the launch command derives from the framework only) — replaced by an "auto-configured" info card showing the derived mode (Uvicorn for FastAPI, built-in dev server otherwise). `serverType` remains in the config model for compatibility and is derived at save time; the WSGI/ASGI module field now only shows for FastAPI.

## Test plan

- [x] `:app:testStandardDebugUnitTest` — `com.webtoapp.core.python.*` (5/5 in `PythonRuntimeTest` including the new bootstrap-content assertions), `StringsKtTranslationParityTest`, `AppStringsResourceConsistencyTest`
- [x] `:app:compileStandardDebugKotlin`
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` (template rebuilt `--rerun-tasks`; new bootstrap verified synced into shell sources)
- [ ] Manual: import the feedback project (raw `http.server` `app.py` + `index.html`), preview shows the live backend and `/api/*` returns JSON