### PR TITLE
fix(webview): request the Android 17 local-network permission for LAN URLs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,10 @@
     <!-- ====== 网络（宿主必需：加载网页、下载运行时、推送请求）====== -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- 宿主使用：预览/分析局域网地址。Android 16 opt-in、17 强制（部分 ROM 不分
+         targetSdk 直接强制）；缺失时 LAN 请求超时或报 ERR_LOCAL_NETWORK_PERMISSION_MISSING。
+         旧系统会忽略未知权限，无副作用。 -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <!-- ====== 存储 / 媒体（宿主必需：选择图标、导入 HTML、素材库）====== -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -194,6 +194,7 @@ object Strings {
     val pyRuntimeModeAuto: String get() = StringsA.pyRuntimeModeAuto
     val pyRuntimeModeAutoDesc: String get() = StringsA.pyRuntimeModeAutoDesc
     val pythonStaticFallbackBanner: String get() = StringsA.pythonStaticFallbackBanner
+    val siteAnalyzeLanTimeoutHint: String get() = StringsA.siteAnalyzeLanTimeoutHint
     val pyProjectReady: String get() = StringsA.pyProjectReady
     val pyProjectNotFound: String get() = StringsA.pyProjectNotFound
     val pyStartingPreview: String get() = StringsA.pyStartingPreview
@@ -6753,6 +6754,19 @@ object StringsA {
         AppLanguage.RUSSIAN -> "Бэкенд Python не запущен — только статический предпросмотр, запросы к API не сработают"
         AppLanguage.JAPANESE -> "Pythonバックエンドが実行されていません — 静的プレビューのみで、APIリクエストは失敗します"
         AppLanguage.KOREAN -> "Python 백엔드가 실행 중이 아닙니다 — 정적 미리보기만 제공되며 API 요청은 실패합니다"
+    }
+
+    val siteAnalyzeLanTimeoutHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "连接局域网地址超时：请确认与目标设备在同一网络，并在系统设置中允许本应用访问本地网络/局域网"
+        AppLanguage.ENGLISH -> "Timed out connecting to a LAN address: make sure you are on the same network as the target device, and allow local network access for this app in system settings"
+        AppLanguage.ARABIC -> "انتهت مهلة الاتصال بعنوان شبكة محلية: تأكد من أنك على نفس شبكة الجهاز الهدف، واسمح لهذا التطبيق بالوصول إلى الشبكة المحلية في إعدادات النظام"
+        AppLanguage.PORTUGUESE -> "Tempo esgotado ao conectar a um endereço de rede local: verifique se você está na mesma rede do dispositivo de destino e permita o acesso à rede local para este app nas configurações do sistema"
+        AppLanguage.SPANISH -> "Se agotó el tiempo de conexión a una dirección de red local: compruebe que está en la misma red que el dispositivo de destino y permita el acceso a la red local para esta app en los ajustes del sistema"
+        AppLanguage.FRENCH -> "Délai dépassé lors de la connexion à une adresse réseau locale : vérifiez que vous êtes sur le même réseau que l'appareil cible et autorisez l'accès au réseau local pour cette application dans les paramètres système"
+        AppLanguage.GERMAN -> "Zeitüberschreitung bei der Verbindung zu einer lokalen Netzwerkadresse: Stellen Sie sicher, dass Sie sich im selben Netzwerk wie das Zielgerät befinden, und erlauben Sie dieser App in den Systemeinstellungen den Zugriff auf das lokale Netzwerk"
+        AppLanguage.RUSSIAN -> "Истекло время ожидания при подключении к локальному сетевому адресу: убедитесь, что вы в одной сети с целевым устройством, и разрешите этому приложению доступ к локальной сети в настройках системы"
+        AppLanguage.JAPANESE -> "ローカルネットワークアドレスへの接続がタイムアウトしました：対象デバイスと同じネットワークにいることを確認し、システム設定でこのアプリのローカルネットワークへのアクセスを許可してください"
+        AppLanguage.KOREAN -> "로컬 네트워크 주소 연결 시간이 초과되었습니다: 대상 기기와 같은 네트워크에 있는지 확인하고, 시스템 설정에서 이 앱의 로컬 네트워크 접근을 허용해 주세요"
     }
 
     val pyProjectReady: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/pwa/PwaAnalyzer.kt
+++ b/app/src/main/java/com/webtoapp/core/pwa/PwaAnalyzer.kt
@@ -208,7 +208,7 @@ object PwaAnalyzer {
                 FetchTextResult.Success(body = content, finalUrl = finalUrl)
             }
         } catch (e: Exception) {
-            val userMessage = buildExceptionMessage(e, kind)
+            val userMessage = buildExceptionMessage(e, kind, url)
             AppLogger.e(TAG, "${kind.name} request failed for $url: $userMessage", e)
             FetchTextResult.Failure(userMessage = userMessage)
         }
@@ -242,12 +242,17 @@ object PwaAnalyzer {
         }
     }
 
-    private fun buildExceptionMessage(error: Exception, kind: RequestKind): String {
+    private fun buildExceptionMessage(error: Exception, kind: RequestKind, url: String): String {
+        // LAN denials under the Android 16/17 local-network permission surface as silent
+        // TCP timeouts, so a timing-out private address gets a targeted hint.
+        val lanHint = com.webtoapp.core.webview.LocalNetworkPermission.isPrivateNetworkUrl(url)
         return when (error) {
             is UnknownHostException -> "无法解析站点地址"
             is SocketTimeoutException, is InterruptedIOException ->
                 if (kind == RequestKind.MANIFEST) {
                     "Manifest 请求超时"
+                } else if (lanHint) {
+                    Strings.siteAnalyzeLanTimeoutHint
                 } else {
                     "站点连接超时，目标站点可能拦截了自动分析请求"
                 }
@@ -255,6 +260,8 @@ object PwaAnalyzer {
             is IOException ->
                 if (kind == RequestKind.MANIFEST) {
                     "Manifest 下载失败"
+                } else if (lanHint) {
+                    Strings.siteAnalyzeLanTimeoutHint
                 } else {
                     "无法访问网站，目标站点可能拒绝了自动分析请求"
                 }

--- a/app/src/main/java/com/webtoapp/core/webview/LocalNetworkPermission.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/LocalNetworkPermission.kt
@@ -1,0 +1,96 @@
+package com.webtoapp.core.webview
+
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Local network access permission, introduced in Android 16 (opt-in) and enforced from
+ * Android 17 / SDK 37 for apps targeting 37+; some OEM ROMs enforce it regardless of
+ * targetSdk. Without the grant, traffic to LAN hosts is blocked deep in the network
+ * stack: WebView fails with ERR_LOCAL_NETWORK_PERMISSION_MISSING and plain TCP sockets
+ * silently time out. Loopback (127.0.0.1) is never restricted, so on-device local server
+ * runtimes keep working.
+ *
+ * The permission constant only exists from SDK 37 while this project compiles against
+ * SDK 36, hence the hardcoded string.
+ */
+object LocalNetworkPermission {
+    const val PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+
+    /** SDKs below 36 grant local network access implicitly via INTERNET. */
+    fun isGranted(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < 36) return true
+        return ContextCompat.checkSelfPermission(context, PERMISSION) == PackageManager.PERMISSION_GRANTED
+    }
+
+    fun isPrivateNetworkUrl(url: String?): Boolean {
+        if (url.isNullOrBlank()) return false
+        val host = try {
+            android.net.Uri.parse(url).host ?: return false
+        } catch (_: Exception) {
+            return false
+        }
+        return isPrivateNetworkHost(host)
+    }
+
+    fun isPrivateNetworkHost(host: String): Boolean {
+        val h = host.trim().lowercase().removeSuffix(".")
+        if (h.isEmpty()) return false
+
+        // Loopback is exempt from the permission by design.
+        if (h == "localhost" || h == "::1" || h == "127.0.0.1" || h.startsWith("127.")) return false
+
+        if (h == "local" || h.endsWith(".local")) return true
+
+        val v4 = h.removeSurrounding("[", "]")
+        val parts = v4.split(".")
+        if (parts.size == 4 && parts.all { it.toIntOrNull() in 0..255 }) {
+            val a = parts[0].toInt()
+            val b = parts[1].toInt()
+            return when {
+                a == 10 -> true                              // 10.0.0.0/8
+                a == 192 && b == 168 -> true                 // 192.168.0.0/16
+                a == 172 && b in 16..31 -> true              // 172.16.0.0/12
+                a == 169 && b == 254 -> true                 // 169.254.0.0/16 link-local
+                else -> false
+            }
+        }
+
+        // IPv6 without dots: unique-local fc00::/7 and link-local fe80::/10.
+        if (!h.contains(".")) {
+            val firstGroup = h.substringBefore(":").takeIf { it.isNotEmpty() }?.toIntOrNull(16)
+            if (firstGroup != null) {
+                if ((firstGroup shr 8) == 0xfc || (firstGroup shr 8) == 0xfd) return true
+                if ((firstGroup and 0xffc0) == 0xfe80) return true
+            }
+        }
+        return false
+    }
+
+    fun isLocalNetworkBlockedError(description: String?): Boolean {
+        return description?.contains("ERR_LOCAL_NETWORK", ignoreCase = true) == true
+    }
+
+    /**
+     * A permission prompt is warranted only on SDKs that have the permission, when it is
+     * not granted yet, and when either the failing request targeted the local network
+     * (LAN denials surface as timeouts) or the WebView error explicitly names it.
+     */
+    fun shouldRequest(context: Context, failedUrl: String?, errorDescription: String? = null): Boolean {
+        if (Build.VERSION.SDK_INT < 36) return false
+        if (isGranted(context)) return false
+        return isLocalNetworkBlockedError(errorDescription) || isPrivateNetworkUrl(failedUrl)
+    }
+
+    fun request(activity: Activity): Boolean {
+        return try {
+            activity.requestPermissions(arrayOf(PERMISSION), 4354)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -2411,6 +2411,14 @@ class WebViewManager(
                         }
                     }
 
+                    if (view != null) {
+                        // On ROMs enforcing the Android 17 local-network permission, LAN
+                        // loads fail here with ERR_LOCAL_NETWORK_PERMISSION_MISSING or a
+                        // bare timeout; request the permission and auto-reload on grant.
+                        // The error page below still shows while the dialog is pending.
+                        maybeRequestLocalNetworkPermission(view, failedUrl, rawDescription)
+                    }
+
                     if (view != null && failedUrl.startsWith("file://")) {
                         val isSameRetry = failedUrl == fileRetryUrl
                         val currentRetry = if (isSameRetry) fileRetryCount else 0
@@ -2831,6 +2839,58 @@ class WebViewManager(
             current = base
         }
         return current as? Activity
+    }
+
+    private val localNetworkPermissionRequestedUrls = mutableSetOf<String>()
+
+    /**
+     * Fires the local-network permission dialog for a failing LAN main-frame request.
+     * The manager has no hook into the hosting activity's onRequestPermissionsResult,
+     * so grant detection is a bounded poll instead; on grant the page reloads, on
+     * denial the already-rendered error page stays. Each failed URL prompts at most
+     * once per WebViewManager instance.
+     */
+    private fun maybeRequestLocalNetworkPermission(view: WebView, failedUrl: String, errorDescription: String) {
+        if (!LocalNetworkPermission.shouldRequest(context, failedUrl, errorDescription)) return
+        if (!localNetworkPermissionRequestedUrls.add(failedUrl)) {
+            AppLogger.d("WebViewManager", "Local network permission already requested for: $failedUrl")
+            return
+        }
+        val activity = try {
+            view.context.findActivity()
+        } catch (_: Exception) {
+            null
+        }
+        if (activity == null || activity.isFinishing || activity.isDestroyed) {
+            AppLogger.w("WebViewManager", "Local network permission request skipped: no active activity")
+            return
+        }
+        if (!LocalNetworkPermission.request(activity)) {
+            localNetworkPermissionRequestedUrls.remove(failedUrl)
+            return
+        }
+        AppLogger.i("WebViewManager", "Requested local network permission for: $failedUrl")
+        pollLocalNetworkGrant(view, failedUrl, attempts = 75)
+    }
+
+    private fun pollLocalNetworkGrant(view: WebView, url: String, attempts: Int) {
+        if (attempts <= 0) return
+        view.postDelayed({
+            // The interim error page reports about:blank / file:/// as its URL; treat
+            // those as "still on the failed page" and only give up once the user has
+            // navigated to a genuinely different destination.
+            val current = view.url
+            if (current != null && current != url && current != "about:blank" && !current.startsWith("file:///")) {
+                AppLogger.d("WebViewManager", "Skip local network reload, WebView navigated away: $current")
+                return@postDelayed
+            }
+            if (LocalNetworkPermission.isGranted(context)) {
+                AppLogger.i("WebViewManager", "Local network permission granted, reloading: $url")
+                view.loadUrl(url)
+            } else {
+                pollLocalNetworkGrant(view, url, attempts - 1)
+            }
+        }, 800)
     }
 
     private fun normalizeNetworkErrorDescription(rawDescription: String): String {

--- a/app/src/test/java/com/webtoapp/core/webview/LocalNetworkPermissionTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/LocalNetworkPermissionTest.kt
@@ -1,0 +1,88 @@
+package com.webtoapp.core.webview
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class LocalNetworkPermissionTest {
+
+    private val context: Context = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun `loopback hosts are never private network`() {
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("127.0.0.1")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("127.0.1.5")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("localhost")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("LOCALHOST")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("::1")).isFalse()
+    }
+
+    @Test
+    fun `private IPv4 ranges are detected`() {
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("192.168.1.188")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("10.0.0.1")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("10.255.255.255")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("172.16.0.1")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("172.31.255.255")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("169.254.10.20")).isTrue()
+    }
+
+    @Test
+    fun `public IPv4 ranges are not private network`() {
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("8.8.8.8")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("172.15.0.1")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("172.32.0.1")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("192.169.1.1")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("11.0.0.1")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("100.100.100.100")).isFalse()
+    }
+
+    @Test
+    fun `local names and private IPv6 are private network`() {
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("nas.local")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("printer.LOCAL.")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("fe80::1a2b")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("fd12:3456::1")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("fc00::5")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("2001:db8::1")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkHost("example.com")).isFalse()
+    }
+
+    @Test
+    fun `urls are classified by their host`() {
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("http://192.168.1.188:3000")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("http://10.1.2.3:8080/path?q=1")).isTrue()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("http://localhost:5000")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("http://127.0.0.1:19500/")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("https://example.com")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl(null)).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("")).isFalse()
+        assertThat(LocalNetworkPermission.isPrivateNetworkUrl("not a url")).isFalse()
+    }
+
+    @Test
+    fun `webview local network errors are recognized`() {
+        assertThat(
+            LocalNetworkPermission.isLocalNetworkBlockedError("net::ERR_LOCAL_NETWORK_PERMISSION_MISSING")
+        ).isTrue()
+        assertThat(LocalNetworkPermission.isLocalNetworkBlockedError("ERR_CONNECTION_TIMED_OUT")).isFalse()
+        assertThat(LocalNetworkPermission.isLocalNetworkBlockedError(null)).isFalse()
+    }
+
+    @Test
+    fun `below SDK 36 the permission is implicitly granted and never requested`() {
+        // Robolectric runs at SDK 33 here: the permission does not exist on this
+        // platform, so access is implicitly granted via INTERNET and no prompt is due.
+        assertThat(LocalNetworkPermission.isGranted(context)).isTrue()
+        assertThat(LocalNetworkPermission.shouldRequest(context, "http://192.168.1.188:3000")).isFalse()
+        assertThat(
+            LocalNetworkPermission.shouldRequest(context, "https://example.com", "ERR_LOCAL_NETWORK_PERMISSION_MISSING")
+        ).isFalse()
+    }
+}

--- a/shell/src/main/AndroidManifest.xml
+++ b/shell/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <!-- Android 16 opt-in / Android 17 enforced on some ROMs regardless of targetSdk;
+         without it LAN hosts fail with ERR_LOCAL_NETWORK_PERMISSION_MISSING. Harmless on
+         older releases (unknown permissions are ignored). -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"


### PR DESCRIPTION
## Summary

Fixes #544

Devices enforcing the new `ACCESS_LOCAL_NETWORK` permission block LAN traffic at the network stack: WebView fails with `ERR_LOCAL_NETWORK_PERMISSION_MISSING` and plain TCP sockets silently time out. This hits both the host editor ("分析网站" timeout in the report) and generated APKs (the explicit WebView error). Loopback is exempt, so on-device local server runtimes are unaffected.

- Declare `ACCESS_LOCAL_NETWORK` in the **shell template** and **host** manifests (older releases ignore the unknown permission; SDK 36 is where it starts existing).
- New shell-synced `LocalNetworkPermission` helper: private-range host/URL detection (10/8, 172.16/12, 192.168/16, 169.254/16, `.local`, IPv6 ULA/link-local; loopback excluded), grant check (implicitly granted below SDK 36), and the permission request itself.
- The shared `WebViewManager.onReceivedError` now reacts to failing main-frame LAN requests on SDK ≥ 36 without the grant: prompts once per failed URL and polls for the grant to auto-reload; the interim error page still renders so a denial loses nothing. The permission literal is hardcoded because `Manifest.permission.ACCESS_LOCAL_NETWORK` only exists from SDK 37 while we compile against 36.
- `PwaAnalyzer` swaps the generic timeout wording for a targeted LAN hint (same network / allow local-network access in system settings) when a private-address analysis times out. New string covers all 10 languages.

## Test plan

- [x] `:app:testStandardDebugUnitTest` — new `LocalNetworkPermissionTest` (7/7: loopback/private/public ranges, `.local` + IPv6, URL classification, error recognition, SDK gating), full `com.webtoapp.core.webview.*` package, `StringsKtTranslationParityTest`, `AppStringsResourceConsistencyTest`
- [x] `:app:compileStandardDebugKotlin`
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` rebuilt `--rerun-tasks`
- [ ] Manual on an enforcing ROM (e.g. Xiaomi/HyperOS on Android 16/17): open a `http://192.168.x.x` app → permission prompt appears → allow → page reloads

**Immediate workaround for affected users (no app update needed):** system settings → app info → permissions → allow *Local network / 局域网访问* for both WebToApp and the generated app.