### PR TITLE
fix(webview): patch poster-less videos to kill the internal poster pseudo-URL

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/VideoPosterCompat.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/VideoPosterCompat.kt
@@ -1,0 +1,61 @@
+package com.webtoapp.core.webview
+
+import android.webkit.WebView
+import com.webtoapp.core.logging.AppLogger
+
+/**
+ * Android WebView renders a `<video>` without a `poster` attribute through an
+ * internal pseudo-URL (`android-webview-video-poster:default_video_poster/<id>`)
+ * that only exists inside WebView. Site scripts that feed every media URL
+ * through fetch / canvas / lazy-loader pipelines cannot load that scheme and
+ * fail with "No 'Access-Control-Allow-Origin' header" (or a CSP violation),
+ * which can break their player init (#563). Browsers never generate the
+ * pseudo-URL, so sites cannot guard against it themselves.
+ *
+ * Giving each poster-less video a transparent data-URI poster stops WebView
+ * from generating the pseudo-URL at all, which removes the whole error class.
+ */
+object VideoPosterCompat {
+
+    fun injectScript(webView: WebView) {
+        try {
+            webView.evaluateJavascript(INJECTION_SCRIPT, null)
+        } catch (e: Exception) {
+            AppLogger.w("VideoPosterCompat", "Script injection failed", e)
+        }
+    }
+
+    internal val INJECTION_SCRIPT = """
+(function(){
+    if (window.__wtaVideoPosterShimInstalled) return;
+    window.__wtaVideoPosterShimInstalled = true;
+    var POSTER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    function patch(video) {
+        try {
+            if (!video.hasAttribute('poster')) {
+                video.setAttribute('poster', POSTER);
+            }
+        } catch (e) {}
+    }
+    function scan(root) {
+        try {
+            if (root && root.nodeName === 'VIDEO') patch(root);
+            if (root && root.querySelectorAll) {
+                var videos = root.querySelectorAll('video');
+                for (var i = 0; i < videos.length; i++) patch(videos[i]);
+            }
+        } catch (e) {}
+    }
+    scan(document);
+    try {
+        var observer = new MutationObserver(function (mutations) {
+            for (var i = 0; i < mutations.length; i++) {
+                var added = mutations[i].addedNodes;
+                for (var j = 0; j < added.length; j++) scan(added[j]);
+            }
+        });
+        observer.observe(document.documentElement || document.body || document, { childList: true, subtree: true });
+    } catch (e) {}
+})();
+    """.trimIndent()
+}

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
@@ -13,6 +13,7 @@ import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.shell.ShellConfig
 import com.webtoapp.core.webview.LongPressHandler
+import com.webtoapp.core.webview.VideoPosterCompat
 import com.webtoapp.core.webview.WebScrollTracker
 import com.webtoapp.core.webview.WebViewCallbacks
 
@@ -91,6 +92,7 @@ fun createShellWebViewCallbacks(
                 val isLocalRuntimePage = isLocalRuntimeShellUrl(url)
                 updateNavigation(it.canGoBack(), it.canGoForward())
                 WebScrollTracker.injectScript(it)
+                VideoPosterCompat.injectScript(it)
 
                 if (config.translateEnabled && !isLocalRuntimePage) {
                     injectTranslateScript(it, config.translateTargetLanguage, config.translateShowButton)

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -56,6 +56,7 @@ import com.webtoapp.core.port.PortConflictException
 import com.webtoapp.core.port.PortManager
 import com.webtoapp.core.webview.LocalHttpServer
 import com.webtoapp.core.webview.LongPressHandler
+import com.webtoapp.core.webview.VideoPosterCompat
 import com.webtoapp.core.webview.WebScrollTracker
 import com.webtoapp.core.webview.WebViewCallbacks
 import com.webtoapp.core.webview.WebViewManager
@@ -2238,6 +2239,7 @@ fun WebViewScreen(
                     canGoBack = it.canGoBack()
                     canGoForward = it.canGoForward()
                     WebScrollTracker.injectScript(it)
+                    VideoPosterCompat.injectScript(it)
 
                     if (webApp?.webViewConfig?.longPressMenuEnabled ?: true) {
                         longPressHandler.injectLongPressEnhancer(it)

--- a/app/src/test/java/com/webtoapp/core/webview/VideoPosterCompatTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/VideoPosterCompatTest.kt
@@ -1,0 +1,53 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Guards the contract of [VideoPosterCompat.INJECTION_SCRIPT] — the shim must give every
+ * poster-less `<video>` a real data-URI poster so WebView never generates its internal
+ * `android-webview-video-poster:` pseudo-URL, which site media pipelines cannot load
+ * (CORS/CSP failure, issue #563).
+ */
+class VideoPosterCompatTest {
+
+    private val script = VideoPosterCompat.INJECTION_SCRIPT
+
+    @Test
+    fun `script is guarded against re-injection`() {
+        val guardIdx = script.indexOf("__wtaVideoPosterShimInstalled")
+        assertThat(guardIdx).isGreaterThan(0)
+        val observerIdx = script.indexOf("new MutationObserver")
+        assertThat(observerIdx).isGreaterThan(guardIdx)
+    }
+
+    @Test
+    fun `script only patches videos that have no poster attribute`() {
+        // Site-provided posters must never be overwritten — the shim is a fallback only.
+        val guardIdx = script.indexOf("hasAttribute('poster')")
+        val setIdx = script.indexOf("setAttribute('poster'")
+        assertThat(guardIdx).isGreaterThan(0)
+        assertThat(setIdx).isGreaterThan(guardIdx)
+        assertThat(script).doesNotContain("removeAttribute")
+    }
+
+    @Test
+    fun `poster fallback is a data URI`() {
+        // A data-URI poster is what stops WebView from synthesizing its internal
+        // android-webview-video-poster: URL; any remote URL would reintroduce a fetch.
+        assertThat(script).contains("data:image/gif;base64,")
+    }
+
+    @Test
+    fun `script rescans dynamically inserted videos`() {
+        // SPA players append <video> long after onPageFinished; the observer must
+        // scan added subtrees for late videos.
+        assertThat(script).contains("new MutationObserver")
+        assertThat(script).contains("childList: true, subtree: true")
+    }
+
+    @Test
+    fun `script is an IIFE`() {
+        assertThat(script.trimStart().startsWith("(function()")).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #563.

Android WebView renders a `<video>` without a `poster` attribute through an internal pseudo-URL (`android-webview-video-poster:default_video_poster/<id>`) that exists only inside WebView — browsers never generate it. Site scripts that push every media URL through fetch / canvas / lazy-loader pipelines cannot load that scheme and fail with "No 'Access-Control-Allow-Origin' header" (or a CSP variant), which can break their player init. The site cannot guard against it because the failure mode is invisible in a normal browser.

Fix: `VideoPosterCompat` — a page-finished injection (same slot as `WebScrollTracker`, wired into both the host preview path and the shell callback path, so preview and exported APKs behave identically) that:

- gives every poster-less `<video>` a transparent 1x1 data-URI poster, so WebView never synthesizes the pseudo-URL at all;
- never touches videos that already carry a site-provided poster;
- re-scans subtrees through a `MutationObserver` for SPA players that append videos long after load.

No config field added: the shim is a pure compat fix, always on.

## Test plan

- [x] `:app:compileStandardDebugKotlin`, `VideoPosterCompatTest` (script-contract guards, same style as `AudioUnlockInjectorTest`)
- [x] Shell template rebuilt; `VideoPosterCompat` confirmed present in the template DEX
- [x] Emulator end-to-end: local test page with 3 videos (2 poster-less, 1 site poster) + 1 SPA-inserted video -> console reports `unpatched=0 patched=3 sitePoster=1` both initially and after the late insert, via the real preview WebView
