### PR TITLE
fix(go): precheck the W^X gate before launching the Go runtime

### DIFF
--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -28,10 +28,9 @@ class GoRuntime(private val context: Context) {
     }
 
     /**
-     * Go execs via memfd_create + execveat, which is increasingly restricted under the SELinux
-     * policy of a high-targetSdk build. Surface the restriction on launch failure instead of
-     * looking like a generic crash. Keyed off the actual app targetSdk (not the channel flag)
-     * so every high-target build gets the note.
+     * Go execs via memfd_create + execveat, which SELinux fully blocks under targetSdk 29+
+     * (memfd_file open is denied, verified on API 35). Kept as a failure-note fallback for
+     * OEM-specific policies; the startServer precheck handles the standard case.
      * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
      */
     private fun channelNote(): String =
@@ -96,6 +95,17 @@ class GoRuntime(private val context: Context) {
         envVars: Map<String, String> = emptyMap()
     ): Int = withContext(Dispatchers.IO) {
         try {
+            // The loader's three-tier fallback (direct exec -> system linker -> memfd
+            // execveat) is fully blocked under SELinux W^X at targetSdk 29+: exec and
+            // execute_no_trans on app_data_file, and open on memfd_file are all denied
+            // (verified on an API 35 emulator). Only generated APKs (targetSdk 28) pass.
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+                _serverState.value = ServerState.Error(
+                    com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("Go")
+                )
+                return@withContext -1
+            }
+
             stopServer()
             _serverState.value = ServerState.Starting
 


### PR DESCRIPTION
## Summary

Follow-up to #549 (issue #548).

**Emulator verification on an API 35 image** (standard host at targetSdk 35, imported Go project with a prebuilt static aarch64 binary) shows the `go_exec_loader` three-tier fallback is **fully blocked** by SELinux in the `untrusted_app_29+` domain:

```
avc: denied { execute_no_trans } for .../hello-server tclass=file      (tier 1: direct exec)
avc: denied { open } for /memfd:wta-go-exec tclass=memfd_file          (tier 3: memfd execveat)
execveat failed: Permission denied → exit 115
```

The `memfd_file` SELinux class (new kernels) is denied to untrusted apps, so the memfd path that #549 assumed "structurally unaffected" is in fact always blocked at targetSdk 29+. The gplay channel note's "may fail" was optimistic.

This PR makes `GoRuntime.startServer` fail fast with the same targeted `RuntimeExecPolicy` message already used by Python/PHP/WordPress, instead of the cryptic `execveat failed: Permission denied`. Node (JNI via `nativeLibraryDir`) remains genuinely unaffected, and generated APKs keep targetSdk 28 so their Go apps are unchanged.

## Test plan

- [x] `:app:compileStandardDebugKotlin`
- [x] `:app:testStandardDebugUnitTest` — `com.webtoapp.core.golang.*`, `com.webtoapp.core.linux.*`
- [x] Manual repro on API 35 emulator: before = `execveat failed: Permission denied`; the precheck now fires before the loader (same repro steps: import Go project with prebuilt binary → preview)