### PR TITLE
polish(templates): richer save / manage template dialogs

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1076,6 +1076,7 @@ object Strings {
     val templateManage: String get() = StringsB.templateManage
     val templateRename: String get() = StringsB.templateRename
     val templateEmpty: String get() = StringsB.templateEmpty
+    val templateOverwriteHint: String get() = StringsB.templateOverwriteHint
     fun templateApplied(name: String): String = StringsB.templateApplied(name)
     fun templateSaved(name: String): String = StringsB.templateSaved(name)
     val sectionWebEngine: String get() = StringsB.sectionWebEngine
@@ -18626,6 +18627,19 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Шаблонов пока нет"
         AppLanguage.JAPANESE -> "テンプレートはまだありません"
         AppLanguage.KOREAN -> "아직 템플릿이 없습니다"
+    }
+
+    val templateOverwriteHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "同名模板已存在，保存将覆盖它"
+        AppLanguage.ENGLISH -> "A template with this name exists; saving will overwrite it"
+        AppLanguage.ARABIC -> "يوجد قالب بهذا الاسم؛ الحفظ سيستبدله"
+        AppLanguage.PORTUGUESE -> "Já existe um modelo com este nome; salvar o substituirá"
+        AppLanguage.SPANISH -> "Ya existe una plantilla con este nombre; guardar la sobrescribirá"
+        AppLanguage.FRENCH -> "Un modèle portant ce nom existe déjà ; l'enregistrer le remplacera"
+        AppLanguage.GERMAN -> "Eine Vorlage mit diesem Namen existiert bereits; Speichern überschreibt sie"
+        AppLanguage.RUSSIAN -> "Шаблон с таким названием уже существует; сохранение перезапишет его"
+        AppLanguage.JAPANESE -> "同じ名前のテンプレートが存在します。保存すると上書きされます"
+        AppLanguage.KOREAN -> "같은 이름의 템플릿이 있습니다. 저장하면 덮어씁니다"
     }
 
     fun templateApplied(name: String): String = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/ConfigTemplateMenuButton.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/ConfigTemplateMenuButton.kt
@@ -4,22 +4,40 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DriveFileRenameOutline
 import androidx.compose.material.icons.outlined.LibraryAddCheck
+import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.data.model.WebViewConfig
 import com.webtoapp.data.repository.ConfigTemplateStore
 import com.webtoapp.ui.components.PremiumTextField
+import com.webtoapp.ui.design.*
+import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
+
+/** "3 days ago"-style stamp; the platform formatter localizes it for free. */
+private fun relativeCreatedAt(createdAt: Long): String =
+    android.text.format.DateUtils.getRelativeTimeSpanString(
+        createdAt,
+        System.currentTimeMillis(),
+        TimeUnit.MINUTES.toMillis(1)
+    ).toString()
 
 /**
  * Top-bar action for common-config templates: save the current WebViewConfig as a named
@@ -36,8 +54,7 @@ fun ConfigTemplateMenuButton(
     val context = LocalContext.current
     var templates by remember { mutableStateOf(ConfigTemplateStore.list(context)) }
     var refresh by remember { mutableIntStateOf(0) }
-    LaunchedEffect(refresh, templates.isEmpty()) {
-        // reload after any mutation; also opportunistically refresh when the menu opens
+    LaunchedEffect(refresh) {
         if (refresh > 0) templates = ConfigTemplateStore.list(context)
     }
 
@@ -68,6 +85,7 @@ fun ConfigTemplateMenuButton(
         ) {
             DropdownMenuItem(
                 text = { Text(Strings.templateSaveAs) },
+                leadingIcon = { Icon(Icons.Outlined.Save, null) },
                 onClick = {
                     menuOpen = false
                     saveDialogOpen = true
@@ -85,6 +103,14 @@ fun ConfigTemplateMenuButton(
                     templates.forEach { template ->
                         DropdownMenuItem(
                             text = { Text(template.name) },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Outlined.LibraryAddCheck,
+                                    null,
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            },
                             onClick = {
                                 menuOpen = false
                                 onApplyConfig(template.webViewConfig)
@@ -96,6 +122,7 @@ fun ConfigTemplateMenuButton(
                 HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                 DropdownMenuItem(
                     text = { Text(Strings.templateManage) },
+                    leadingIcon = { Icon(Icons.Outlined.Tune, null) },
                     onClick = {
                         menuOpen = false
                         manageOpen = true
@@ -107,24 +134,52 @@ fun ConfigTemplateMenuButton(
 
     if (saveDialogOpen) {
         var name by remember { mutableStateOf("") }
+        val trimmed = name.trim()
+        val nameExists = trimmed.isNotEmpty() && templates.any {
+            it.name.equals(trimmed, ignoreCase = true)
+        }
         AlertDialog(
             onDismissRequest = { saveDialogOpen = false },
+            icon = { Icon(Icons.Outlined.LibraryAddCheck, null) },
             title = { Text(Strings.templateSaveAs) },
             text = {
-                PremiumTextField(
-                    value = name,
-                    onValueChange = { name = it },
-                    label = { Text(Strings.templateNameLabel) },
-                    singleLine = true
-                )
+                Column {
+                    Text(
+                        Strings.configTemplatesDesc,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    PremiumTextField(
+                        value = name,
+                        onValueChange = { if (it.length <= 40) name = it },
+                        label = { Text(Strings.templateNameLabel) },
+                        singleLine = true,
+                        supportingText = {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    if (nameExists) Strings.templateOverwriteHint else "",
+                                    color = MaterialTheme.colorScheme.tertiary
+                                )
+                                Text(
+                                    "${name.length}/40",
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+                            }
+                        }
+                    )
+                }
             },
             confirmButton = {
                 TextButton(
-                    enabled = name.isNotBlank(),
+                    enabled = trimmed.isNotEmpty(),
                     onClick = {
-                        if (ConfigTemplateStore.save(context, name, config)) {
+                        if (ConfigTemplateStore.save(context, trimmed, config)) {
                             refresh++
-                            notify(Strings.templateSaved(name.trim()))
+                            notify(Strings.templateSaved(trimmed))
                         }
                         saveDialogOpen = false
                     }
@@ -137,71 +192,161 @@ fun ConfigTemplateMenuButton(
     }
 
     if (manageOpen) {
-        AlertDialog(
+        Dialog(
             onDismissRequest = { manageOpen = false },
-            title = { Text(Strings.templateManage) },
-            text = {
-                if (templates.isEmpty()) {
-                    Text(Strings.templateEmpty)
-                } else {
-                    LazyColumn(modifier = Modifier.heightIn(max = 360.dp)) {
-                        items(templates, key = { it.name }) { template ->
-                            Row(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(template.name, modifier = Modifier.weight(1f))
-                                TextButton(onClick = {
-                                    renameTarget = template
-                                    renameText = template.name
-                                }) {
-                                    Icon(
-                                        Icons.Outlined.DriveFileRenameOutline,
-                                        contentDescription = Strings.templateRename,
-                                        modifier = Modifier.size(18.dp)
-                                    )
-                                }
-                                TextButton(onClick = {
-                                    ConfigTemplateStore.delete(context, template.name)
-                                    refresh++
-                                }) {
-                                    Icon(
-                                        Icons.Outlined.Delete,
-                                        contentDescription = Strings.delete,
-                                        tint = MaterialTheme.colorScheme.error,
-                                        modifier = Modifier.size(18.dp)
-                                    )
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            WtaCard(
+                modifier = Modifier
+                    .fillMaxWidth(0.95f)
+                    .fillMaxHeight(0.6f),
+                tone = WtaCardTone.Surface,
+                contentPadding = PaddingValues(0.dp),
+                shape = RoundedCornerShape(WtaRadius.Card)
+            ) {
+                Column {
+                    TopAppBar(
+                        title = { Text(Strings.templateManage) },
+                        navigationIcon = {
+                            IconButton(onClick = { manageOpen = false }) {
+                                Icon(Icons.Outlined.Close, Strings.close)
+                            }
+                        }
+                    )
+
+                    if (templates.isEmpty()) {
+                        Column(
+                            modifier = Modifier.fillMaxSize().padding(32.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            Icon(
+                                Icons.Outlined.LibraryAddCheck,
+                                null,
+                                modifier = Modifier.size(48.dp),
+                                tint = MaterialTheme.colorScheme.outline
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                Strings.templateEmpty,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(templates, key = { it.name }) { template ->
+                                WtaCard(
+                                    onClick = {
+                                        manageOpen = false
+                                        onApplyConfig(template.webViewConfig)
+                                        notify(Strings.templateApplied(template.name))
+                                    },
+                                    tone = WtaCardTone.Surface
+                                ) {
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Surface(
+                                            shape = MaterialTheme.shapes.small,
+                                            color = MaterialTheme.colorScheme.primaryContainer
+                                        ) {
+                                            Icon(
+                                                Icons.Outlined.LibraryAddCheck,
+                                                null,
+                                                modifier = Modifier.padding(8.dp).size(20.dp),
+                                                tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                            )
+                                        }
+                                        Spacer(modifier = Modifier.width(12.dp))
+                                        Column(modifier = Modifier.weight(1f)) {
+                                            Text(
+                                                template.name,
+                                                style = MaterialTheme.typography.titleSmall,
+                                                fontWeight = FontWeight.SemiBold,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
+                                            Text(
+                                                relativeCreatedAt(template.createdAt),
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                        IconButton(onClick = {
+                                            renameTarget = template
+                                            renameText = template.name
+                                        }) {
+                                            Icon(
+                                                Icons.Outlined.DriveFileRenameOutline,
+                                                contentDescription = Strings.templateRename,
+                                                modifier = Modifier.size(18.dp)
+                                            )
+                                        }
+                                        IconButton(onClick = {
+                                            ConfigTemplateStore.delete(context, template.name)
+                                            refresh++
+                                        }) {
+                                            Icon(
+                                                Icons.Outlined.Delete,
+                                                contentDescription = Strings.delete,
+                                                tint = MaterialTheme.colorScheme.error,
+                                                modifier = Modifier.size(18.dp)
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            },
-            confirmButton = {
-                TextButton(onClick = { manageOpen = false }) { Text(Strings.close) }
             }
-        )
+        }
     }
 
     renameTarget?.let { target ->
+        var nameExistsError by remember(target) { mutableStateOf(false) }
         AlertDialog(
-            onDismissRequest = { renameTarget = null },
+            onDismissRequest = {
+                renameTarget = null
+                nameExistsError = false
+            },
             title = { Text(Strings.templateRename) },
             text = {
                 PremiumTextField(
                     value = renameText,
-                    onValueChange = { renameText = it },
+                    onValueChange = {
+                        if (it.length <= 40) renameText = it
+                        nameExistsError = false
+                    },
                     label = { Text(Strings.templateNameLabel) },
-                    singleLine = true
+                    singleLine = true,
+                    isError = nameExistsError,
+                    supportingText = {
+                        if (nameExistsError) {
+                            Text(
+                                Strings.templateOverwriteHint,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
                 )
             },
             confirmButton = {
                 TextButton(
                     enabled = renameText.isNotBlank(),
                     onClick = {
-                        ConfigTemplateStore.rename(context, target.name, renameText)
-                        renameTarget = null
-                        refresh++
+                        if (ConfigTemplateStore.rename(context, target.name, renameText)) {
+                            renameTarget = null
+                            refresh++
+                        } else {
+                            nameExistsError = true
+                        }
                     }
                 ) { Text(Strings.btnSave) }
             },


### PR DESCRIPTION
## Summary

Follow-up to #561 (issue #559): the save and manage dialogs were bare `AlertDialog`s. This brings them up to the app's dialog language (patterned after the ad-block subscription selector):

- **Manage** — full-height `WtaCard` dialog with embedded top bar; template rows as cards with a leading badge icon, semibold name, relative creation time ("3 days ago" — platform formatter, localizes for free), and trailing rename/delete; proper centered empty state; tapping a row applies the template and closes.
- **Save** — header icon, one-line description of what gets snapshotted, live `n/40` counter, and a tertiary-colored "will overwrite" hint as soon as the typed name matches an existing template (case-insensitive, same rule as the store).
- **Rename** — inline error when the new name collides, instead of silently failing.
- **Dropdown** — leading icons on save / template / manage items.

One new string (`templateOverwriteHint`) × 10 languages; no store or tool changes.

## Test plan

- [x] `:app:compileStandardDebugKotlin`
- [x] `StringsKtTranslationParityTest`, `AppStringsResourceConsistencyTest`