### PR TITLE
fix(activation): match the offline-policy styling exactly in the mode selector

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -120,7 +120,6 @@ fun ActivationCodeCard(
                 WtaToggleRow(
                     icon = Icons.Outlined.VpnKey,
                     title = Strings.activationCodeVerify,
-                    subtitle = Strings.activationCodeHint,
                     checked = enabled,
                     onCheckedChange = onEnabledChange
                 )
@@ -155,8 +154,7 @@ fun ActivationCodeCard(
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
                                 text = Strings.activationModeLocal,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = if (!remoteConfig.enabled) FontWeight.SemiBold else FontWeight.Normal
+                                style = MaterialTheme.typography.bodySmall
                             )
                         }
                         Row(
@@ -172,17 +170,9 @@ fun ActivationCodeCard(
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
                                 text = Strings.activationModeRemote,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = if (remoteConfig.enabled) FontWeight.SemiBold else FontWeight.Normal
+                                style = MaterialTheme.typography.bodySmall
                             )
                         }
-                        Text(
-                            text = if (remoteConfig.enabled) Strings.activationModeRemoteDesc
-                            else Strings.activationModeLocalDesc,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-
                         WtaSectionDivider()
 
                         if (!remoteConfig.enabled) {


### PR DESCRIPTION
## Summary

Follow-up polish on #571 (issue #567), two residuals the maintainer flagged:

- The card header's `WtaToggleRow` had a subtitle ("启用后，用户需要输入正确的激活码才能使用应用") — no other feature-card header carries one. Removed.
- The verification-mode radio rows used semibold `bodyMedium` labels plus a free-floating description text pinned to the raw left edge. Now they are exactly the offline-policy selector's bare style: `RadioButton` + `bodySmall` label, no per-option prose (the option titles are self-explanatory, and "本地激活码/在线验证" match the offline-policy group visually 1:1).

## Test plan

- [x] `:app:compileStandardDebugKotlin`
- [x] `StringsKtTranslationParityTest`