### PR TITLE
ci: split APK artifacts by flavor to prevent wrong-package installs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -105,12 +105,20 @@ jobs:
             :shell:assembleDebug \
             :shell:assembleRelease
 
-      - name: Upload APK artifacts
+      - name: Upload standard APKs
         uses: actions/upload-artifact@v4
         with:
-          name: android-apks-DEBUG-SIGNED-do-not-distribute-${{ github.run_number }}
+          name: standard-apks-DEBUG-SIGNED-do-not-distribute-${{ github.run_number }}
           path: |
-            app/build/outputs/apk/**/*.apk
+            app/build/outputs/apk/standard/**/*.apk
             shell/build/outputs/apk/**/*.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload gplay APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: gplay-apks-shiaho.webtoapp-DEBUG-SIGNED-do-not-distribute-${{ github.run_number }}
+          path: app/build/outputs/apk/gplay/**/*.apk
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
## Summary

Since #551 the CI builds both distribution flavors. Both APKs landed in a single artifact, and installing the wrong one surfaces as a confusing `Activity class {com.webtoapp/com.webtoapp.ui.MainActivity} does not exist` at launch, because the gplay flavor ships under `shiaho.webtoapp` (same activity class, different applicationId — the two are intentionally decoupled).

- Split the artifact upload into two steps: `standard-apks-…` (applicationId `com.webtoapp`, includes shell template APKs) and `gplay-apks-shiaho.webtoapp-…` with the applicationId in the artifact name.
- No code changes; the two flavors remain a single rule set otherwise.

## Test plan

- [ ] CI green; both artifacts uploaded on the next run