### PR TITLE
feat(apps): per-app Clear Cache action in the list + ClearAppCache agent tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Checklist in order:
 
 ### 11. Change a feature that has an Agent tool
 
-The in-app Agent exposes 53 tools that wrap host service classes. When you change a feature, trace the tool chain:
+The in-app Agent exposes 54 tools that wrap host service classes. When you change a feature, trace the tool chain:
 
 ```text
 LLM response (tool_calls)
@@ -348,4 +348,4 @@ Landed:
 - Config field drift detection (`checkConfigFieldDrift`)
 - Module Market: Chrome Web Store live search + GreasyFork browse
 - Code editor find-and-replace
-- Agent tool system: 53 tools (app lifecycle, config templates, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files, imagery) with Channel-based permission prompting, per-section SSE parse resilience, and plan mode; runtime/build-env tools surface `localExecAllowed` so the LLM knows targetSdk>=29 hosts cannot exec app-storage binaries
+- Agent tool system: 54 tools (app lifecycle, config templates, ports/engine, hosts/runtime, stats/modifier/import, build env/Play, modules, files, imagery) with Channel-based permission prompting, per-section SSE parse resilience, and plan mode; runtime/build-env tools surface `localExecAllowed` so the LLM knows targetSdk>=29 hosts cannot exec app-storage binaries

--- a/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/ToolRegistryFactory.kt
@@ -7,6 +7,7 @@ import com.webtoapp.core.agent.tool.builtin.BatchImportAppsTool
 import com.webtoapp.core.agent.tool.builtin.BuildApkTool
 import com.webtoapp.core.agent.tool.builtin.CheckPlayPolicyTool
 import com.webtoapp.core.agent.tool.builtin.CheckAppHealthTool
+import com.webtoapp.core.agent.tool.builtin.ClearAppCacheTool
 import com.webtoapp.core.agent.tool.builtin.ClearRuntimeCacheTool
 import com.webtoapp.core.agent.tool.builtin.CreateAppTool
 import com.webtoapp.core.agent.tool.builtin.CreateModuleTool
@@ -100,6 +101,7 @@ class ToolRegistryFactory(
         ExportAppTool(),
         CreateShortcutTool(),
         MoveToCategoryTool(),
+        ClearAppCacheTool(),
         DeleteAppTool(),
         DuplicateAppTool(),
         ExportAabTool(),

--- a/app/src/main/java/com/webtoapp/core/agent/tool/builtin/AppLifecycleTools.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/tool/builtin/AppLifecycleTools.kt
@@ -165,6 +165,33 @@ class MoveToCategoryTool : Tool {
     }
 }
 
+class ClearAppCacheTool : Tool {
+    override val name = "ClearAppCache"
+    override val description = """
+        Clear one app's host-side caches: the incremental APK build cache entry (usually
+        the largest disk consumer, regenerated on the next build), the app's WebView
+        origin storage (site localStorage/IndexedDB, so the site starts fresh) and the
+        shared WebView HTTP cache. Cookies, app configuration and exported APKs are kept.
+        Use it to free disk space or to reset a site's local data before retesting.
+    """.trimIndent()
+    override val parametersSchema: JsonElement = jsonSchema {
+        integer("appId", "The app id (from ListApps).", required = true)
+    }
+    override fun isReadOnly() = false
+    override fun activityDescription(args: JsonObject): String? =
+        args.get("appId")?.asString?.let { "Clearing cache for app $it" }
+    override suspend fun execute(args: JsonObject, ctx: ToolContext): ToolResult {
+        val appId = args.get("appId")?.asLong ?: return ToolResult.error("ClearAppCache: missing appId.")
+        val app = ctx.appRepository.getWebApp(appId) ?: return ToolResult.error("ClearAppCache: app $appId not found.")
+        val result = com.webtoapp.core.appcache.AppCacheCleaner.clearForApp(ctx.androidContext, app)
+        return ToolResult.ok(
+            "Cleared caches for \"${app.name}\": freed ${result.freedBytesText}, " +
+                "${result.originsCleared} site storage origin(s) reset. " +
+                "The build cache is regenerated on the next build."
+        )
+    }
+}
+
 class DeleteAppTool : Tool {
     override val name = "DeleteApp"
     override val description = """

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuildCache.kt
@@ -262,6 +262,13 @@ class ApkBuildCache(private val context: Context) {
         }
     }
 
+    /** Disk bytes the [clear] call for this app would free; 0 when nothing is cached. */
+    fun entrySizeBytes(webApp: WebApp, packageName: String): Long {
+        val dir = File(rootDir, cacheKeyFor(webApp, packageName))
+        if (!dir.exists()) return 0L
+        return dir.walkBottomUp().filter { it.isFile }.sumOf { it.length() }
+    }
+
     fun clearAll() {
         if (rootDir.exists()) {
             rootDir.deleteRecursively()

--- a/app/src/main/java/com/webtoapp/core/appcache/AppCacheCleaner.kt
+++ b/app/src/main/java/com/webtoapp/core/appcache/AppCacheCleaner.kt
@@ -1,0 +1,121 @@
+package com.webtoapp.core.appcache
+
+import android.content.Context
+import android.webkit.WebStorage
+import android.webkit.WebView
+import com.webtoapp.core.apkbuilder.ApkBuildCache
+import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.core.webview.WebViewPool
+import com.webtoapp.data.model.WebApp
+import java.io.File
+import java.util.Locale
+
+/**
+ * Clears a single app's host-side caches:
+ *
+ * - the incremental APK build cache entry (`apk_build_cache/app_<id>`) — usually the
+ *   largest per-app disk consumer; regenerated on the next build;
+ * - the app's WebView origin storage (localStorage / IndexedDB / WebSQL) via
+ *   [WebStorage.deleteOrigin], so the site starts fresh on the next preview;
+ * - the shared WebView HTTP disk cache — android.webkit has no per-origin API for
+ *   it, and it is pure re-downloadable cache.
+ *
+ * Cookies, app configuration and exported APKs are intentionally untouched —
+ * clearing cookies would log the user out of every other previewed app.
+ */
+object AppCacheCleaner {
+
+    data class Result(
+        val freedBuildCacheBytes: Long,
+        val originsCleared: Int
+    ) {
+        val freedBytesText: String
+            get() = formatBytes(freedBuildCacheBytes)
+    }
+
+    fun clearForApp(context: Context, app: WebApp): Result {
+        val appContext = context.applicationContext
+
+        var freedBytes = 0L
+        try {
+            val cache = ApkBuildCache(appContext)
+            val packageName = app.packageName.orEmpty()
+            freedBytes = cache.entrySizeBytes(app, packageName)
+            cache.clear(app, packageName)
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "Failed to clear build cache for app ${app.id}", e)
+        }
+
+        var originsCleared = 0
+        for (origin in originsFor(app)) {
+            try {
+                WebStorage.getInstance().deleteOrigin(origin)
+                originsCleared++
+            } catch (e: Exception) {
+                AppLogger.w(TAG, "Failed to clear storage for origin $origin", e)
+            }
+        }
+
+        try {
+            val webView = WebViewPool.acquire(appContext)
+            try {
+                webView.clearCache(true)
+            } finally {
+                WebViewPool.recycle(webView)
+            }
+        } catch (e: Exception) {
+            AppLogger.w(TAG, "Failed to clear WebView HTTP cache", e)
+        }
+
+        AppLogger.i(
+            TAG,
+            "Cleared caches for app ${app.id}: freedBytes=$freedBytes origins=$originsCleared"
+        )
+
+        return Result(freedBytes, originsCleared)
+    }
+
+    /** Web origins whose site storage belongs to this app. Pure and unit-testable. */
+    internal fun originsFor(app: WebApp): List<String> {
+        val urls = buildList {
+            add(app.url)
+            app.multiWebConfig?.sites?.forEach { add(it.url) }
+        }
+        return urls
+            .mapNotNull { url -> webOriginOf(url) }
+            .distinct()
+    }
+
+    private fun webOriginOf(raw: String): String? {
+        if (raw.isBlank()) return null
+        val trimmed = raw.trim()
+        // Saved apps may store the URL without a scheme (the editor normalizes
+        // it only at build/preview time); treat bare hostnames as http, same as
+        // ensureWebUrlScheme's default.
+        val candidate = if (trimmed.contains("://")) trimmed else "http://$trimmed"
+        val uri = try {
+            java.net.URI(candidate)
+        } catch (_: Exception) {
+            return null
+        }
+        val scheme = uri.scheme?.lowercase() ?: return null
+        if (scheme !in HTTP_SCHEMES) return null
+        val host = uri.host ?: return null
+        val port = if (uri.port != -1) ":${uri.port}" else ""
+        return "$scheme://$host$port"
+    }
+
+    internal fun formatBytes(bytes: Long): String {
+        return when {
+            bytes < 1024 -> "$bytes B"
+            bytes < 1024L * 1024 -> String.format(Locale.US, "%.1f KB", bytes / 1024.0)
+            bytes < 1024L * 1024 * 1024 ->
+                String.format(Locale.US, "%.1f MB", bytes / (1024.0 * 1024.0))
+            else -> String.format(Locale.US, "%.2f GB", bytes / (1024.0 * 1024.0 * 1024.0))
+        }
+    }
+
+    private val HTTP_SCHEMES = setOf("http", "https")
+
+    private const val TAG = "AppCacheCleaner"
+}

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2859,6 +2859,10 @@ object Strings {
     val categoryNamePlaceholder: String get() = StringsD.categoryNamePlaceholder
     val categoryIcon: String get() = StringsD.categoryIcon
     val moveToCategory: String get() = StringsD.moveToCategory
+    val clearAppCacheMenu: String get() = StringsD.clearAppCacheMenu
+    val clearAppCacheTitle: String get() = StringsD.clearAppCacheTitle
+    val clearAppCacheConfirm: String get() = StringsD.clearAppCacheConfirm
+    val clearAppCacheDone: String get() = StringsD.clearAppCacheDone
     val deleteCategoryConfirm: String get() = StringsD.deleteCategoryConfirm
     val randomNameTooltip: String get() = StringsD.randomNameTooltip
     val sampleVueCounterName: String get() = StringsD.sampleVueCounterName
@@ -40895,6 +40899,58 @@ object StringsD {
         AppLanguage.RUSSIAN -> "Переместить в категорию"
         AppLanguage.JAPANESE -> "カテゴリに移動"
         AppLanguage.KOREAN -> "카테고리로 이동"
+    }
+
+    val clearAppCacheMenu: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "清理缓存"
+        AppLanguage.ENGLISH -> "Clear Cache"
+        AppLanguage.ARABIC -> "مسح ذاكرة التخزين المؤقت"
+        AppLanguage.PORTUGUESE -> "Limpar Cache"
+        AppLanguage.SPANISH -> "Borrar Caché"
+        AppLanguage.FRENCH -> "Vider le Cache"
+        AppLanguage.GERMAN -> "Cache leeren"
+        AppLanguage.RUSSIAN -> "Очистить кэш"
+        AppLanguage.JAPANESE -> "キャッシュを消去"
+        AppLanguage.KOREAN -> "캐시 지우기"
+    }
+
+    val clearAppCacheTitle: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "清理应用缓存"
+        AppLanguage.ENGLISH -> "Clear App Cache"
+        AppLanguage.ARABIC -> "مسح ذاكرة التخزين المؤقت للتطبيق"
+        AppLanguage.PORTUGUESE -> "Limpar Cache do Aplicativo"
+        AppLanguage.SPANISH -> "Borrar Caché de la Aplicación"
+        AppLanguage.FRENCH -> "Vider le Cache de l'Application"
+        AppLanguage.GERMAN -> "App-Cache leeren"
+        AppLanguage.RUSSIAN -> "Очистить кэш приложения"
+        AppLanguage.JAPANESE -> "アプリのキャッシュを消去"
+        AppLanguage.KOREAN -> "앱 캐시 지우기"
+    }
+
+    val clearAppCacheConfirm: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "将删除该应用的 APK 增量构建缓存和站点本地数据（保留 Cookie 与应用配置）。被清理的构建缓存会在下次构建时重新生成。"
+        AppLanguage.ENGLISH -> "Deletes this app's incremental APK build cache and site local storage. Cookies and app settings are kept; the build cache is regenerated on the next build."
+        AppLanguage.ARABIC -> "سيتم حذف ذاكرة التخزين المؤقت لبناء APK والبيانات المحلية للموقع لهذا التطبيق. تُحفظ ملفات تعريف الارتباط وإعدادات التطبيق، ويُعاد توليد ذاكرة البناء في البناء التالي."
+        AppLanguage.PORTUGUESE -> "Exclui o cache incremental de build do APK e os dados locais do site deste aplicativo. Cookies e configurações são mantidos; o cache de build é recriado no próximo build."
+        AppLanguage.SPANISH -> "Elimina la caché de compilación incremental del APK y los datos locales del sitio de esta aplicación. Se conservan las cookies y la configuración; la caché se regenera en la próxima compilación."
+        AppLanguage.FRENCH -> "Supprime le cache de build APK incrémental et les données locales du site de cette application. Les cookies et les réglages sont conservés ; le cache est régénéré au prochain build."
+        AppLanguage.GERMAN -> "Löscht den inkrementellen APK-Build-Cache und die lokalen Websitedaten dieser App. Cookies und Einstellungen bleiben erhalten; der Build-Cache wird beim nächsten Build neu erzeugt."
+        AppLanguage.RUSSIAN -> "Удалит инкрементальный кэш сборки APK и локальные данные сайта этого приложения. Cookie и настройки сохраняются; кэш сборки создастся заново при следующей сборке."
+        AppLanguage.JAPANESE -> "このアプリのAPK増分ビルドキャッシュとサイトのローカルデータを削除します。Cookieとアプリ設定は保持され、ビルドキャッシュは次回ビルド時に再生成されます。"
+        AppLanguage.KOREAN -> "이 앱의 APK 증분 빌드 캐시와 사이트 로컬 데이터를 삭제합니다. 쿠키와 앱 설정은 유지되며, 빌드 캐시는 다음 빌드 때 다시 생성됩니다."
+    }
+
+    val clearAppCacheDone: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "已清理，释放 %s"
+        AppLanguage.ENGLISH -> "Cleared — freed %s"
+        AppLanguage.ARABIC -> "تم المسح — تم تحرير %s"
+        AppLanguage.PORTUGUESE -> "Limpo — liberado %s"
+        AppLanguage.SPANISH -> "Borrado — liberado %s"
+        AppLanguage.FRENCH -> "Vidé — %s libérés"
+        AppLanguage.GERMAN -> "Geleert — %s freigegeben"
+        AppLanguage.RUSSIAN -> "Очищено — освобождено %s"
+        AppLanguage.JAPANESE -> "消去しました — %s 解放"
+        AppLanguage.KOREAN -> "지웠습니다 — %s 확보"
     }
 
     val deleteCategoryConfirm: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/HomeScreen.kt
@@ -149,6 +149,8 @@ fun HomeScreen(
     var editingCategory by remember { mutableStateOf<AppCategory?>(null) }
     var showMoveToCategoryDialog by remember { mutableStateOf(false) }
     var appToMove by remember { mutableStateOf<WebAppSummary?>(null) }
+    var showClearCacheDialog by remember { mutableStateOf(false) }
+    var appToClearCache by remember { mutableStateOf<WebAppSummary?>(null) }
 
     var isSearchActive by remember { mutableStateOf(false) }
     var selectedApp by remember { mutableStateOf<WebAppSummary?>(null) }
@@ -687,6 +689,10 @@ fun HomeScreen(
                                 appToMove = app
                                 showMoveToCategoryDialog = true
                             },
+                            onClearCache = {
+                                appToClearCache = app
+                                showClearCacheDialog = true
+                            },
                             healthStatus = healthMap[app.id]?.status,
                             previewImageLoader = previewImageLoader,
                             screenshotPath = if (previewSpec.captureUrl != null) {
@@ -905,6 +911,46 @@ fun HomeScreen(
         )
     }
 
+    if (showClearCacheDialog && appToClearCache != null) {
+        AnimatedAlertDialog(
+            onDismissRequest = {
+                showClearCacheDialog = false
+                appToClearCache = null
+            },
+            title = { Text(Strings.clearAppCacheTitle) },
+            text = { Text(Strings.clearAppCacheConfirm) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val target = appToClearCache
+                        showClearCacheDialog = false
+                        appToClearCache = null
+                        if (target != null) {
+                            scope.launch {
+                                val fullApp = viewModel.getWebApp(target.id) ?: return@launch
+                                val result = com.webtoapp.core.appcache.AppCacheCleaner
+                                    .clearForApp(context, fullApp)
+                                snackbarHostState.showSnackbar(
+                                    Strings.clearAppCacheDone.replace("%s", result.freedBytesText)
+                                )
+                            }
+                        }
+                    }
+                ) {
+                    Text(Strings.clearAppCacheMenu)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showClearCacheDialog = false
+                    appToClearCache = null
+                }) {
+                    Text(Strings.btnCancel)
+                }
+            }
+        )
+    }
+
     if (showCategoryEditor) {
         CategoryEditorDialog(
             category = editingCategory,
@@ -1054,6 +1100,7 @@ fun AppCard(
     onBuildApk: () -> Unit = {},
     onShareApk: () -> Unit = {},
     onMoveToCategory: () -> Unit = {},
+    onClearCache: () -> Unit = {},
     healthStatus: com.webtoapp.core.stats.HealthStatus? = null,
     previewImageLoader: ImageLoader,
     screenshotPath: String? = null,
@@ -1332,6 +1379,14 @@ fun AppCard(
                         onClick = {
                             expanded = false
                             onMoveToCategory()
+                        }
+                    )
+                    com.webtoapp.ui.design.WtaDropdownMenuItem(
+                        text = Strings.clearAppCacheMenu,
+                        leadingIcon = Icons.Outlined.CleaningServices,
+                        onClick = {
+                            expanded = false
+                            onClearCache()
                         }
                     )
                     HorizontalDivider()

--- a/app/src/test/java/com/webtoapp/core/agent/tool/builtin/ClearAppCacheToolTest.kt
+++ b/app/src/test/java/com/webtoapp/core/agent/tool/builtin/ClearAppCacheToolTest.kt
@@ -1,0 +1,61 @@
+package com.webtoapp.core.agent.tool.builtin
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.core.agent.files.ProjectFileManager
+import com.webtoapp.core.agent.permission.PermissionChecker
+import com.webtoapp.core.agent.permission.PermissionPrompter
+import com.webtoapp.core.agent.plan.PlanManager
+import com.webtoapp.core.agent.tool.ToolRegistryFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ClearAppCacheToolTest {
+
+    private val tool = ClearAppCacheTool()
+
+    @Test
+    fun `tool advertises write semantics with a required appId schema`() {
+        assertThat(tool.name).isEqualTo("ClearAppCache")
+        // Cache clearing has side effects — must go through the permission prompt.
+        assertThat(tool.isReadOnly()).isFalse()
+
+        val args = com.google.gson.JsonObject().apply { addProperty("appId", 4) }
+        assertThat(tool.activityDescription(args)).isEqualTo("Clearing cache for app 4")
+
+        val schema = tool.parametersSchema.toString()
+        assertThat(schema).contains("appId")
+        assertThat(schema).contains("required")
+    }
+
+    @Test
+    fun `description tells the LLM what is cleared and what is kept`() {
+        assertThat(tool.description).contains("build cache")
+        assertThat(tool.description).contains("origin storage")
+        // The keep-list is what stops the LLM from promising a full data wipe.
+        assertThat(tool.description).contains("Cookies")
+    }
+
+    @Test
+    fun `tool is registered exactly once and registry names stay unique`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prompter = PermissionPrompter()
+        val planManager = PlanManager(
+            sessionId = "test",
+            fileManager = ProjectFileManager(context),
+            permissionChecker = PermissionChecker(prompter)
+        )
+        val registry = ToolRegistryFactory(planManager, imageRegistry = null)
+            .build(hasImageModel = false)
+
+        val matches = registry.all.filter { it.name == "ClearAppCache" }
+        assertThat(matches).hasSize(1)
+        assertThat(matches.single().isReadOnly()).isFalse()
+
+        val names = registry.all.map { it.name }
+        assertThat(names.distinct()).isEqualTo(names)
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/appcache/AppCacheCleanerTest.kt
+++ b/app/src/test/java/com/webtoapp/core/appcache/AppCacheCleanerTest.kt
@@ -1,0 +1,73 @@
+package com.webtoapp.core.appcache
+
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.MultiWebConfig
+import com.webtoapp.data.model.MultiWebSite
+import com.webtoapp.data.model.WebApp
+import org.junit.Test
+
+class AppCacheCleanerTest {
+
+    @Test
+    fun `web app origin keeps scheme host and explicit port`() {
+        val app = WebApp(id = 1, name = "a", url = "https://example.com", appType = com.webtoapp.data.model.AppType.WEB)
+        assertThat(AppCacheCleaner.originsFor(app)).containsExactly("https://example.com")
+
+        val withPort = app.copy(url = "http://127.0.0.1:8080/index.html")
+        assertThat(AppCacheCleaner.originsFor(withPort)).containsExactly("http://127.0.0.1:8080")
+    }
+
+    @Test
+    fun `scheme-less saved urls fall back to http like the editor normalizer`() {
+        val app = WebApp(
+            id = 5,
+            name = "bare",
+            url = "10.0.2.2:8898/media.html",
+            appType = com.webtoapp.data.model.AppType.WEB
+        )
+        assertThat(AppCacheCleaner.originsFor(app)).containsExactly("http://10.0.2.2:8898")
+    }
+
+    @Test
+    fun `multi web apps clear every site origin, deduplicated`() {
+        val app = WebApp(
+            id = 2,
+            name = "m",
+            url = "",
+            appType = com.webtoapp.data.model.AppType.MULTI_WEB,
+            multiWebConfig = MultiWebConfig(
+                sites = listOf(
+                    MultiWebSite(id = "1", name = "a", url = "https://a.example.com"),
+                    MultiWebSite(id = "2", name = "b", url = "https://b.example.com/x"),
+                    MultiWebSite(id = "3", name = "dup", url = "https://a.example.com/other")
+                )
+            )
+        )
+        assertThat(AppCacheCleaner.originsFor(app)).containsExactly(
+            "https://a.example.com",
+            "https://b.example.com"
+        ).inOrder()
+    }
+
+    @Test
+    fun `non-http urls and blanks yield no origins`() {
+        val app = WebApp(
+            id = 3,
+            name = "h",
+            url = "file:///data/index.html",
+            appType = com.webtoapp.data.model.AppType.HTML
+        )
+        assertThat(AppCacheCleaner.originsFor(app)).isEmpty()
+        assertThat(AppCacheCleaner.originsFor(app.copy(url = ""))).isEmpty()
+        assertThat(AppCacheCleaner.originsFor(app.copy(url = "not a url"))).isEmpty()
+    }
+
+    @Test
+    fun `byte formatting stays compact and locale-stable`() {
+        assertThat(AppCacheCleaner.formatBytes(0)).isEqualTo("0 B")
+        assertThat(AppCacheCleaner.formatBytes(512)).isEqualTo("512 B")
+        assertThat(AppCacheCleaner.formatBytes(2048)).isEqualTo("2.0 KB")
+        assertThat(AppCacheCleaner.formatBytes(5 * 1024 * 1024)).isEqualTo("5.0 MB")
+        assertThat(AppCacheCleaner.formatBytes((1.5 * 1024 * 1024 * 1024).toLong())).isEqualTo("1.50 GB")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #577.

Each app card's three-dot menu gains a **Clear Cache** item (between Move to Category and Delete). A confirmation dialog states the exact scope; the completion snackbar reports freed bytes.

What it clears, scoped to the app:

- the incremental APK build cache entry (`apk_build_cache/app_<id>`) — usually the largest per-app disk consumer, regenerated on the next build;
- the app's WebView origin storage (localStorage/IndexedDB) via `WebStorage.deleteOrigin` — every site for multi-web apps, deduplicated;
- the shared WebView HTTP cache (android.webkit has no per-origin API; it is pure re-downloadable cache).

What it keeps (and why, stated in the dialog): cookies (clearing them would log the user out of every other previewed app), app configuration, exported APKs.

Implementation notes:

- `AppCacheCleaner` in a new host-only `core/appcache` package (outside shell sync); `ApkBuildCache.entrySizeBytes()` feeds the freed-size report.
- Origin extraction handles scheme-less saved URLs (the editor normalizes URLs only at build time, so bare `host:port/path` values are common in the DB) — treated as http, same as `ensureWebUrlScheme`.
- New `ClearAppCache` agent tool: write semantics (permission-gated), appId-only schema, description documenting both the cleared list and the keep-list so the LLM cannot promise a full data wipe. Registered in the app-lifecycle group; AGENTS.md tool count 53 → 54.

## Test plan

- [x] `AppCacheCleanerTest` — origin extraction (scheme/host/port, scheme-less fallback, multi-web dedup, non-http filtering), byte formatting
- [x] `ClearAppCacheToolTest` — write semantics + required schema, description contract, and a full-registry build asserting the tool is registered exactly once with unique names
- [x] i18n parity (4 new strings × 10 languages)
- [x] Emulator end-to-end: menu placement, dialog, snackbar; a seeded 512KB build-cache entry was actually deleted and reported as "512.0 KB freed"; origin storage cleared for both https and scheme-less URLs
