### PR TITLE
build: unify standard and gplay flavors into one rule set

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -100,6 +100,8 @@ jobs:
             -PallowDebugSignedRelease=true \
             :app:assembleStandardDebug \
             :app:assembleStandardRelease \
+            :app:assembleGplayDebug \
+            :app:assembleGplayRelease \
             :shell:assembleDebug \
             :shell:assembleRelease
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,27 +80,16 @@ android {
     flavorDimensions += "distribution"
     productFlavors {
         create("standard") {
-            // Full-capability sideloaded variant (GitHub releases, keeps `com.webtoapp`).
-            // Inherits targetSdk 35 from defaultConfig: low targetSdk is a top heuristic
-            // for antivirus / Play Protect "legacy malware" flags, which got the host
-            // wrongly blocked. The cost is SELinux W^X (applies from targetSdk 29):
-            // exec of downloaded runtimes (Python / PHP / WordPress) from app storage is
-            // blocked, so those host previews degrade with a clear message
-            // (RuntimeExecPolicy). Node (JNI via native libs) and Go (memfd exec) are
-            // unaffected. Generated APKs still ship targetSdk 28 via the shell template.
-            buildConfigField("boolean", "GPLAY_CHANNEL", "false")
+            // Sideloaded variant (GitHub releases, keeps `com.webtoapp` for the existing
+            // update path). Identical to gplay in every way except the applicationId —
+            // both inherit targetSdk 35 from defaultConfig and run the same code paths
+            // (runtime capability gates key off the installed targetSdk, not the channel).
         }
         create("gplay") {
-            // Google Play distribution variant (Play requires targetSdk 35+; inherits 35
-            // from defaultConfig). Native fork+exec runtimes (esp. Node.js V8 JIT, Go
-            // memfd exec) may still fail under the stricter SELinux policy; launch paths
-            // degrade gracefully rather than crash.
-            //
-            // `com.webtoapp` is already registered on Google Play by another party, so the
-            // Play build ships under a distinct applicationId. The standard flavor (GitHub
-            // releases) keeps `com.webtoapp` so existing users keep their update path.
+            // Google Play variant. Only Play's applicationId requirement differs
+            // (`com.webtoapp` is registered on Google Play by another party); behavior,
+            // targetSdk and every build rule are shared with the standard flavor.
             applicationId = "shiaho.webtoapp"
-            buildConfigField("boolean", "GPLAY_CHANNEL", "true")
         }
     }
 

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -29,9 +29,7 @@ android {
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 
         // Shell template never ships to Google Play — it is the runtime host for *generated* apps,
-        // which always use targetSdk 28 (fork+exec). The GPLAY_CHANNEL flag is mirrored here only so
-        // shell-synced runtime sources (NodeService/GoRuntime) that reference it compile cleanly.
-        buildConfigField("boolean", "GPLAY_CHANNEL", "false")
+        // which always use targetSdk 28 (fork+exec).
 
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
## Summary

Decision from the maintainer (see the thread on #548): keep the single high-SDK host (targetSdk 35) and drop any channel-specific behavior. The two distribution flavors must be one rule set:

- Removed the `GPLAY_CHANNEL` `BuildConfig` flag from both flavors (and its shell mirror). Since #549/#550 moved every runtime-capability gate to the installed `targetSdk` (`RuntimeExecPolicy`), no source consumes the flag anymore — it was the last carrier of "two rules".
- The flavors now differ only in `applicationId` (Play registration requirement); everything else inherits from `defaultConfig`.
- CI now builds `assembleGplayDebug/Release` alongside standard so the Play artifact is verified on every change and the two paths cannot drift apart unnoticed.

## Test plan

- [x] `:app:compileStandardDebugKotlin :app:compileGplayDebugKotlin :shell:compileReleaseKotlin`
- [x] Full `:app:testStandardDebugUnitTest` and `:app:testGplayDebugUnitTest`
- [ ] CI green on both check jobs (now includes gplay assembly)