### PR TITLE
fix(media): arbitrate frames, polyfill navigator.mediaSession, stop none/zero clobbering

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
@@ -13,6 +13,7 @@ import android.media.session.MediaSession
 import android.media.session.PlaybackState
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.support.v4.media.session.MediaSessionCompat
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
@@ -70,6 +71,17 @@ class MediaSessionBridge(
     private var playbackState = PlaybackState.STATE_NONE
 
     /**
+     * Identity of the frame that currently owns the session. The injected script
+     * runs once per frame (document-start, wildcard origin), so every frame would
+     * otherwise write metadata/state/position into this single bridge and the last
+     * writer would win — a muted ad iframe could clobber the real player (#566).
+     * Only a frame reporting `playing`/`buffering` claims ownership; its updates
+     * stay authoritative while fresh, others are dropped.
+     */
+    private var activeFrameId: String? = null
+    private var activeFrameLastSeenMs = 0L
+
+    /**
      * `true` once any non-`none` playback state has ever been reported. Used to
      * guard [clearPlayback] so the initial `STATE_NONE` event (emitted during
      * page load before any media exists) does not run full media-session
@@ -77,6 +89,8 @@ class MediaSessionBridge(
      * start.
      */
     private var hasActivePlaybackSession = false
+
+    private var teardownRunnable: Runnable? = null
 
     private val supportedActions = mutableSetOf<String>()
 
@@ -156,9 +170,37 @@ class MediaSessionBridge(
         newTitle: String?,
         newArtist: String?,
         newAlbum: String?,
-        newArtworkUrl: String?
+        newArtworkUrl: String?,
+        frameId: String?
     ) {
         mainHandler.post {
+            if (!isAuthoritative(frameId)) {
+                return@post
+            }
+
+            val incomingBlank =
+                newTitle.isNullOrBlank() &&
+                    newArtist.isNullOrBlank() &&
+                    newAlbum.isNullOrBlank() &&
+                    newArtworkUrl.isNullOrBlank()
+
+            val currentBlank =
+                title.isBlank() &&
+                    artist.isBlank() &&
+                    album.isBlank() &&
+                    artworkUrl.isBlank()
+
+            /*
+             * A frame without media metadata used to send ("", "", "", "")
+             * every second, wiping real track info and falling back to the
+             * app label. Empty payloads never replace known metadata.
+             */
+            if (incomingBlank && !currentBlank) {
+                return@post
+            }
+
+            cancelTeardown()
+
             title = newTitle.orEmpty()
             artist = newArtist.orEmpty()
             album = newAlbum.orEmpty()
@@ -175,14 +217,42 @@ class MediaSessionBridge(
     }
 
     @JavascriptInterface
-    fun updatePlaybackState(state: String?) {
+    fun updatePlaybackState(
+        state: String?,
+        frameId: String?,
+        audible: Boolean
+    ) {
         mainHandler.post {
-            playbackState = when (state?.lowercase()) {
+            val resolved = when (state?.lowercase()) {
                 "playing" -> PlaybackState.STATE_PLAYING
                 "paused" -> PlaybackState.STATE_PAUSED
                 "buffering" -> PlaybackState.STATE_BUFFERING
                 "none", "stopped", null -> PlaybackState.STATE_NONE
                 else -> PlaybackState.STATE_PAUSED
+            }
+
+            /*
+             * Only an audible, actively playing frame claims session ownership.
+             * A muted autoplaying clip (ad/preview) may still report state while
+             * no fresh owner exists, but never steals the session from the real
+             * player (#566). Frames without an element (WebAudio players with
+             * an explicit playbackState) report as audible.
+             */
+            if (resolved == PlaybackState.STATE_PLAYING ||
+                resolved == PlaybackState.STATE_BUFFERING
+            ) {
+                if (audible) {
+                    activeFrameId = frameId
+                    activeFrameLastSeenMs = SystemClock.elapsedRealtime()
+                }
+            } else if (!isAuthoritative(frameId)) {
+                return@post
+            }
+
+            playbackState = resolved
+
+            if (resolved != PlaybackState.STATE_NONE) {
+                cancelTeardown()
             }
 
             publish()
@@ -193,9 +263,18 @@ class MediaSessionBridge(
     fun updatePosition(
         duration: Double,
         position: Double,
-        rate: Double
+        rate: Double,
+        frameId: String?
     ) {
         mainHandler.post {
+            if (!isAuthoritative(frameId)) {
+                return@post
+            }
+
+            if (frameId != null && frameId == activeFrameId) {
+                activeFrameLastSeenMs = SystemClock.elapsedRealtime()
+            }
+
             val durationChanged =
                 abs(durationSeconds - duration) >= 0.5
 
@@ -251,16 +330,60 @@ class MediaSessionBridge(
 
     // ---- State publishing ----
 
+    /**
+     * A frame owns its updates while it is the active frame and has reported
+     * within [FRAME_TAKEOVER_MS]. Frames that never played only get through
+     * while no fresh owner exists.
+     */
+    private fun isAuthoritative(frameId: String?): Boolean {
+        val current = activeFrameId ?: return true
+        if (frameId == null || frameId == current) return true
+        return SystemClock.elapsedRealtime() - activeFrameLastSeenMs > FRAME_TAKEOVER_MS
+    }
+
+    private fun cancelTeardown() {
+        teardownRunnable?.let { runnable ->
+            mainHandler.removeCallbacks(runnable)
+        }
+        teardownRunnable = null
+    }
+
+    private fun scheduleTeardown() {
+        cancelTeardown()
+
+        val runnable = Runnable {
+            teardownRunnable = null
+
+            if (playbackState == PlaybackState.STATE_NONE &&
+                (
+                    hasActivePlaybackSession ||
+                        mediaSession.isActive ||
+                        lastNotification != null
+                    )
+            ) {
+                clearPlayback()
+            }
+        }
+
+        teardownRunnable = runnable
+        mainHandler.postDelayed(runnable, TEARDOWN_GRACE_MS)
+    }
+
     private fun publish() {
         if (playbackState == PlaybackState.STATE_NONE) {
-            // Only tear down when media has actually been active at some point.
-            // The initial "none" state arrives during page load before any media
-            // exists, and running full cleanup there is unnecessary and risky.
+            /*
+             * "none" arrives from any frame whose media ended (or that never
+             * had any). Tearing down immediately let one ended ad element kill
+             * a session another frame was still playing (#566); wait out the
+             * grace period and cancel if anything reports activity again.
+             */
             if (hasActivePlaybackSession || mediaSession.isActive || lastNotification != null) {
-                clearPlayback()
+                scheduleTeardown()
             }
             return
         }
+
+        cancelTeardown()
 
         hasActivePlaybackSession = true
 
@@ -580,7 +703,12 @@ class MediaSessionBridge(
     }
 
     private fun clearPlayback() {
+        cancelTeardown()
+
         hasActivePlaybackSession = false
+
+        activeFrameId = null
+        activeFrameLastSeenMs = 0L
 
         playbackState = PlaybackState.STATE_NONE
         positionSeconds = 0.0
@@ -632,6 +760,14 @@ class MediaSessionBridge(
         const val JAVASCRIPT_INTERFACE_NAME =
             "WtaMediaSession"
 
+        /**
+         * How long the active frame's reports stay authoritative after the
+         * last one, and how long a `none` report must survive before the
+         * session is torn down.
+         */
+        private const val FRAME_TAKEOVER_MS = 3_000L
+        private const val TEARDOWN_GRACE_MS = 2_500L
+
         @Volatile
         private var activeBridge:
             WeakReference<MediaSessionBridge>? = null
@@ -664,10 +800,37 @@ class MediaSessionBridge(
 
               if (!nativeBridge) return;
 
+              /*
+               * This script runs once per frame (document start, wildcard
+               * origin). Every frame gets a stable id so the native bridge can
+               * arbitrate when several frames report at once (#566).
+               */
+              const frameId =
+                window.__wtaMediaFrameId ||
+                (window.__wtaMediaFrameId =
+                  "f" + Math.random().toString(36).slice(2, 10));
+
               const registeredHandlers = Object.create(null);
               const boundElements = new WeakSet();
 
-              const mediaSession = navigator.mediaSession || null;
+              const hadNativeSession =
+                !!(navigator.mediaSession && navigator.mediaSession);
+
+              /*
+               * True once the page itself called setPositionState(); such a
+               * site manages progress itself, so the heartbeat must not
+               * overwrite its values with DOM-derived ones.
+               */
+              let siteManagesPosition = false;
+
+              let metadataValue = null;
+              let playbackStateValue = "none";
+
+              function notifyChange() {
+                try {
+                  synchronize();
+                } catch (_) {}
+              }
 
               // WebView has no native MediaMetadata constructor; sites that do
               // `navigator.mediaSession.metadata = new MediaMetadata({...})`
@@ -689,6 +852,74 @@ class MediaSessionBridge(
                   }
                 };
               }
+
+              // WebView does not expose the Web Media Session API at all, so
+              // every `navigator.mediaSession.metadata = ...` assignment a
+              // site makes would throw (or be skipped by feature checks) and
+              // the bridge could never see site-provided track info (#566).
+              // Polyfill it with getters/setters that feed the bridge.
+              if (!hadNativeSession) {
+                const polyfillSession = {
+                  get metadata() {
+                    return metadataValue;
+                  },
+                  set metadata(value) {
+                    metadataValue = value || null;
+                    notifyChange();
+                  },
+                  get playbackState() {
+                    return playbackStateValue;
+                  },
+                  set playbackState(value) {
+                    playbackStateValue =
+                      value && value !== "none"
+                        ? String(value)
+                        : "none";
+                    notifyChange();
+                  },
+                  setActionHandler: function(action, handler) {
+                    const isFunction =
+                      typeof handler === "function";
+
+                    registeredHandlers[action] =
+                      isFunction ? handler : null;
+
+                    nativeBridge.setActionSupported(
+                      action,
+                      isFunction
+                    );
+                  },
+                  setPositionState: function(state) {
+                    if (!state) return;
+
+                    siteManagesPosition = true;
+
+                    nativeBridge.updatePosition(
+                      Number(state.duration) || 0,
+                      Number(state.position) || 0,
+                      Number(state.playbackRate) || 1,
+                      frameId
+                    );
+                  },
+                  setMicrophoneActive: function() {},
+                  setCameraActive: function() {}
+                };
+
+                try {
+                  Object.defineProperty(
+                    navigator,
+                    "mediaSession",
+                    {
+                      value: polyfillSession,
+                      configurable: true,
+                      writable: true
+                    }
+                  );
+                } catch (_) {}
+              }
+
+              const mediaSession =
+                navigator.mediaSession || null;
 
               // Call/camera state APIs (edge case): keep them callable so sites
               // using them do not crash; state is not surfaced to the system UI.
@@ -729,25 +960,72 @@ class MediaSessionBridge(
                 return output;
               }
 
+              /*
+               * Playing beats paused-with-progress beats idle; audible beats
+               * muted. Keeps a muted 10-second ad clip from winning over the
+               * real player inside the same frame.
+               */
+              function mediaScore(element) {
+                let score = 0;
+
+                if (
+                  !element.paused &&
+                  !element.ended &&
+                  element.readyState > 0
+                ) {
+                  score += 4;
+                } else if (
+                  element.currentTime > 0 &&
+                  !element.ended
+                ) {
+                  score += 2;
+                }
+
+                if (!element.muted && element.volume > 0) {
+                  score += 1;
+                }
+
+                return score;
+              }
+
               function getActiveMedia() {
                 const elements = getMediaElements();
 
+                let best = null;
+                let bestScore = -1;
+
+                elements.forEach(element => {
+                  const score = mediaScore(element);
+                  if (score > bestScore) {
+                    best = element;
+                    bestScore = score;
+                  }
+                });
+
+                return best;
+              }
+
+              /*
+               * Frames without media elements, without page metadata and
+               * without an active playback state must stay completely silent —
+               * reporting zeros or "none" from such a frame used to wipe the
+               * real player's session (#566).
+               */
+              function frameOwnsMedia() {
+                if (getMediaElements().length > 0) return true;
+
+                if (mediaSession && mediaSession.metadata) return true;
+
+                const reported =
+                  mediaSession && mediaSession.playbackState;
+
                 return (
-                  elements.find(element =>
-                    !element.paused &&
-                    !element.ended &&
-                    element.readyState > 0
-                  ) ||
-                  elements.find(element =>
-                    element.currentTime > 0 &&
-                    !element.ended
-                  ) ||
-                  elements[0] ||
-                  null
+                  !!reported &&
+                  reported !== "none"
                 );
               }
 
-              function sendMetadata() {
+              function sendMetadata(element) {
                 const metadata = mediaSession?.metadata;
 
                 let artwork = "";
@@ -770,17 +1048,28 @@ class MediaSessionBridge(
                   );
                 }
 
+                // document.title is only a sane fallback for the frame that
+                // actually owns the playing element.
+                const fallbackTitle =
+                  metadata?.title || (element ? document.title : "");
+
                 nativeBridge.updateMetadata(
-                  metadata?.title || document.title || "",
+                  fallbackTitle,
                   metadata?.artist || "",
                   metadata?.album || "",
-                  artwork
+                  artwork,
+                  frameId
                 );
               }
 
               function sendPosition(element) {
+                if (siteManagesPosition) {
+                  // setPositionState() already forwarded the site's own
+                  // values; DOM-derived ones would only fight them.
+                  return;
+                }
+
                 if (!element) {
-                  nativeBridge.updatePosition(0, 0, 1);
                   return;
                 }
 
@@ -803,7 +1092,8 @@ class MediaSessionBridge(
                 nativeBridge.updatePosition(
                   duration,
                   position,
-                  playbackRate
+                  playbackRate,
+                  frameId
                 );
               }
 
@@ -828,15 +1118,30 @@ class MediaSessionBridge(
                   }
                 }
 
-                nativeBridge.updatePlaybackState(state);
+                // Frames without an element (WebAudio players driving an
+                // explicit playbackState) count as audible; muted clips never
+                // claim the session away from the real player.
+                const audible =
+                  !element ||
+                  (!element.muted && element.volume > 0);
+
+                nativeBridge.updatePlaybackState(
+                  state,
+                  frameId,
+                  audible
+                );
               }
 
               function synchronize() {
+                if (!frameOwnsMedia()) return;
+
                 const element = getActiveMedia();
 
-                sendMetadata();
-                sendPlaybackState(element);
+                // Position first so a state change publishes fresh values;
+                // state last so publish() applies metadata and position.
                 sendPosition(element);
+                sendMetadata(element);
+                sendPlaybackState(element);
 
                 getMediaElements().forEach(bindElement);
               }
@@ -989,6 +1294,7 @@ class MediaSessionBridge(
                 };
 
               if (
+                hadNativeSession &&
                 mediaSession &&
                 typeof mediaSession.setActionHandler ===
                   "function"
@@ -1018,6 +1324,7 @@ class MediaSessionBridge(
               }
 
               if (
+                hadNativeSession &&
                 mediaSession &&
                 typeof mediaSession.setPositionState ===
                   "function"
@@ -1030,10 +1337,13 @@ class MediaSessionBridge(
                 mediaSession.setPositionState =
                   function(state) {
                     if (state) {
+                      siteManagesPosition = true;
+
                       nativeBridge.updatePosition(
                         Number(state.duration) || 0,
                         Number(state.position) || 0,
-                        Number(state.playbackRate) || 1
+                        Number(state.playbackRate) || 1,
+                        frameId
                       );
                     }
 
@@ -1072,7 +1382,9 @@ class MediaSessionBridge(
                 event => {
                   if (!event.persisted) {
                     nativeBridge.updatePlaybackState(
-                      "none"
+                      "none",
+                      frameId,
+                      true
                     );
                   }
                 }

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -746,7 +746,7 @@ class WebViewActivity : AppCompatActivity() {
                     statusBarAutoColor = color
                     refreshStatusBarAppearance()
                 },
-                onWebViewCreated = { wv ->
+                onWebViewCreated = { wv, loadedApp ->
                     webView = wv
 
                     wv.onResume()
@@ -770,7 +770,13 @@ class WebViewActivity : AppCompatActivity() {
                         wv.addJavascriptInterface(printBridge, com.webtoapp.core.webview.PrintBridge.JS_INTERFACE_NAME)
                     }
 
-                    if (previewWvConfig?.enableMediaSession == true) {
+                    // App-id launches resolve the saved config before the WebView is
+                    // created (targetUrl gates the AndroidView on the loaded app);
+                    // preview launches carry it in the intent. Both paths must
+                    // install the media bridge, otherwise playback started from the
+                    // app list never publishes a media session.
+                    val effectiveMediaConfig = previewApp?.webViewConfig ?: loadedApp?.webViewConfig
+                    if (effectiveMediaConfig?.enableMediaSession == true) {
                         val mediaBridge = com.webtoapp.core.webview.MediaSessionBridge(
                             this@WebViewActivity,
                             wv
@@ -982,7 +988,7 @@ fun WebViewScreen(
     testModuleIds: List<String>? = null,
     onStatusBarConfigChanged: ((com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType, com.webtoapp.data.model.StatusBarColorMode, String?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType) -> Unit)? = null,
     onStatusBarAutoColorChanged: ((String?) -> Unit)? = null,
-    onWebViewCreated: (WebView) -> Unit,
+    onWebViewCreated: (WebView, WebApp?) -> Unit,
     onFileChooser: (ValueCallback<Array<Uri>>?, WebChromeClient.FileChooserParams?) -> Boolean,
     onShowCustomView: (View, WebChromeClient.CustomViewCallback?) -> Unit,
     onHideCustomView: () -> Unit,
@@ -2959,7 +2965,7 @@ fun WebViewScreen(
                             tracker.attach()
                             statusBarColorTracker = tracker
                             webViewRef = wv
-                            onWebViewCreated(wv)
+                            onWebViewCreated(wv, null)
                             tracker.scheduleSample(80L)
                         },
                         swipeRefreshEnabled = mwApp.webViewConfig.swipeRefreshEnabled,
@@ -3139,7 +3145,7 @@ fun WebViewScreen(
                                     )
                                     tracker.attach()
                                     statusBarColorTracker = tracker
-                                    onWebViewCreated(this)
+                                    onWebViewCreated(this, webApp)
                                     WebScrollTracker.install(this)
 
                                     webViewRef = this

--- a/app/src/test/java/com/webtoapp/core/webview/MediaSessionBridgeScriptTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/MediaSessionBridgeScriptTest.kt
@@ -1,0 +1,105 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Guards the contract of [MediaSessionBridge.INJECTION_SCRIPT] — the script runs
+ * once per frame (document start, wildcard origin), so it must identify its frame,
+ * stay silent when the frame owns no media, and never let DOM-derived values fight
+ * the page's own setPositionState() updates (#566).
+ */
+class MediaSessionBridgeScriptTest {
+
+    private val script = MediaSessionBridge.INJECTION_SCRIPT
+
+    @Test
+    fun `script is guarded against re-injection within a frame`() {
+        val guardIdx = script.indexOf("window.__wtaMediaBridgeInstalled")
+        assertThat(guardIdx).isGreaterThan(0)
+        val heartbeatIdx = script.indexOf("__wtaMediaHeartbeat")
+        assertThat(heartbeatIdx).isGreaterThan(guardIdx)
+    }
+
+    @Test
+    fun `every frame carries a stable frame id passed to all native updates`() {
+        assertThat(script).contains("window.__wtaMediaFrameId")
+        assertThat(script).containsMatch("artwork,\\s*frameId")
+        assertThat(script).containsMatch("state,\\s*frameId,\\s*audible")
+        assertThat(script).containsMatch("playbackRate,\\s*frameId")
+        assertThat(script).containsMatch("\"none\",\\s*frameId,\\s*true")
+    }
+
+    @Test
+    fun `muted elements never claim the session away from the real player`() {
+        assertThat(script).contains("!element.muted && element.volume > 0")
+        // The audible flag is derived and forwarded on every state report.
+        val audibleIdx = script.indexOf("const audible =")
+        val stateIdx = script.indexOf("state,")
+        assertThat(audibleIdx).isGreaterThan(0)
+        assertThat(stateIdx).isGreaterThan(audibleIdx)
+    }
+
+    @Test
+    fun `frames without media metadata or active playback stay silent`() {
+        // The silence check must run before any native bridge call inside
+        // synchronize() — a media-less frame must not even report zeros/none.
+        val silenceIdx = script.indexOf("if (!frameOwnsMedia()) return;")
+        val syncIdx = script.indexOf("function synchronize()")
+        assertThat(silenceIdx).isGreaterThan(syncIdx)
+        assertThat(script).doesNotContain("updatePosition(0, 0, 1)")
+    }
+
+    @Test
+    fun `document title fallback only applies to the frame owning the media element`() {
+        val fallbackIdx = script.indexOf("(element ? document.title : \"\")")
+        assertThat(fallbackIdx).isGreaterThan(0)
+        // And it is what gets sent to the bridge, not a bare document.title.
+        assertThat(script).doesNotContain("metadata?.title || document.title ||")
+    }
+
+    @Test
+    fun `heartbeat never overwrites the page's own setPositionState values`() {
+        // Once the page calls setPositionState, the site owns progress: the
+        // interceptor sets the flag and forwards the values itself.
+        val flagIdx = script.indexOf("siteManagesPosition = true")
+        val guardIdx = script.indexOf("if (siteManagesPosition)")
+        assertThat(flagIdx).isGreaterThan(0)
+        assertThat(guardIdx).isGreaterThan(0)
+        // The guard must be inside sendPosition, before any nativeBridge call there.
+        val sendPosIdx = script.indexOf("function sendPosition")
+        assertThat(guardIdx).isGreaterThan(sendPosIdx)
+    }
+
+    @Test
+    fun `active media selection prefers playing and audible elements`() {
+        // A muted auto-playing clip must not win over the real player.
+        assertThat(script).contains("function mediaScore")
+        assertThat(script).contains("!element.muted && element.volume > 0")
+    }
+
+    @Test
+    fun `synchronize sends position before playback state`() {
+        val sendPosCall = script.indexOf("sendPosition(element);")
+        val sendStateCall = script.indexOf("sendPlaybackState(element);")
+        assertThat(sendPosCall).isGreaterThan(0)
+        assertThat(sendStateCall).isGreaterThan(sendPosCall)
+    }
+
+    @Test
+    fun `media metadata polyfill stays available for sites`() {
+        assertThat(script).contains("window.MediaMetadata = class MediaMetadata")
+        assertThat(script).contains("navigator.mediaSession")
+    }
+
+    @Test
+    fun `navigator dot mediaSession itself is polyfilled when WebView omits it`() {
+        // WebView does not expose the Web Media Session API, so plain
+        // `navigator.mediaSession.metadata = ...` assignments would throw or be
+        // skipped and site track info would never reach the bridge (#566).
+        assertThat(script).contains("hadNativeSession")
+        assertThat(script).containsMatch("Object\\.defineProperty\\(\\s*navigator")
+        assertThat(script).containsMatch("set metadata\\(value\\)")
+        assertThat(script).containsMatch("set playbackState\\(value\\)")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #566.

The reported symptoms (generic "Listen Now · Octave" title, no artist/album/artwork, wrong 00:07/00:10 progress) came from four independent defects, each reproduced and fixed against a two-frame conflict page on an emulator (muted 10s looping ad clip in a main frame titled "Listen Now" + real 60s player with full Media Session metadata in an iframe):

1. **`navigator.mediaSession` does not exist in WebView.** Site code doing `navigator.mediaSession.metadata = new MediaMetadata({...})` threw or was skipped by feature checks, so track info never reached the bridge and Android fell back to `document.title` / the app label — exactly the "Listen Now · Octave" card. The injected script now polyfills the whole interface when missing: `metadata` / `playbackState` accessors that feed the bridge, `setActionHandler`, `setPositionState`.
2. **One native bridge, one heartbeat per frame, last writer wins.** The document-start script runs in every frame; each now carries a `frameId`, and the native side only accepts updates from the frame that claimed ownership by reporting an *audible* playing/buffering state. A muted autoplaying clip can report while no owner exists but can never steal the session from the real player.
3. **Media-less frames zeroed the session.** Frames with no elements, no metadata and no active state stay completely silent instead of sending `(0,0,1)` and `"none"` every second; `STATE_NONE` tears the session down only after a 2.5s grace period, so one ended ad element cannot kill a session another frame is still playing; empty metadata payloads never overwrite known track info.
4. **The heartbeat fought the site and picked the wrong element.** Sites calling `setPositionState()` keep ownership of progress (the heartbeat no longer overwrites it with DOM values); element selection prefers playing + audible elements; `document.title` is only used by the frame that owns the media.

Bonus fix found during verification: `WebViewActivity` installed the bridge only for intent-JSON preview launches — launching from the app list (app-id path) resolved the saved config after the WebView existed and never installed the bridge, so media sessions silently never appeared on that path. The created-callback now receives the loaded app and uses its config.

No config field changes; host preview and exported APKs share the same bridge (`core/webview`, shell-synced; template rebuilt).

## Test plan

- [x] `MediaSessionBridgeScriptTest` — 10 script-contract guards (silence rule, frameId on every native call, audible claim, setPositionState ownership, polyfill install, ordering)
- [x] Node dry-runs of the extracted script against stubbed DOM/bridge (single-frame and two-frame scenarios)
- [x] Emulator end-to-end with the conflict page: `dumpsys media_session` shows `state=PLAYING`, position advancing on the 60s track, `metadata: Real Track, Real Artist, Real Album`; notification extras show `android.title=Real Track`; muted ad and "Listen Now" title suppressed
- [x] Shell template rebuilt, `MediaSessionBridge` confirmed in the template DEX

Follow-ups (not in this PR): action buttons registered via `setActionHandler` in iframes did not show up in the exported action mask during testing — needs a separate look.
