### PR TITLE
fix(activation): drop the dead device-binding option from local codes

### DIFF
--- a/app/src/main/java/com/webtoapp/core/activation/ActivationCode.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationCode.kt
@@ -6,7 +6,6 @@ enum class ActivationCodeType(val displayName: String, val description: String) 
     PERMANENT("Permanent", "Valid permanently after activation, no restrictions"),
     TIME_LIMITED("Time Limited", "Valid within specified time after activation"),
     USAGE_LIMITED("Usage Limited", "Can be used specified number of times after activation"),
-    DEVICE_BOUND("Device Bound", "Bound to current device after activation"),
     COMBINED("Combined", "Supports both time and usage limits")
 }
 
@@ -23,9 +22,6 @@ data class ActivationCode(
     @SerializedName("usageLimit")
     val usageLimit: Int? = null,
 
-    @SerializedName("allowDeviceBinding")
-    val allowDeviceBinding: Boolean = false,
-
     @SerializedName("note")
     val note: String? = null,
 
@@ -38,7 +34,11 @@ data class ActivationCode(
         fun fromJson(json: String): ActivationCode? {
             return try {
                 if (json.trimStart().startsWith("{")) {
-                    gson.fromJson(json, ActivationCode::class.java)
+                    // Legacy configs may still carry a removed type value (e.g. the old
+                    // DEVICE_BOUND); Gson maps unknown enum names to null, so fall back
+                    // to PERMANENT instead of leaking a null type into callers.
+                    val parsed = gson.fromJson(json, ActivationCode::class.java)
+                    if (parsed?.type == null) parsed?.copy(type = ActivationCodeType.PERMANENT) else parsed
                 } else {
                     null
                 }

--- a/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
+++ b/app/src/main/java/com/webtoapp/core/activation/ActivationManager.kt
@@ -221,18 +221,6 @@ class ActivationManager(private val context: Context) {
             if (currentStatus.isUsageExceeded) {
                 return ActivationResult.UsageExceeded
             }
-            if (code.type == ActivationCodeType.DEVICE_BOUND &&
-                currentStatus.deviceId != null &&
-                currentStatus.deviceId != deviceId
-            ) {
-                return ActivationResult.DeviceMismatch
-            }
-        }
-
-        if (code.type == ActivationCodeType.DEVICE_BOUND && code.allowDeviceBinding) {
-            if (currentStatus.deviceId != null && currentStatus.deviceId != deviceId) {
-                return ActivationResult.DeviceMismatch
-            }
         }
 
         if (code.type == ActivationCodeType.TIME_LIMITED ||
@@ -330,9 +318,6 @@ class ActivationManager(private val context: Context) {
                 preferences[intPreferencesKey("usage_limit_$appId")] = it
                 preferences[intPreferencesKey("usage_count_$appId")] = 0
             }
-            if (code.type == ActivationCodeType.DEVICE_BOUND && code.allowDeviceBinding) {
-                preferences[stringPreferencesKey("device_id_$appId")] = deviceId
-            }
             preferences[stringPreferencesKey("code_type_$appId")] = code.type.name
         }
         AppLogger.i(TAG, "Activation status saved: app=$appId, type=${code.type}")
@@ -393,7 +378,6 @@ class ActivationManager(private val context: Context) {
             type = type,
             timeLimitMs = timeLimitMs,
             usageLimit = usageLimit,
-            allowDeviceBinding = type == ActivationCodeType.DEVICE_BOUND,
             note = note
         )
     }
@@ -501,7 +485,6 @@ sealed class ActivationResult {
     data class Invalid(val message: String = "") : ActivationResult()
     data object Empty : ActivationResult()
     data object AlreadyActivated : ActivationResult()
-    data object DeviceMismatch : ActivationResult()
     data object Expired : ActivationResult()
     data object UsageExceeded : ActivationResult()
 }

--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -73,11 +73,6 @@ private fun getCodeTypeTheme(type: ActivationCodeType): CodeTypeTheme {
             color = scheme.tertiary,
             labelBg = scheme.tertiary.copy(alpha = 0.10f)
         )
-        ActivationCodeType.DEVICE_BOUND -> CodeTypeTheme(
-            icon = Icons.Outlined.PhonelinkLock,
-            color = com.webtoapp.ui.design.WtaColors.semantic.warning,
-            labelBg = com.webtoapp.ui.design.WtaColors.semantic.warningContainer
-        )
         ActivationCodeType.COMBINED -> CodeTypeTheme(
             icon = Icons.Outlined.Layers,
             color = com.webtoapp.ui.design.WtaColors.semantic.info,
@@ -1106,9 +1101,6 @@ private fun EnhancedActivationCodeItem(
                             add("🔢 $limit ${Strings.times}")
                         }
                     }
-                    ActivationCodeType.DEVICE_BOUND -> {
-                        add("🔒 ${Strings.deviceBound}")
-                    }
                     ActivationCodeType.PERMANENT -> {
                         add("♾️ ${Strings.permanentValid}")
                     }
@@ -1135,17 +1127,6 @@ private fun EnhancedActivationCodeItem(
                 }
             }
 
-            if (code.type == ActivationCodeType.DEVICE_BOUND) {
-                Text(
-                    text = Strings.deviceBoundRemoteTip,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
-                    fontSize = 11.sp,
-                    modifier = Modifier
-                        .padding(top = 4.dp)
-                        .fillMaxWidth()
-                )
-            }
         }
     }
 }
@@ -1193,55 +1174,34 @@ private fun AddActivationCodeDialog(
                     fontWeight = FontWeight.SemiBold
                 )
 
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    ActivationCodeType.values().forEach { type ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    ActivationCodeType.entries.forEach { type ->
                         val theme = getCodeTypeTheme(type)
-                        val isSelected = codeType == type
-
-                        Surface(
-                            shape = RoundedCornerShape(12.dp),
-                            color = if (isSelected) theme.labelBg else Color.Transparent,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { codeType = type }
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                RadioButton(
-                                    selected = isSelected,
-                                    onClick = { codeType = type },
-                                    colors = RadioButtonDefaults.colors(
-                                        selectedColor = theme.color
-                                    )
-                                )
-                                Spacer(modifier = Modifier.width(6.dp))
+                        FilterChip(
+                            selected = codeType == type,
+                            onClick = { codeType = type },
+                            label = { Text(getActivationTypeName(type)) },
+                            leadingIcon = {
                                 Icon(
                                     theme.icon,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp),
-                                    tint = if (isSelected) theme.color else MaterialTheme.colorScheme.onSurfaceVariant
+                                    null,
+                                    modifier = Modifier.size(16.dp),
+                                    tint = if (codeType == type) theme.color else MaterialTheme.colorScheme.onSurfaceVariant
                                 )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Column(modifier = Modifier.weight(weight = 1f, fill = true)) {
-                                    Text(
-                                        text = getActivationTypeName(type),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
-                                        color = if (isSelected) theme.color else MaterialTheme.colorScheme.onSurface
-                                    )
-                                    Text(
-                                        text = getActivationTypeDesc(type),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        lineHeight = 16.sp
-                                    )
-                                }
                             }
-                        }
+                        )
                     }
                 }
+                Text(
+                    text = getActivationTypeDesc(codeType),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
 
                 HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
@@ -1766,7 +1726,6 @@ private fun getActivationTypeName(type: ActivationCodeType): String = when (type
     ActivationCodeType.PERMANENT -> Strings.activationTypePermanent
     ActivationCodeType.TIME_LIMITED -> Strings.activationTypeTimeLimited
     ActivationCodeType.USAGE_LIMITED -> Strings.activationTypeUsageLimited
-    ActivationCodeType.DEVICE_BOUND -> Strings.activationTypeDeviceBound
     ActivationCodeType.COMBINED -> Strings.activationTypeCombined
 }
 
@@ -1774,6 +1733,5 @@ private fun getActivationTypeDesc(type: ActivationCodeType): String = when (type
     ActivationCodeType.PERMANENT -> Strings.activationTypePermanentDesc
     ActivationCodeType.TIME_LIMITED -> Strings.activationTypeTimeLimitedDesc
     ActivationCodeType.USAGE_LIMITED -> Strings.activationTypeUsageLimitedDesc
-    ActivationCodeType.DEVICE_BOUND -> Strings.activationTypeDeviceBoundDesc
     ActivationCodeType.COMBINED -> Strings.activationTypeCombinedDesc
 }

--- a/app/src/main/java/com/webtoapp/ui/components/EnhancedActivationDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/EnhancedActivationDialog.kt
@@ -190,7 +190,7 @@ private fun ActivationDialogHeader(
     val semantic = com.webtoapp.ui.design.WtaColors.semantic
     val iconBgColor = when (result) {
         is ActivationResult.Success -> semantic.success
-        is ActivationResult.Invalid, is ActivationResult.DeviceMismatch,
+        is ActivationResult.Invalid,
         is ActivationResult.Expired, is ActivationResult.UsageExceeded -> MaterialTheme.colorScheme.error
         is ActivationResult.AlreadyActivated -> MaterialTheme.colorScheme.primary
         else -> MaterialTheme.colorScheme.primary
@@ -199,7 +199,6 @@ private fun ActivationDialogHeader(
     val icon: ImageVector = when (result) {
         is ActivationResult.Success -> Icons.Filled.CheckCircle
         is ActivationResult.Invalid -> Icons.Filled.Cancel
-        is ActivationResult.DeviceMismatch -> Icons.Filled.PhonelinkErase
         is ActivationResult.Expired -> Icons.Filled.TimerOff
         is ActivationResult.UsageExceeded -> Icons.Filled.Block
         is ActivationResult.AlreadyActivated -> Icons.Filled.Verified
@@ -290,14 +289,6 @@ private fun ActivationResultCard(result: ActivationResult) {
             containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.7f),
             contentColor = MaterialTheme.colorScheme.error,
             suggestion = Strings.invalidCodeSuggestion
-        )
-        is ActivationResult.DeviceMismatch -> ResultCardData(
-            icon = Icons.Filled.PhonelinkErase,
-            title = Strings.activationCodeBoundToOtherDevice,
-            message = Strings.deviceMismatchDetail,
-            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.7f),
-            contentColor = MaterialTheme.colorScheme.error,
-            suggestion = Strings.deviceMismatchSuggestion
         )
         is ActivationResult.Expired -> ResultCardData(
             icon = Icons.Filled.TimerOff,
@@ -578,7 +569,6 @@ private fun getStatusTypeName(type: ActivationCodeType): String = when (type) {
     ActivationCodeType.PERMANENT -> Strings.activationTypePermanent
     ActivationCodeType.TIME_LIMITED -> Strings.activationTypeTimeLimited
     ActivationCodeType.USAGE_LIMITED -> Strings.activationTypeUsageLimited
-    ActivationCodeType.DEVICE_BOUND -> Strings.activationTypeDeviceBound
     ActivationCodeType.COMBINED -> Strings.activationTypeCombined
 }
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -25,12 +25,6 @@ fun ShellActivationDialog(
         onDismiss = onDismiss,
         onActivate = { code ->
             val result = if (config.activationRemoteEnabled) {
-                val deviceBound = config.activationCodes.any { raw ->
-                    val parsed = com.webtoapp.core.activation.ActivationCode.fromJson(raw)
-                        ?: com.webtoapp.core.activation.ActivationCode.fromLegacyString(raw)
-                    parsed.code == code &&
-                        parsed.type == com.webtoapp.core.activation.ActivationCodeType.DEVICE_BOUND
-                }
                 activation.verifyRemoteActivation(
                     -1L,
                     code,
@@ -40,8 +34,7 @@ fun ShellActivationDialog(
                         offlinePolicy = parseOfflinePolicy(config.activationRemoteOfflinePolicy),
                         deliverUrl = config.activationRemoteDeliverUrl,
                         encryptUrl = config.activationRemoteEncryptUrl,
-                        aesKeyBase64 = config.activationRemoteAesKey,
-                        deviceBound = deviceBound
+                        aesKeyBase64 = config.activationRemoteAesKey
                     )
                 )
             } else {

--- a/app/src/test/java/com/webtoapp/core/activation/ActivationCodeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/ActivationCodeTest.kt
@@ -12,8 +12,7 @@ class ActivationCodeTest {
               "code":"ABC-123",
               "type":"TIME_LIMITED",
               "timeLimitMs":3600000,
-              "usageLimit":5,
-              "allowDeviceBinding":true
+              "usageLimit":5
             }
         """.trimIndent()
 
@@ -24,7 +23,6 @@ class ActivationCodeTest {
         assertThat(parsed?.type).isEqualTo(ActivationCodeType.TIME_LIMITED)
         assertThat(parsed?.timeLimitMs).isEqualTo(3_600_000L)
         assertThat(parsed?.usageLimit).isEqualTo(5)
-        assertThat(parsed?.allowDeviceBinding).isTrue()
     }
 
     @Test
@@ -56,7 +54,6 @@ class ActivationCodeTest {
             type = ActivationCodeType.COMBINED,
             timeLimitMs = 60_000L,
             usageLimit = 10,
-            allowDeviceBinding = true,
             note = "test"
         )
 
@@ -64,5 +61,14 @@ class ActivationCodeTest {
 
         assertThat(restored).isNotNull()
         assertThat(restored?.copy(createdAt = 0L)).isEqualTo(original.copy(createdAt = 0L))
+    }
+
+    @Test
+    fun `fromJson downgrades the removed DEVICE_BOUND type to PERMANENT`() {
+        val json = """{"code":"DEV1","type":"DEVICE_BOUND","allowDeviceBinding":true}"""
+        val parsed = ActivationCode.fromJson(json)
+        assertThat(parsed).isNotNull()
+        assertThat(parsed!!.code).isEqualTo("DEV1")
+        assertThat(parsed.type).isEqualTo(ActivationCodeType.PERMANENT)
     }
 }

--- a/app/src/test/java/com/webtoapp/core/activation/ActivationCodeTest2.kt
+++ b/app/src/test/java/com/webtoapp/core/activation/ActivationCodeTest2.kt
@@ -32,14 +32,6 @@ class ActivationCodeExtendedTest {
         assertThat(code.usageLimit).isEqualTo(5)
     }
 
-    @Test
-    fun `fromJson parses DEVICE_BOUND type with allowDeviceBinding`() {
-        val json = """{"code":"DEV1","type":"DEVICE_BOUND","allowDeviceBinding":true}"""
-        val code = ActivationCode.fromJson(json)
-        assertThat(code).isNotNull()
-        assertThat(code!!.type).isEqualTo(ActivationCodeType.DEVICE_BOUND)
-        assertThat(code.allowDeviceBinding).isTrue()
-    }
 
     @Test
     fun `fromJson parses COMBINED type`() {
@@ -91,7 +83,6 @@ class ActivationCodeExtendedTest {
             code = "ROUNDTRIP",
             type = ActivationCodeType.USAGE_LIMITED,
             usageLimit = 100,
-            allowDeviceBinding = true,
             note = "test note"
         )
         val json = original.toJson()
@@ -100,7 +91,6 @@ class ActivationCodeExtendedTest {
         assertThat(restored!!.code).isEqualTo(original.code)
         assertThat(restored.type).isEqualTo(original.type)
         assertThat(restored.usageLimit).isEqualTo(original.usageLimit)
-        assertThat(restored.allowDeviceBinding).isEqualTo(original.allowDeviceBinding)
         assertThat(restored.note).isEqualTo(original.note)
     }
 
@@ -116,7 +106,7 @@ class ActivationCodeExtendedTest {
         val code = ActivationCode.fromLegacyString("SIMPLE")
         assertThat(code.timeLimitMs).isNull()
         assertThat(code.usageLimit).isNull()
-        assertThat(code.allowDeviceBinding).isFalse()
+        assertThat(code.note).isNull()
     }
 
     @Test
@@ -125,7 +115,6 @@ class ActivationCodeExtendedTest {
             ActivationCodeType.PERMANENT,
             ActivationCodeType.TIME_LIMITED,
             ActivationCodeType.USAGE_LIMITED,
-            ActivationCodeType.DEVICE_BOUND,
             ActivationCodeType.COMBINED
         )
     }

--- a/app/src/test/java/com/webtoapp/data/converter/ConvertersTest.kt
+++ b/app/src/test/java/com/webtoapp/data/converter/ConvertersTest.kt
@@ -71,7 +71,7 @@ class ConvertersTest {
             [
               {"code":"GOOD","type":"PERMANENT","note":"ok"},
               "broken-item",
-              {"code":"GOOD2","type":"DEVICE_BOUND","note":"ok2"}
+              {"code":"GOOD2","type":"USAGE_LIMITED","note":"ok2"}
             ]
         """.trimIndent()
 

--- a/app/src/test/java/com/webtoapp/data/model/WebAppModelTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/WebAppModelTest.kt
@@ -76,7 +76,7 @@ class WebAppModelTest {
             name = "Demo",
             url = "https://example.com",
             activationCodeList = listOf(
-                ActivationCode(code = "NEW", type = ActivationCodeType.DEVICE_BOUND)
+                ActivationCode(code = "NEW", type = ActivationCodeType.COMBINED)
             )
         )
 


### PR DESCRIPTION
## Summary

Fixes #569

The "Device Bound" code type (and its "allow device binding" toggle) never worked for local codes and semantically cannot: verification state lives in the app's on-device DataStore, so a fresh install on any device starts clean and the same code activates again. No server, no cross-device state.

- **Removed end to end**: `ActivationCodeType.DEVICE_BOUND`, `ActivationCode.allowDeviceBinding`, both validation branches, `ActivationResult.DeviceMismatch`, the shell-dialogs trigger that forwarded the flag into remote requests, the code-item badge/tip, and the mismatch result card. Online verification's server-side device binding is untouched.
- **Legacy tolerance**: configs still carrying `"type": "DEVICE_BOUND"` downgrade to `PERMANENT` during JSON parse (Gson would otherwise inject a null type).
- **Dialog simplification**: the five two-line radio cards become one compact chip row (permanent / time-limited / usage-limited / combined); the selected type's description shows as a single caption line. Conditional inputs, custom-code toggle and note unchanged.

## Test plan

- [x] Full `:app:testStandardDebugUnitTest` (incl. new `fromJson downgrades the removed DEVICE_BOUND type to PERMANENT`, updated type-list and converter tests)
- [x] `:app:compileStandardDebugKotlin` + `:shell:compileReleaseKotlin`
- [x] Shell template rebuilt `--rerun-tasks` (activation runtime is shell-synced)