### PR TITLE
fix(agent): surface the W^X exec restriction in runtime and build-env tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Checklist in order:
 
 ### 11. Change a feature that has an Agent tool
 
-The in-app Agent exposes 40+ tools that wrap host service classes. When you change a feature, trace the tool chain:
+The in-app Agent exposes ~50 tools that wrap host service classes. When you change a feature, trace the tool chain:
 
 ```text
 LLM response (tool_calls)
@@ -313,4 +313,4 @@ Landed:
 - Config field drift detection (`checkConfigFieldDrift`)
 - Module Market: Chrome Web Store live search + GreasyFork browse
 - Code editor find-and-replace
-- Agent tool system: 40+ tools (app lifecycle, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files) with Channel-based permission prompting, per-section SSE parse resilience, and plan mode
+- Agent tool system: 49 tools (app lifecycle, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files, imagery) with Channel-based permission prompting, per-section SSE parse resilience, and plan mode; runtime/build-env tools surface `localExecAllowed` so the LLM knows targetSdk>=29 hosts cannot exec app-storage binaries

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/BuildEnvPlayTools.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/BuildEnvPlayTools.kt
@@ -14,6 +14,9 @@ class GetBuildEnvStatusTool : Tool {
         Check the local build environment status: Node.js/npm/PHP/Composer/Python readiness,
         versions, storage used, and cache size. This environment is needed for on-device
         frontend builds (React/Vue) and PHP/Composer/Python dependency installation.
+        On host builds with targetSdk >= 29 (SELinux W^X, localExecAllowed=false) the
+        environment binaries cannot be exec'd, so components report "not ready" even when
+        installed — that is expected on those builds, not a broken install.
     """.trimIndent()
     override val parametersSchema: JsonElement = jsonSchema {}
     override fun isReadOnly() = true
@@ -21,7 +24,9 @@ class GetBuildEnvStatusTool : Tool {
         val mgr = LinuxEnvironmentManager.getInstance(ctx.androidContext)
         mgr.checkEnvironment()
         val info = mgr.getEnvironmentInfo()
+        val execAllowed = com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(ctx.androidContext)
         return ToolResult.ok(buildString {
+            appendLine("localExecAllowed=$execAllowed" + if (execAllowed) "" else " (targetSdk>=29 host: build-env binaries cannot be executed; components report not-ready even when installed)")
             appendLine("Installed: ${info.isInstalled}")
             appendLine("Node: ${info.nodeVersion ?: "not installed"} (${if (info.nodeReady) "ready" else "not ready"})")
             appendLine("npm: ${info.npmVersion ?: "not installed"} (${if (info.npmReady) "ready" else "not ready"})")
@@ -44,6 +49,8 @@ class InitializeBuildEnvTool : Tool {
         - component "php": install PHP runtime.
         - component "composer": install Composer (requires PHP first).
         - component "python": install Python runtime.
+        Note: on host builds with targetSdk >= 29 the environment cannot be exec'd at all,
+        so installs "succeed" but the components stay not-ready — do not retry.
     """.trimIndent()
     override val parametersSchema: JsonElement = jsonSchema {
         enum("component", listOf("core", "php", "composer", "python"), "The component to install.", required = true)

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/HostsRuntimeTools.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/HostsRuntimeTools.kt
@@ -92,7 +92,10 @@ class GetRuntimeStatusTool : Tool {
     override val name = "GetRuntimeStatus"
     override val description = """
         Check which server runtimes are installed and ready: PHP/WordPress, Node.js, Python, Go.
-        Pass a specific runtime to check just one.
+        Pass a specific runtime to check just one. "ready" means installed on disk; on host
+        builds with targetSdk >= 29 (SELinux W^X) the exec-based runtimes (PHP/WordPress/
+        Python/Go) still cannot start locally for preview — see localExecAllowed in the
+        output. Node.js (JNI) and every exported APK are unaffected either way.
     """.trimIndent()
     override val parametersSchema: JsonElement = jsonSchema {
         enum("runtime", listOf("php", "node", "python", "go"), "Check a specific runtime only.")
@@ -100,7 +103,9 @@ class GetRuntimeStatusTool : Tool {
     override fun isReadOnly() = true
     override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
         val c = ctx.androidContext
+        val execAllowed = com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(c)
         val lines = buildList {
+            add("localExecAllowed=$execAllowed" + if (execAllowed) "" else " (targetSdk>=29 host: PHP/WordPress/Python/Go cannot start locally for preview; Node.js and exported APKs are unaffected)")
             if (args.get("runtime")?.asString?.let { it == "php" || it == "wordpress" } != false) {
                 add("PHP: ready=${WordPressDependencyManager.isPhpReady(c)}")
                 add("WordPress: ready=${WordPressDependencyManager.isWordPressReady(c)}")
@@ -124,6 +129,9 @@ class InstallRuntimeTool : Tool {
     override val description = """
         Download and install a server runtime (PHP/WordPress, Node.js, Python, or Go).
         This is a large download. Use GetRuntimeStatus first to check what's needed.
+        On host builds with targetSdk >= 29 (localExecAllowed=false in GetRuntimeStatus),
+        installing PHP/Python/Go still makes sense for building/exporting apps, but their
+        local preview cannot start; do not retry the install to "fix" that.
     """.trimIndent()
     override val parametersSchema: JsonElement = jsonSchema {
         enum("runtime", listOf("php", "node", "python", "go"), "The runtime to install.", required = true)


### PR DESCRIPTION
## Summary

Fixes #557

Full audit of the Agent tool chain against every service change since the tools were last touched (June). Result: registration completeness (49/49 both directions), `UpdateApp`'s generic JSON patch, `isReadOnly` flags, and the port/engine/lifecycle signatures are all clean — the only real drift was awareness of the targetSdk 35 SELinux W^X restriction:

- `GetRuntimeStatus` / `GetBuildEnvStatus` now print `localExecAllowed=...` (from `RuntimeExecPolicy.canExecAppDataBinaries`) with an explanatory line when false, so the LLM sees "exec-based runtimes cannot start on this build" as a fact instead of discovering it through failed preview attempts.
- Descriptions of `GetRuntimeStatus`, `InstallRuntime`, `GetBuildEnvStatus`, `InitializeBuildEnv` state the restriction and explicitly instruct the model not to retry installs to "fix" not-ready components on those builds.
- AGENTS.md tool docs: 49 tools, imagery domain listed, `localExecAllowed` noted for future agents.

Agent tools are host-only (`core/agent` is never shell-synced), so no template rebuild is needed.

## Test plan

- [x] `:app:compileStandardDebugKotlin`
- [x] Full `:app:testStandardDebugUnitTest`