### PR TITLE
build(host): raise targetSdk to 35 (antivirus legacy-malware flagging)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,7 @@ android {
         applicationId = "com.webtoapp"
         minSdk = 23
 
-        targetSdk = 28
+        targetSdk = 35
         versionCode = 55
         versionName = "2.4.5"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
@@ -80,22 +80,26 @@ android {
     flavorDimensions += "distribution"
     productFlavors {
         create("standard") {
-            // Default full-capability variant: targetSdk 28 is required so the host can
-            // fork+exec native server runtimes (Node/PHP/Python/Go/WordPress) from app
-            // storage. Keep this low — do not raise without re-validating every runtime.
+            // Full-capability sideloaded variant (GitHub releases, keeps `com.webtoapp`).
+            // Inherits targetSdk 35 from defaultConfig: low targetSdk is a top heuristic
+            // for antivirus / Play Protect "legacy malware" flags, which got the host
+            // wrongly blocked. The cost is SELinux W^X (applies from targetSdk 29):
+            // exec of downloaded runtimes (Python / PHP / WordPress) from app storage is
+            // blocked, so those host previews degrade with a clear message
+            // (RuntimeExecPolicy). Node (JNI via native libs) and Go (memfd exec) are
+            // unaffected. Generated APKs still ship targetSdk 28 via the shell template.
             buildConfigField("boolean", "GPLAY_CHANNEL", "false")
         }
         create("gplay") {
-            // Google Play distribution variant. Play requires targetSdk 35+ for new apps.
-            // NOTE: native fork+exec runtimes (esp. Node.js V8 JIT, Go memfd exec) may fail
-            // under the stricter SELinux policy of high targetSdk; runtime launch is guarded
-            // to degrade gracefully (see BuildConfig.GPLAY_CHANNEL) rather than crash.
+            // Google Play distribution variant (Play requires targetSdk 35+; inherits 35
+            // from defaultConfig). Native fork+exec runtimes (esp. Node.js V8 JIT, Go
+            // memfd exec) may still fail under the stricter SELinux policy; launch paths
+            // degrade gracefully rather than crash.
             //
             // `com.webtoapp` is already registered on Google Play by another party, so the
             // Play build ships under a distinct applicationId. The standard flavor (GitHub
             // releases) keeps `com.webtoapp` so existing users keep their update path.
             applicationId = "shiaho.webtoapp"
-            targetSdk = 35
             buildConfigField("boolean", "GPLAY_CHANNEL", "true")
         }
     }

--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -25,18 +25,19 @@ class GoRuntime(private val context: Context) {
         private const val TAG = "GoRuntime"
         private const val MAX_HEALTH_CHECK_RETRIES = 30
         private const val HEALTH_CHECK_INTERVAL_MS = 500L
-
-        /**
-         * Go execs via memfd_create + execveat, which is increasingly restricted under the SELinux
-         * policy of a high-targetSdk (Google Play) channel. Surface the channel limitation on
-         * launch failure instead of looking like a generic crash.
-         * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
-         */
-        private fun channelNote(): String =
-            if (com.webtoapp.BuildConfig.GPLAY_CHANNEL) {
-                " [Google Play 渠道：受高 targetSdk 限制，Go 运行时可能不可用]"
-            } else ""
     }
+
+    /**
+     * Go execs via memfd_create + execveat, which is increasingly restricted under the SELinux
+     * policy of a high-targetSdk build. Surface the restriction on launch failure instead of
+     * looking like a generic crash. Keyed off the actual app targetSdk (not the channel flag)
+     * so every high-target build gets the note.
+     * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
+     */
+    private fun channelNote(): String =
+        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+            com.webtoapp.core.linux.RuntimeExecPolicy.restrictionNote()
+        } else ""
 
     sealed class ServerState {
         object Stopped : ServerState()

--- a/app/src/main/java/com/webtoapp/core/linux/RuntimeExecPolicy.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/RuntimeExecPolicy.kt
@@ -1,0 +1,36 @@
+package com.webtoapp.core.linux
+
+import android.content.Context
+
+/**
+ * SELinux W^X policy gate for on-device fork+exec runtimes.
+ *
+ * Apps targeting SDK 29+ lose the ability to exec (or mmap PROT_EXEC) files in app
+ * data storage — which is exactly where the on-demand server runtimes (Python / PHP /
+ * WordPress) are downloaded and extracted. Binaries shipped as APK native libs
+ * (Node.js via the JNI bridge) and memfd-exec loaders (Go) are not affected.
+ *
+ * Generated APKs keep targetSdk 28, so this only ever gates the *host preview*
+ * runtimes; inside a generated app the probe always passes.
+ */
+object RuntimeExecPolicy {
+
+    fun canExecAppDataBinaries(context: Context): Boolean {
+        val target = try {
+            context.applicationInfo.targetSdkVersion
+        } catch (_: Exception) {
+            28
+        }
+        return target < 29
+    }
+
+    /**
+     * Runtime-layer suffix appended to launch failures under the restriction.
+     * (shell-synced runtime string; intentionally not routed through Strings i18n)
+     */
+    fun restrictionNote(): String =
+        " [受 targetSdk≥29 SELinux 限制，无法执行应用数据目录中的本地运行时]"
+
+    fun hostPreviewBlockedMessage(runtimeName: String): String =
+        "当前构建 targetSdk≥29，系统安全策略禁止从应用数据目录启动 $runtimeName 运行时，本地服务器预览不可用"
+}

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeService.kt
@@ -25,18 +25,19 @@ class NodeService : Service() {
         private const val TAG = "NodeService"
         private const val MAX_HEALTH_CHECK_RETRIES = 60
         private const val HEALTH_CHECK_INTERVAL_MS = 500L
-
-        /**
-         * Node.js runs via dlopen(libnode.so) + V8 JIT, which needs RWX memory. Under the stricter
-         * SELinux policy of a high-targetSdk (Google Play) channel this can fail at dlopen/exec time.
-         * Surface the channel limitation to the user instead of looking like a generic crash.
-         * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
-         */
-        private fun channelNote(): String =
-            if (com.webtoapp.BuildConfig.GPLAY_CHANNEL) {
-                " [Google Play 渠道：受高 targetSdk 限制，Node.js 运行时可能不可用]"
-            } else ""
     }
+
+    /**
+     * Node.js runs via dlopen(libnode.so) + V8 JIT, which needs RWX memory. Under the stricter
+     * SELinux policy of a high-targetSdk build this can fail at dlopen/exec time. Surface the
+     * restriction to the user instead of looking like a generic crash. Keyed off the actual
+     * app targetSdk (not the channel flag) so every high-target build gets the note.
+     * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
+     */
+    private fun channelNote(): String =
+        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(applicationContext)) {
+            com.webtoapp.core.linux.RuntimeExecPolicy.restrictionNote()
+        } else ""
 
     private val workerThread = HandlerThread("NodeService-worker").apply { start() }
     private val workerHandler = Handler(workerThread.looper)

--- a/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
@@ -75,6 +75,13 @@ class PhpAppRuntime(private val context: Context) {
         customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()
     ): Int = withContext(Dispatchers.IO) {
         try {
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+                _serverState.value = ServerState.Error(
+                    com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("PHP")
+                )
+                return@withContext -1
+            }
+
             if (!isPhpAvailable()) {
                 _serverState.value = ServerState.Error("PHP 二进制未就绪，请先下载依赖")
                 return@withContext -1

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -318,6 +318,13 @@ object PythonDependencyManager {
         extraEnv: Map<String, String> = emptyMap(),
         onOutput: ((String) -> Unit)? = null
     ): Boolean = withContext(Dispatchers.IO) {
+        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+            val msg = com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("Python")
+            AppLogger.w(TAG, msg)
+            onOutput?.invoke(msg)
+            return@withContext false
+        }
+
         val reqFile = File(projectDir, "requirements.txt")
         if (!reqFile.exists()) {
             AppLogger.i(TAG, "No requirements.txt, skipping dependency install")

--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -79,6 +79,14 @@ class PythonRuntime(private val context: Context) {
         customPythonExtensions: List<com.webtoapp.data.model.CustomPythonExtension> = emptyList()
     ): Int = withContext(Dispatchers.IO) {
         try {
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+                val msg = com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("Python")
+                AppLogger.w(TAG, msg)
+                ShellLogger.w(TAG, msg)
+                _serverState.value = ServerState.Error(msg)
+                return@withContext -1
+            }
+
             if (!isPythonAvailable()) {
                 _serverState.value = ServerState.Error("Python 运行时未就绪，请先下载依赖")
                 return@withContext -1

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
@@ -56,6 +56,12 @@ class WordPressPhpRuntime(private val context: Context) {
 
     suspend fun startServer(documentRoot: String, port: Int = 0, portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL, customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()): Int = withContext(Dispatchers.IO) {
         try {
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+                _serverState.value = ServerState.Error(
+                    com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("WordPress (PHP)")
+                )
+                return@withContext -1
+            }
 
             if (!isPhpAvailable()) {
                 _serverState.value = ServerState.Error("PHP 二进制未就绪，请先下载依赖")

--- a/app/src/main/java/com/webtoapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/MainActivity.kt
@@ -103,6 +103,25 @@ class MainActivity : ComponentActivity() {
 
         AppLogger.i("MainActivity", "Normal mode, showing main UI")
 
+        // targetSdk 33+: notifications (build progress, runtime downloads) are
+        // runtime-gated and silently off unless requested once up front.
+        if (android.os.Build.VERSION.SDK_INT >= 33) {
+            try {
+                if (androidx.core.content.ContextCompat.checkSelfPermission(
+                        this, android.Manifest.permission.POST_NOTIFICATIONS
+                    ) != android.content.pm.PackageManager.PERMISSION_GRANTED
+                ) {
+                    androidx.core.app.ActivityCompat.requestPermissions(
+                        this,
+                        arrayOf(android.Manifest.permission.POST_NOTIFICATIONS),
+                        4356
+                    )
+                }
+            } catch (e: Exception) {
+                AppLogger.w("MainActivity", "POST_NOTIFICATIONS request failed", e)
+            }
+        }
+
         try {
             enableEdgeToEdge()
         } catch (e: Exception) {

--- a/app/src/test/java/com/webtoapp/core/linux/RuntimeExecPolicyTest.kt
+++ b/app/src/test/java/com/webtoapp/core/linux/RuntimeExecPolicyTest.kt
@@ -1,0 +1,37 @@
+package com.webtoapp.core.linux
+
+import android.app.Application
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class RuntimeExecPolicyTest {
+
+    private fun contextWithTargetSdk(target: Int): Application {
+        val app = RuntimeEnvironment.getApplication()
+        app.applicationInfo.targetSdkVersion = target
+        return app
+    }
+
+    @Test
+    fun `low targetSdk builds may exec app data binaries`() {
+        assertThat(RuntimeExecPolicy.canExecAppDataBinaries(contextWithTargetSdk(28))).isTrue()
+    }
+
+    @Test
+    fun `the W-X gate starts exactly at targetSdk 29`() {
+        assertThat(RuntimeExecPolicy.canExecAppDataBinaries(contextWithTargetSdk(29))).isFalse()
+    }
+
+    @Test
+    fun `high targetSdk builds are blocked from exec`() {
+        assertThat(RuntimeExecPolicy.canExecAppDataBinaries(contextWithTargetSdk(35))).isFalse()
+        assertThat(RuntimeExecPolicy.hostPreviewBlockedMessage("Python")).contains("Python")
+        assertThat(RuntimeExecPolicy.restrictionNote()).isNotEmpty()
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,5 @@
+# Robolectric 4.12 supports up to SDK 34 while the app manifest targets 35+;
+# without an explicit default Robolectric derives the device SDK from the
+# manifest targetSdk and fails to configure. 33 matches the level used by the
+# majority of explicit @Config(sdk = [33]) tests; class-level @Config wins.
+sdk=33


### PR DESCRIPTION
## Summary

Fixes #548

The sideloaded standard host kept `targetSdk 28`, which antivirus engines and Play Protect treat as a strong legacy-malware heuristic — the app keeps getting wrongly flagged. The gplay flavor has shipped `targetSdk 35` on the same codebase, proving the 31+/34+/35 compliance surface (PendingIntent mutability, typed foreground services, edge-to-edge, media permissions) is already in place, so the only real delta is the SELinux W^X restriction (exec of app-storage binaries) that starts at targetSdk 29.

- `defaultConfig.targetSdk = 35`; gplay inherits (redundant explicit 35 dropped). Generated APKs are untouched — the shell template still ships targetSdk 28.
- New shell-synced `RuntimeExecPolicy` probes the *installed* app's targetSdk: generated APKs (always 28) pass unconditionally, so export behavior is byte-identical; only the host preview runtimes are gated.
- Python / PHP / WordPress preview start and the standalone pip install path fail fast with a targeted "targetSdk≥29 blocks local runtimes" message instead of a cryptic `EACCES`. Node (JNI via APK native libs) and Go (memfd exec) still launch; their failure notes now key off targetSdk instead of the `GPLAY_CHANNEL` flag.
- Request `POST_NOTIFICATIONS` once on first launch — without it Android 13+ silently hides build/download notifications at target 35 (this also fixes the shipping gplay channel).
- `app/src/test/resources/robolectric.properties` pins `sdk=33`: Robolectric 4.12 caps at SDK 34 and fails to configure `@Config`-less tests once the manifest targets 35 (`Package targetSdkVersion=35 > maxSdkVersion=34`).

## Trade-off (known and accepted)

At target 35 the host can no longer exec Python / PHP / WordPress runtimes downloaded into app storage, so **those three local-server previews degrade with a clear message** on the standard build. The permanent fix is static musl runtimes + memfd exec (Python: python-build-standalone static builds would also retire `ElfInterpPatcher`); tracked as follow-up work. Node and Go previews are structurally unaffected.

## Test plan

- [x] `:app:compileStandardDebugKotlin :app:compileGplayDebugKotlin`
- [x] Full `:app:testStandardDebugUnitTest` and `:app:testGplayDebugUnitTest` green (incl. new `RuntimeExecPolicyTest` 3/3)
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` rebuilt `--rerun-tasks` (runtime sources changed)
- [ ] Manual smoke on device: normal web preview, Node/Go preview, Python preview shows the targeted degraded message, notification prompt appears once on Android 13+