### PR TITLE
feat(webview): configurable pull-to-refresh zone; classic top edge back as default

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -3790,6 +3790,7 @@ private fun com.webtoapp.data.model.WebViewConfig.toWebViewBlock(context: androi
         showFloatingBackButton = showFloatingBackButton,
         backButtonBehavior = backButtonBehavior,
         swipeRefreshEnabled = swipeRefreshEnabled,
+        swipeRefreshZone = swipeRefreshZone.name,
         fullscreenEnabled = fullscreenEnabled,
         performanceOptimization = performanceOptimization,
         pwaOfflineEnabled = pwaOfflineEnabled && !clearBrowsingDataOnLaunch,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfig.kt
@@ -130,6 +130,7 @@ data class ApkConfig(
     val openExternalLinks: Boolean get() = webView.openExternalLinks
     val showFloatingBackButton: Boolean get() = webView.showFloatingBackButton
     val swipeRefreshEnabled: Boolean get() = webView.swipeRefreshEnabled
+    val swipeRefreshZone: String get() = webView.swipeRefreshZone
     val fullscreenEnabled: Boolean get() = webView.fullscreenEnabled
     val performanceOptimization: Boolean get() = webView.performanceOptimization
     val pwaOfflineEnabled: Boolean get() = webView.pwaOfflineEnabled
@@ -496,6 +497,7 @@ data class WebViewBlock(
     val showFloatingBackButton: Boolean = false,
     val backButtonBehavior: String = "GO_BACK",
     val swipeRefreshEnabled: Boolean = true,
+    val swipeRefreshZone: String = "TOP_EDGE",
     val fullscreenEnabled: Boolean = true,
     val performanceOptimization: Boolean = false,
     val pwaOfflineEnabled: Boolean = false,

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkConfigJsonFactory.kt
@@ -167,6 +167,7 @@ internal object ApkConfigJsonFactory {
         "orientationMode" to webView.orientationMode,
         "keyboardAdjustMode" to webView.keyboardAdjustMode,
         "swipeRefreshEnabled" to webView.swipeRefreshEnabled,
+        "swipeRefreshZone" to webView.swipeRefreshZone,
         "fullscreenEnabled" to webView.fullscreenEnabled,
         "hideToolbar" to webView.hideToolbar,
         "hideBrowserToolbar" to webView.hideBrowserToolbar,

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -1166,6 +1166,9 @@ object Strings {
     val zoomSetting: String get() = StringsB.zoomSetting
     val zoomSettingHint: String get() = StringsB.zoomSettingHint
     val swipeRefreshSetting: String get() = StringsB.swipeRefreshSetting
+    val swipeRefreshZoneLabel: String get() = StringsB.swipeRefreshZoneLabel
+    val swipeRefreshZoneTopEdge: String get() = StringsB.swipeRefreshZoneTopEdge
+    val swipeRefreshZoneAnywhere: String get() = StringsB.swipeRefreshZoneAnywhere
     val swipeRefreshSettingHint: String get() = StringsB.swipeRefreshSettingHint
     val autoRefreshSettingLabel: String get() = StringsB.autoRefreshSettingLabel
     val autoRefreshSettingDesc: String get() = StringsB.autoRefreshSettingDesc
@@ -19821,6 +19824,45 @@ object StringsB {
         AppLanguage.RUSSIAN -> "Разрешить обновление свайпом вниз"
         AppLanguage.JAPANESE -> "下にスワイプして更新を許可"
         AppLanguage.KOREAN -> "아래로 스와이프하여 새로고침 허용"
+    }
+
+    val swipeRefreshZoneLabel: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "触发区域"
+        AppLanguage.ENGLISH -> "Trigger area"
+        AppLanguage.ARABIC -> "منطقة التشغيل"
+        AppLanguage.PORTUGUESE -> "Área de disparo"
+        AppLanguage.SPANISH -> "Área de activación"
+        AppLanguage.FRENCH -> "Zone de déclenchement"
+        AppLanguage.GERMAN -> "Auslösebereich"
+        AppLanguage.RUSSIAN -> "Зона срабатывания"
+        AppLanguage.JAPANESE -> "発生エリア"
+        AppLanguage.KOREAN -> "트리거 영역"
+    }
+
+    val swipeRefreshZoneTopEdge: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "仅顶部边缘（经典）"
+        AppLanguage.ENGLISH -> "Top edge only (classic)"
+        AppLanguage.ARABIC -> "الحافة العلوية فقط (كلاسيكي)"
+        AppLanguage.PORTUGUESE -> "Somente a borda superior (clássico)"
+        AppLanguage.SPANISH -> "Solo el borde superior (clásico)"
+        AppLanguage.FRENCH -> "Bord supérieur uniquement (classique)"
+        AppLanguage.GERMAN -> "Nur oberer Rand (klassisch)"
+        AppLanguage.RUSSIAN -> "Только верхний край (классика)"
+        AppLanguage.JAPANESE -> "上部端のみ（クラシック）"
+        AppLanguage.KOREAN -> "상단 가장자리만 (클래식)"
+    }
+
+    val swipeRefreshZoneAnywhere: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "页面顶部时任意位置"
+        AppLanguage.ENGLISH -> "Anywhere while at page top"
+        AppLanguage.ARABIC -> "أي مكان عند أعلى الصفحة"
+        AppLanguage.PORTUGUESE -> "Qualquer lugar no topo da página"
+        AppLanguage.SPANISH -> "Cualquier lugar en la parte superior de la página"
+        AppLanguage.FRENCH -> "N'importe où en haut de la page"
+        AppLanguage.GERMAN -> "Überall am Seitenanfang"
+        AppLanguage.RUSSIAN -> "В любом месте вверху страницы"
+        AppLanguage.JAPANESE -> "ページ最上部ではどこでも"
+        AppLanguage.KOREAN -> "페이지 상단이라면 어디든"
     }
 
     val autoRefreshSettingLabel: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
+++ b/app/src/main/java/com/webtoapp/core/shell/ShellModeManager.kt
@@ -1499,6 +1499,9 @@ data class WebViewShellConfig(
     @SerializedName("swipeRefreshEnabled")
     val swipeRefreshEnabled: Boolean = true,
 
+    @SerializedName("swipeRefreshZone")
+    val swipeRefreshZone: String = "TOP_EDGE",
+
     @SerializedName("fullscreenEnabled")
     val fullscreenEnabled: Boolean = true,
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -190,6 +190,17 @@ enum class LongPressMenuStyle {
     CONTEXT
 }
 
+/**
+ * Where on the screen the pull-to-refresh gesture may start.
+ * [TOP_EDGE] is the classic narrow band under the status bar (pre-2.4.5
+ * behaviour, the default); [ANYWHERE] arms the pull across the whole content
+ * area while the page is scrolled to the top (#511 / #515 behaviour).
+ */
+enum class SwipeRefreshZone {
+    TOP_EDGE,
+    ANYWHERE
+}
+
 enum class UserAgentMode(
     val displayName: String,
     val description: String,
@@ -268,6 +279,7 @@ data class WebViewConfig(
     val desktopMode: Boolean = false,
     val zoomEnabled: Boolean = true,
     val swipeRefreshEnabled: Boolean = true,
+    val swipeRefreshZone: SwipeRefreshZone = SwipeRefreshZone.TOP_EDGE,
     val autoRefreshEnabled: Boolean = false,
     val autoRefreshIntervalSec: Int = 60,
     val autoRefreshShowCountdown: Boolean = true,

--- a/app/src/main/java/com/webtoapp/ui/components/WebSwipeRefreshLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/WebSwipeRefreshLayout.kt
@@ -6,6 +6,7 @@ import android.view.MotionEvent
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.webtoapp.data.model.SwipeRefreshZone
 import kotlin.math.roundToInt
 
 class WebSwipeRefreshLayout @JvmOverloads constructor(
@@ -13,7 +14,16 @@ class WebSwipeRefreshLayout @JvmOverloads constructor(
     attrs: AttributeSet? = null
 ) : SwipeRefreshLayout(context, attrs) {
 
+    /**
+     * Where a touch may start a pull. [SwipeRefreshZone.TOP_EDGE] arms the
+     * gesture only inside a narrow band below the status-bar exclusion (the
+     * pre-#515 EdgeSwipeRefreshLayout behaviour); [SwipeRefreshZone.ANYWHERE]
+     * arms it across the whole content area (#515 behaviour).
+     */
+    var gestureZone: SwipeRefreshZone = SwipeRefreshZone.TOP_EDGE
+
     var topExclusionDp: Float = 12f
+    var edgeBandDp: Float = 48f
     var indicatorTravelDp: Float = 96f
     var triggerDistanceDp: Float = 64f
 
@@ -26,6 +36,9 @@ class WebSwipeRefreshLayout @JvmOverloads constructor(
 
     private val topExclusionPx: Float
         get() = topExclusionDp * density
+
+    private val edgeBandPx: Float
+        get() = edgeBandDp * density
 
     private val indicatorTravelPx: Float
         get() = indicatorTravelDp * density
@@ -65,7 +78,13 @@ class WebSwipeRefreshLayout @JvmOverloads constructor(
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 refreshIndicatorOffsetIfNeeded()
-                pullArmed = ev.y >= topExclusionLowerBoundPx()
+                val lowerBound = topExclusionLowerBoundPx()
+                pullArmed = when (gestureZone) {
+                    SwipeRefreshZone.TOP_EDGE ->
+                        ev.y in lowerBound..(lowerBound + edgeBandPx)
+                    SwipeRefreshZone.ANYWHERE ->
+                        ev.y >= lowerBound
+                }
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> pullArmed = false
         }

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -1018,6 +1018,60 @@ fun BrowserAdvancedConfigCard(
                                 checked = config.swipeRefreshEnabled,
                                 onCheckedChange = { onConfigChange(config.copy(swipeRefreshEnabled = it)) }
                             )
+
+                            // Same radio-group pattern as the PWA offline
+                            // strategy selector in sectionOfflinePerformance.
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = config.swipeRefreshEnabled,
+                                enter = CardExpandTransition,
+                                exit = CardCollapseTransition
+                            ) {
+                                Column(
+                                    modifier = Modifier.padding(
+                                        horizontal = WtaSpacing.RowHorizontal,
+                                        vertical = WtaSpacing.ContentGap
+                                    )
+                                ) {
+                                    Text(
+                                        text = Strings.swipeRefreshZoneLabel,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(bottom = 4.dp)
+                                    )
+                                    listOf(
+                                        com.webtoapp.data.model.SwipeRefreshZone.TOP_EDGE to Strings.swipeRefreshZoneTopEdge,
+                                        com.webtoapp.data.model.SwipeRefreshZone.ANYWHERE to Strings.swipeRefreshZoneAnywhere
+                                    ).forEach { (zone, label) ->
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .clip(MaterialTheme.shapes.small)
+                                                .clickable {
+                                                    onConfigChange(
+                                                        config.copy(swipeRefreshZone = zone)
+                                                    )
+                                                }
+                                                .padding(vertical = 4.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            RadioButton(
+                                                selected = config.swipeRefreshZone == zone,
+                                                onClick = {
+                                                    onConfigChange(
+                                                        config.copy(swipeRefreshZone = zone)
+                                                    )
+                                                }
+                                            )
+                                            Spacer(modifier = Modifier.width(4.dp))
+                                            Text(
+                                                text = label,
+                                                style = MaterialTheme.typography.bodySmall
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
                             WtaSectionDivider()
                             WtaToggleRow(
                                 title = Strings.externalLinksSetting,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellBrowserView.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellBrowserView.kt
@@ -47,6 +47,7 @@ fun ShellBrowserAndroidView(
                         android.graphics.Color.parseColor("#6750A4"),
                         android.graphics.Color.parseColor("#7F67BE")
                     )
+                    gestureZone = webViewConfig.swipeRefreshZone
                     isEnabled = swipeRefreshEnabled
                     var surfaceRef: BrowserSurface? = null
                     setOnRefreshListener {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -240,6 +240,11 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         ),
 
         swipeRefreshEnabled = config.webViewConfig.swipeRefreshEnabled,
+        swipeRefreshZone = try {
+            com.webtoapp.data.model.SwipeRefreshZone.valueOf(config.webViewConfig.swipeRefreshZone)
+        } catch (e: Exception) {
+            com.webtoapp.data.model.SwipeRefreshZone.TOP_EDGE
+        },
         fullscreenEnabled = config.webViewConfig.fullscreenEnabled,
 
         performanceOptimization = config.webViewConfig.performanceOptimization,

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -3013,6 +3013,8 @@ fun WebViewScreen(
                                     android.graphics.Color.parseColor("#6750A4"),
                                     android.graphics.Color.parseColor("#7F67BE")
                                 )
+                                gestureZone = webApp?.webViewConfig?.swipeRefreshZone
+                                    ?: com.webtoapp.data.model.SwipeRefreshZone.TOP_EDGE
                                 isEnabled = swipeRefreshEnabled
                                 setOnRefreshListener {
                                     isRefreshing = true

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/WebViewConfigBooleanCoverageTest.kt
@@ -199,6 +199,7 @@ class WebViewConfigBooleanCoverageTest {
                 orientationMode = com.webtoapp.data.model.OrientationMode.LANDSCAPE,
                 cloudflareCompatMode = com.webtoapp.data.model.CloudflareCompatMode.ALWAYS_ON,
                 mixedContentMode = com.webtoapp.data.model.MixedContentMode.COMPATIBILITY,
+                swipeRefreshZone = com.webtoapp.data.model.SwipeRefreshZone.ANYWHERE,
                 autoRefreshIntervalSec = 120,
                 blobInterceptThresholdMb = 10,
                 screenAwakeTimeoutMinutes = 15
@@ -222,6 +223,7 @@ class WebViewConfigBooleanCoverageTest {
         readShell("newWindowBehavior", "POPUP_WINDOW")
         readShell("orientationMode", "LANDSCAPE")
         readShell("cloudflareCompatMode", "ALWAYS_ON")
+        readShell("swipeRefreshZone", "ANYWHERE")
         readShell("autoRefreshIntervalSec", 120)
         readShell("blobInterceptThresholdMb", 10)
         readShell("screenAwakeTimeoutMinutes", 15)


### PR DESCRIPTION
## Summary

Fixes #579.

#515 made pull-from-anywhere the only pull-to-refresh behaviour. This PR restores the classic narrow top-edge gesture as the default and keeps the anywhere-gesture as an opt-in:

- New `swipeRefreshZone` config (`TOP_EDGE` | `ANYWHERE`, default `TOP_EDGE`). `TOP_EDGE` arms the pull only inside a ~48dp band below the status-bar exclusion — the exact arming rule of the pre-#515 `EdgeSwipeRefreshLayout`, re-implemented as a `gestureZone` property on `WebSwipeRefreshLayout` (no second layout class).
- Full config chain per the export wiring rules: `WebViewConfig` model → `ApkConfig.WebViewBlock` → `ApkConfigJsonFactory` → `ShellModeManager` (`@SerializedName`, tolerant string→enum) → runtime use sites in both the host preview (`WebViewActivity`) and the shell path (`ShellBrowserAndroidView`, which already receives the full `WebViewConfig`).
- Editor: radio group under the Swipe Refresh toggle in the navigation section, following the PWA offline-strategy selector pattern; 3 new strings × 10 languages.
- Existing apps deserialize without the field and land on `TOP_EDGE` — no migration.

## Test plan

- [x] `WebViewConfigBooleanCoverageTest` round-trip spot check for the new field; `checkConfigFieldDrift` OK; i18n parity green
- [x] Emulator end-to-end on the preview path: default `TOP_EDGE` — mid-screen pull at page top does nothing (0 reload probes), pull starting inside the edge band refreshes (reload probes fire); switched to `ANYWHERE` — mid-screen pull refreshes; default radio selection verified checked in the editor
- [x] Shell template rebuilt
