### PR TITLE
fix(activation): online activation re-prompted on every launch regardless of the toggle

### DIFF
--- a/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/RemoteActivationVerifier.kt
@@ -332,7 +332,10 @@ class RemoteActivationVerifier(private val context: Context) {
     private suspend fun readValidCache(appId: Long, request: RemoteRequest): Long? {
         val prefs = context.activationDataStore.data.first()
         val cachedCode = prefs[stringPreferencesKey("remote_code_$appId")] ?: return null
-        if (normalize(cachedCode) != normalize(request.code)) return null
+        // Startup probes are built with an empty code (no user input yet); any cached
+        // code is theirs. Comparing literally against "" invalidated the cache on every
+        // launch, forcing re-verification even with "verify every launch" off.
+        if (request.code.isNotBlank() && normalize(cachedCode) != normalize(request.code)) return null
         val expiresAt = prefs[longPreferencesKey("remote_expires_$appId")] ?: return null
         if (expiresAt != 0L && System.currentTimeMillis() > expiresAt + CACHE_GRACE_MS) return null
         return expiresAt

--- a/app/src/test/java/com/webtoapp/core/activation/RemoteActivationVerifierTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/RemoteActivationVerifierTest.kt
@@ -1,6 +1,9 @@
 package com.webtoapp.core.activation
 
 import android.util.Base64
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -189,5 +192,35 @@ class RemoteActivationVerifierTest {
 
         assertThat(verifier.decodeAesKey("")).isNull()
         assertThat(verifier.decodeAesKey("not-valid-base64!!!")).isNull()
+    }
+}
+
+
+@RunWith(RobolectricTestRunner::class)
+class RemoteStartupCacheProbeTest {
+
+    @Test
+    fun `startup probe with empty code accepts a valid cache`() = kotlinx.coroutines.test.runTest {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+        val verifier = RemoteActivationVerifier(context)
+        val request = RemoteActivationVerifier.RemoteRequest(
+            verifyUrl = "https://example.com/verify",
+            publicKeyBase64 = "",
+            offlinePolicy = com.webtoapp.data.model.RemoteActivationOfflinePolicy.ALLOW_CACHED,
+            code = "",
+            deviceId = "device",
+            packageName = "pkg",
+            deliverUrl = false,
+            encryptUrl = false,
+            aesKeyBase64 = "",
+            deviceBound = false
+        )
+        // seed a cache exactly the way a successful verification does
+        context.activationDataStore.edit { prefs ->
+            prefs[stringPreferencesKey("remote_code_-1")] = "ABCD-1234"
+            prefs[longPreferencesKey("remote_expires_-1")] = 0L
+        }
+
+        assertThat(verifier.resolveCachedStartup(-1L, request)).isTrue()
     }
 }


### PR DESCRIPTION
## Summary

With online activation enabled, generated apps asked for the activation code on **every launch** no matter how the "verify on every launch" (`activationRequireEveryTime`) switch was set.

Root cause: the startup probe builds its `RemoteRequest` with `code = ""` (no user input exists yet at that point). `readValidCache` compared that empty string against the cached activation code, never matched, and returned null — so `resolveCachedStartup` (ALLOW_CACHED, the default offline policy) failed on every launch, seconds after a successful verification had written the very cache it was rejecting.

Fix: skip the code comparison when the request carries no code — a startup probe trusts whichever code the cache was written under, still guarded by the expiry check (`remote_expires_*`). Requests that do carry a code (re-verification flows) keep the strict equality.

## Test plan

- [x] New `RemoteStartupCacheProbeTest`: startup probe with empty code accepts a valid cache (regression guard; fails on the old comparison)
- [x] Full `:app:testStandardDebugUnitTest`
- [ ] Manual: exported app with online activation + "verify every launch" off → relaunch does not re-prompt while the cache is valid; toggle on → re-prompts every launch