### PR TITLE
fix(webview): native LocationManager geolocation bridge (WebView GMS-independent location)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/GeolocationBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/GeolocationBridge.kt
@@ -1,0 +1,390 @@
+package com.webtoapp.core.webview
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import androidx.core.content.ContextCompat
+import com.webtoapp.core.logging.AppLogger
+import org.json.JSONObject
+
+/**
+ * Native navigator.geolocation backend for the System WebView engine (#581).
+ *
+ * Chromium's WebView implements navigator.geolocation exclusively through Google
+ * Play Services' fused location provider, with no fallback: on devices where
+ * Google location services are missing or unreachable (de-Googled ROMs, sanctioned
+ * networks) every fix silently times out even with all permissions granted.
+ * This bridge replaces navigator.geolocation with a LocationManager-backed
+ * implementation (GPS / network / passive providers, no Google services involved).
+ *
+ * The shim script is injected at document start whenever webViewConfig.geolocationEnabled
+ * is on; the permission flow is delegated to the host Activity through
+ * [permissionRequester], which shows the same system dialog + location-services
+ * dialog used by the Chromium prompt path.
+ */
+class GeolocationBridge(
+    context: Context,
+    private val policy: String,
+    private val accuracy: String,
+    private val webViewProvider: () -> WebView?,
+    private val permissionRequester: (onResult: (Boolean) -> Unit) -> Unit,
+    private val jsSink: ((String) -> Unit)? = null
+) {
+
+    companion object {
+        private const val TAG = "GeolocationBridge"
+        const val JS_INTERFACE_NAME = "WtaGeolocation"
+        private const val ERR_PERMISSION = 1
+        private const val ERR_UNAVAILABLE = 2
+        private const val LAST_KNOWN_MAX_AGE_MS = 30_000L
+
+        fun getShimScript(): String {
+            return """
+            (function() {
+                if (window._wtaGeoShimmed) return;
+                if (!window.WtaGeolocation) return;
+                window._wtaGeoShimmed = true;
+
+                var ERR_PERMISSION = 1, ERR_UNAVAILABLE = 2, ERR_TIMEOUT = 3;
+                var pending = Object.create(null);
+                var nextId = 1;
+                var cache = null;
+
+                function makeError(code, message) {
+                    var e = new Error(message);
+                    e.code = code;
+                    e.PERMISSION_DENIED = ERR_PERMISSION;
+                    e.POSITION_UNAVAILABLE = ERR_UNAVAILABLE;
+                    e.TIMEOUT = ERR_TIMEOUT;
+                    return e;
+                }
+
+                function makePosition(p) {
+                    function orNull(v) { return (v === null || v === undefined || (typeof v === 'number' && isNaN(v))) ? null : v; }
+                    return {
+                        coords: {
+                            latitude: p.latitude,
+                            longitude: p.longitude,
+                            accuracy: p.accuracy,
+                            altitude: orNull(p.altitude),
+                            altitudeAccuracy: null,
+                            heading: orNull(p.heading),
+                            speed: orNull(p.speed)
+                        },
+                        timestamp: p.timestamp
+                    };
+                }
+
+                window.__wtaGeo = {
+                    onResult: function(id, ok, payload, errCode, errMsg) {
+                        var entry = pending[id];
+                        if (!entry) return;
+                        delete pending[id];
+                        if (entry.timer !== null) { clearTimeout(entry.timer); entry.timer = null; }
+                        if (ok && payload) {
+                            cache = payload;
+                            try { entry.success(makePosition(payload)); } catch (e) {}
+                        } else {
+                            var code = (errCode === ERR_PERMISSION || errCode === ERR_TIMEOUT) ? errCode : ERR_UNAVAILABLE;
+                            try { entry.error && entry.error(makeError(code, errMsg || 'Location unavailable')); } catch (e) {}
+                        }
+                    }
+                };
+
+                function failEntry(id, entry, code, message) {
+                    delete pending[id];
+                    if (entry.timer !== null) { clearTimeout(entry.timer); entry.timer = null; }
+                    try { entry.error && entry.error(makeError(code, message)); } catch (e) {}
+                }
+
+                function call(id, watch, success, error, options) {
+                    var opts = options || {};
+                    var highAccuracy = !!opts.enableHighAccuracy;
+                    var maxAge = (typeof opts.maximumAge === 'number' && opts.maximumAge >= 0) ? opts.maximumAge : 0;
+                    var entry = { success: success, error: error, timer: null };
+                    pending[id] = entry;
+
+                    if (cache && (Date.now() - cache.timestamp) <= maxAge) {
+                        var cached = cache;
+                        delete pending[id];
+                        try { success(makePosition(cached)); } catch (e) {}
+                        return id;
+                    }
+
+                    if (opts.timeout > 0) {
+                        entry.timer = setTimeout(function() {
+                            if (pending[id] === entry) failEntry(id, entry, ERR_TIMEOUT, 'Timed out');
+                        }, opts.timeout);
+                    }
+
+                    try {
+                        var origin = '';
+                        try { origin = window.location.origin || ''; } catch (e0) {}
+                        if (watch) window.WtaGeolocation.startWatch(id, origin, highAccuracy);
+                        else window.WtaGeolocation.requestPosition(id, origin, highAccuracy);
+                    } catch (e) {
+                        if (pending[id] === entry) failEntry(id, entry, ERR_UNAVAILABLE, 'Bridge failure: ' + e.message);
+                    }
+                    return id;
+                }
+
+                var geolocationShim = {
+                    getCurrentPosition: function(success, error, options) {
+                        if (typeof success !== 'function') return;
+                        call(String(nextId++), false, success, error, options);
+                    },
+                    watchPosition: function(success, error, options) {
+                        if (typeof success !== 'function') return 0;
+                        return call('w' + String(nextId++), true, success, error, options);
+                    },
+                    clearWatch: function(id) {
+                        var key = String(id);
+                        var entry = pending[key];
+                        if (entry) {
+                            delete pending[key];
+                            if (entry.timer !== null) clearTimeout(entry.timer);
+                        }
+                        try { window.WtaGeolocation.stopWatch(key); } catch (e) {}
+                    }
+                };
+
+                try {
+                    Object.defineProperty(window.navigator, 'geolocation', {
+                        value: geolocationShim, writable: true, configurable: true
+                    });
+                } catch (e) {
+                    try { window.navigator.geolocation = geolocationShim; } catch (e2) {}
+                }
+
+                if (window.navigator.permissions && window.navigator.permissions.query) {
+                    try {
+                        var origQuery = window.navigator.permissions.query.bind(window.navigator.permissions);
+                        window.navigator.permissions.query = function(desc) {
+                            if (desc && desc.name === 'geolocation') {
+                                var denied = false;
+                                try { denied = !!window.WtaGeolocation.isDeniedByPolicy(); } catch (e1) {}
+                                return Promise.resolve({ state: denied ? 'denied' : 'granted', onchange: null });
+                            }
+                            return origQuery(desc);
+                        };
+                    } catch (e) {}
+                }
+            })();
+            """.trimIndent()
+        }
+    }
+
+    private val appContext = context.applicationContext
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val lm = appContext.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+
+    private val pendingSingles = mutableSetOf<String>()
+    private val watchers = mutableSetOf<String>()
+    private var listenerRegistered = false
+    @Volatile
+    private var destroyed = false
+
+    private val locationListener = LocationListener { location -> onLocation(location) }
+
+    @JavascriptInterface
+    fun isDeniedByPolicy(): Boolean = policy.equals("DENY_ALL", ignoreCase = true)
+
+    @JavascriptInterface
+    fun requestPosition(id: String, origin: String, highAccuracy: Boolean) {
+        mainHandler.post { beginRequest(id, highAccuracy, watch = false) }
+    }
+
+    @JavascriptInterface
+    fun startWatch(id: String, origin: String, highAccuracy: Boolean) {
+        mainHandler.post { beginRequest(id, highAccuracy, watch = true) }
+    }
+
+    @JavascriptInterface
+    fun stopWatch(id: String) {
+        mainHandler.post {
+            watchers.remove(id)
+            maybeUnregisterListener()
+        }
+    }
+
+    fun destroy() {
+        mainHandler.post {
+            destroyed = true
+            runCatching { lm?.removeUpdates(locationListener) }
+            listenerRegistered = false
+            pendingSingles.clear()
+            watchers.clear()
+        }
+    }
+
+    private fun beginRequest(id: String, highAccuracy: Boolean, watch: Boolean) {
+        if (destroyed) return
+        if (isDeniedByPolicy()) {
+            emitError(id, ERR_PERMISSION, "Geolocation denied by policy")
+            return
+        }
+        if (hasAnyLocationPermission()) {
+            startTracking(id, highAccuracy, watch)
+            return
+        }
+        permissionRequester { granted ->
+            mainHandler.post {
+                if (destroyed) return@post
+                if (!granted) {
+                    emitError(id, ERR_PERMISSION, "Location permission denied")
+                } else {
+                    startTracking(id, highAccuracy, watch)
+                }
+            }
+        }
+    }
+
+    private fun startTracking(id: String, highAccuracy: Boolean, watch: Boolean) {
+        if (watch) watchers.add(id) else pendingSingles.add(id)
+
+        bestLastKnown()?.let { lastKnown ->
+            emitLocation(id, lastKnown)
+            if (!watch) {
+                pendingSingles.remove(id)
+                maybeUnregisterListener()
+                return
+            }
+        }
+
+        if (listenerRegistered) return
+        val providers = enabledProviders(highAccuracy)
+        if (providers.isEmpty()) {
+            failRequest(id, watch, ERR_UNAVAILABLE, "Location services are disabled")
+            return
+        }
+        var registered = false
+        providers.forEach { provider ->
+            try {
+                lm?.requestLocationUpdates(provider, 1000L, 0f, locationListener, mainHandler.looper)
+                registered = true
+            } catch (e: Exception) {
+                AppLogger.w(TAG, "requestLocationUpdates failed for provider $provider: ${e.message}")
+            }
+        }
+        if (!registered) {
+            failRequest(id, watch, ERR_UNAVAILABLE, "Failed to register location updates")
+            return
+        }
+        listenerRegistered = true
+    }
+
+    private fun enabledProviders(highAccuracy: Boolean): List<String> {
+        val lm = this.lm ?: return emptyList()
+        val fineGranted = ContextCompat.checkSelfPermission(
+            appContext, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+        val providers = mutableListOf<String>()
+        if (fineGranted && runCatching { lm.isProviderEnabled(LocationManager.GPS_PROVIDER) }.getOrDefault(false)) {
+            providers += LocationManager.GPS_PROVIDER
+        }
+        if (runCatching { lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER) }.getOrDefault(false)) {
+            providers += LocationManager.NETWORK_PROVIDER
+        }
+        if (runCatching { lm.isProviderEnabled(LocationManager.PASSIVE_PROVIDER) }.getOrDefault(false)) {
+            providers += LocationManager.PASSIVE_PROVIDER
+        }
+        if (!highAccuracy && providers.size > 1) {
+            providers.remove(LocationManager.GPS_PROVIDER)
+        }
+        return providers
+    }
+
+    private fun onLocation(location: Location) {
+        if (destroyed) return
+        val ids = pendingSingles.toList() + watchers.toList()
+        if (ids.isEmpty()) {
+            maybeUnregisterListener()
+            return
+        }
+        ids.forEach { emitLocation(it, location) }
+        if (pendingSingles.isNotEmpty()) {
+            pendingSingles.clear()
+            maybeUnregisterListener()
+        }
+    }
+
+    private fun maybeUnregisterListener() {
+        if (pendingSingles.isEmpty() && watchers.isEmpty() && listenerRegistered) {
+            runCatching { lm?.removeUpdates(locationListener) }
+            listenerRegistered = false
+        }
+    }
+
+    private fun failRequest(id: String, watch: Boolean, code: Int, message: String) {
+        if (watch) watchers.remove(id) else pendingSingles.remove(id)
+        emitError(id, code, message)
+        maybeUnregisterListener()
+    }
+
+    private fun bestLastKnown(): Location? {
+        val lm = this.lm ?: return null
+        var best: Location? = null
+        listOf(
+            LocationManager.GPS_PROVIDER,
+            LocationManager.NETWORK_PROVIDER,
+            LocationManager.PASSIVE_PROVIDER
+        ).forEach { provider ->
+            val location = runCatching { lm.getLastKnownLocation(provider) }.getOrNull() ?: return@forEach
+            if (System.currentTimeMillis() - location.time > LAST_KNOWN_MAX_AGE_MS) return@forEach
+            if (best == null || location.time > best!!.time) best = location
+        }
+        return best
+    }
+
+    private fun hasAnyLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun emitLocation(id: String, location: Location) {
+        val json = JSONObject().apply {
+            put("latitude", location.latitude)
+            put("longitude", location.longitude)
+            put("accuracy", location.accuracy.toDouble())
+            put("altitude", if (location.hasAltitude()) location.altitude else JSONObject.NULL)
+            put("heading", if (location.hasBearing()) location.bearing.toDouble() else JSONObject.NULL)
+            put("speed", if (location.hasSpeed()) location.speed.toDouble() else JSONObject.NULL)
+            put("timestamp", location.time)
+        }
+        dispatch(id, json.toString())
+    }
+
+    private fun emitError(id: String, code: Int, message: String) = dispatch(id, null, code, message)
+
+    private fun dispatch(id: String, payload: String?, code: Int = 0, message: String = "") {
+        val ok = payload != null
+        val js = buildString {
+            append("window.__wtaGeo&&window.__wtaGeo.onResult(")
+            append(JSONObject.quote(id)).append(',')
+            append(ok).append(',')
+            append(payload ?: "null").append(',')
+            append(if (ok) 0 else code).append(',')
+            append(JSONObject.quote(message))
+            append(')')
+        }
+        jsSink?.let { sink ->
+            sink(js)
+            return
+        }
+        val webView = webViewProvider()
+        if (webView == null) {
+            AppLogger.w(TAG, "dispatch skipped, webView gone (id=$id ok=$ok)")
+            return
+        }
+        webView.post { webView.evaluateJavascript(js, null) }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
@@ -49,4 +49,13 @@ interface WebViewCallbacks {
     fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
         onResult(true)
     }
+
+    /**
+     * Request location access (Android permission + system location service check, with the same
+     * settings dialog used by the Chromium prompt path) on behalf of GeolocationBridge. Default
+     * denies so hosts without an Activity do not silently fake a grant.
+     */
+    fun requestGeolocationAccess(onResult: (Boolean) -> Unit) {
+        onResult(false)
+    }
 }

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -58,6 +58,7 @@ class WebViewManager(
     private val cloudflareCompatScriptHandlers = java.util.WeakHashMap<WebView, ScriptHandler>()
     private val backStateGuardScriptHandlers = java.util.WeakHashMap<WebView, ScriptHandler>()
     private val printBridgeScriptHandlers = java.util.WeakHashMap<WebView, ScriptHandler>()
+    private val geolocationShimHandlers = java.util.WeakHashMap<WebView, ScriptHandler>()
 
     companion object {
 
@@ -1092,6 +1093,7 @@ class WebViewManager(
     private var extensionMasterEnabled: Boolean = true
 
     private var gmBridge: com.webtoapp.core.extension.GreasemonkeyBridge? = null
+    private var geoBridge: GeolocationBridge? = null
 
     private var extensionRuntimes: MutableMap<String, com.webtoapp.core.extension.ChromeExtensionRuntime> = mutableMapOf()
     private val extensionPopupDialogs = mutableMapOf<String, Dialog>()
@@ -1603,6 +1605,20 @@ class WebViewManager(
                 installPrintBridgeDocumentStart(this)
             }
 
+            if (config.geolocationEnabled) {
+                geoBridge?.destroy()
+                val bridge = GeolocationBridge(
+                    context = context,
+                    policy = config.geolocationPolicy.name,
+                    accuracy = config.geolocationAccuracy.name,
+                    webViewProvider = { webView },
+                    permissionRequester = { onResult -> callbacks.requestGeolocationAccess(onResult) }
+                )
+                geoBridge = bridge
+                addJavascriptInterface(bridge, GeolocationBridge.JS_INTERFACE_NAME)
+                installGeolocationShimDocumentStart(this)
+            }
+
             // Device disguise desktop spoof: patch JS-detectable signals (platform,
             // touchPoints, screen, matchMedia, Client Hints) that UA alone can't cover.
             val ddConfig = currentDeviceDisguiseConfig
@@ -2085,6 +2101,10 @@ class WebViewManager(
 
                 if (config.enableClipboardPolyfill) {
                     view?.evaluateJavascript(CLIPBOARD_POLYFILL_JS, null)
+                }
+
+                if (config.geolocationEnabled) {
+                    view?.evaluateJavascript(GeolocationBridge.getShimScript(), null)
                 }
 
                 // Warm up the audio session on the first user gesture so async audio (e.g. AI
@@ -3669,6 +3689,7 @@ class WebViewManager(
                 removeJavascriptInterface("DownloadBridge")
                 removeJavascriptInterface("NativeShareBridge")
                 removeJavascriptInterface("AndroidPrint")
+                removeJavascriptInterface(GeolocationBridge.JS_INTERFACE_NAME)
                 removeJavascriptInterface(com.webtoapp.core.extension.GreasemonkeyBridge.JS_INTERFACE_NAME)
                 removeJavascriptInterface(com.webtoapp.core.extension.ChromeExtensionRuntime.JS_BRIDGE_NAME)
 
@@ -3702,12 +3723,18 @@ class WebViewManager(
             runCatching { handler.remove() }
         }
         blobCacheHookHandlers.clear()
+        geolocationShimHandlers.values.toList().forEach { handler ->
+            runCatching { handler.remove() }
+        }
+        geolocationShimHandlers.clear()
         managedWebViews.keys.toList().forEach { webView ->
             destroyWebView(webView)
         }
         managedWebViews.clear()
         gmBridge?.destroy()
         gmBridge = null
+        geoBridge?.destroy()
+        geoBridge = null
 
         extensionRuntimes.values.forEach { it.destroy() }
         extensionRuntimes.clear()
@@ -3805,6 +3832,24 @@ class WebViewManager(
             AppLogger.i("WebViewManager", "[DownloadBridge] Installed at document start (applies to all hosts)")
         } catch (e: Exception) {
             AppLogger.w("WebViewManager", "[DownloadBridge] Document-start install failed, will use onPageStarted fallback", e)
+        }
+    }
+
+    private fun installGeolocationShimDocumentStart(webView: WebView) {
+        if (geolocationShimHandlers.containsKey(webView)) return
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            AppLogger.d("WebViewManager", "[GeolocationBridge] Document-start script unsupported; shim will use onPageStarted fallback")
+            return
+        }
+        try {
+            geolocationShimHandlers[webView] = WebViewCompat.addDocumentStartJavaScript(
+                webView,
+                GeolocationBridge.getShimScript(),
+                setOf("*")
+            )
+            AppLogger.i("WebViewManager", "[GeolocationBridge] Native geolocation shim installed at document start")
+        } catch (e: Exception) {
+            AppLogger.w("WebViewManager", "[GeolocationBridge] Document-start install failed, will use onPageStarted fallback", e)
         }
     }
 

--- a/app/src/main/java/com/webtoapp/data/model/WebApp.kt
+++ b/app/src/main/java/com/webtoapp/data/model/WebApp.kt
@@ -373,7 +373,7 @@ data class WebViewConfig(
     val nativeBridgeCapabilities: NativeBridgeCapabilities = NativeBridgeCapabilities(),
 
     val geolocationEnabled: Boolean = false,
-    val geolocationAccuracy: GeolocationAccuracy = GeolocationAccuracy.COARSE,
+    val geolocationAccuracy: GeolocationAccuracy = GeolocationAccuracy.FINE,
     val geolocationPolicy: GeolocationPolicy = GeolocationPolicy.ALWAYS_ASK,
     val enableBlobDownloadInterception: Boolean = true,
     val blobInterceptScope: BlobInterceptScope = BlobInterceptScope.ALL,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -222,6 +222,13 @@ class ShellActivity : AppCompatActivity() {
         )
     }
 
+    fun requestGeolocationAccess(onResult: (Boolean) -> Unit) {
+        permissionDelegate.requestLocationAccess(
+            accuracy = shellConfig?.webViewConfig?.geolocationAccuracy ?: "COARSE",
+            onResult = onResult
+        )
+    }
+
     fun handleDownloadWithPermission(
         url: String,
         userAgent: String,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellPermissionDelegate.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellPermissionDelegate.kt
@@ -29,6 +29,7 @@ class ShellPermissionDelegate(private val activity: AppCompatActivity) {
     private var pendingPermissionRequest: PermissionRequest? = null
     private var pendingGeolocationOrigin: String? = null
     private var pendingGeolocationCallback: GeolocationPermissions.Callback? = null
+    private val pendingLocationAccessCallbacks = mutableListOf<(Boolean) -> Unit>()
 
     private var pendingDownload: PendingDownload? = null
 
@@ -451,6 +452,12 @@ class ShellPermissionDelegate(private val activity: AppCompatActivity) {
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         val granted = permissions.values.any { it }
+        if (pendingLocationAccessCallbacks.isNotEmpty()) {
+            if (granted && isSystemLocationEnabled()) settleLocationAccess(true)
+            else if (granted) showLocationSettingsDialog()
+            else settleLocationAccess(false)
+            return@registerForActivityResult
+        }
         if (granted && pendingGeolocationOrigin != null) {
             GeolocationPermissionsSingleton.addAllowedOrigin(pendingGeolocationOrigin!!)
             if (isSystemLocationEnabled()) {
@@ -470,6 +477,10 @@ class ShellPermissionDelegate(private val activity: AppCompatActivity) {
     private val locationSettingsLauncher = activity.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
+        if (pendingLocationAccessCallbacks.isNotEmpty()) {
+            settleLocationAccess(isSystemLocationEnabled())
+            return@registerForActivityResult
+        }
         val origin = pendingGeolocationOrigin
         val cb = pendingGeolocationCallback
         if (origin != null && cb != null && isSystemLocationEnabled()) {
@@ -499,18 +510,53 @@ class ShellPermissionDelegate(private val activity: AppCompatActivity) {
                     )
                 } catch (e: Exception) {
                     AppLogger.w("ShellPermission", "location settings intent failed: ${e.message}")
+                    settleLocationAccess(false)
                     pendingGeolocationCallback?.invoke(pendingGeolocationOrigin, false, false)
                     pendingGeolocationOrigin = null
                     pendingGeolocationCallback = null
                 }
             }
             .setNegativeButton(Strings.geolocationLocationOffCancel) { _, _ ->
+                settleLocationAccess(false)
                 pendingGeolocationCallback?.invoke(pendingGeolocationOrigin, false, false)
                 pendingGeolocationOrigin = null
                 pendingGeolocationCallback = null
             }
             .setCancelable(false)
             .show()
+    }
+
+    /**
+     * Request location access (Android runtime permission + system location service check)
+     * on behalf of GeolocationBridge's native navigator.geolocation backend. The host shows
+     * the same system dialog and location-services dialog used by the Chromium prompt path.
+     */
+    fun requestLocationAccess(accuracy: String, onResult: (Boolean) -> Unit) {
+        val perms = if (accuracy.equals("FINE", ignoreCase = true)) {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+        } else {
+            arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+        val notGranted = perms.filter {
+            ContextCompat.checkSelfPermission(activity, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (notGranted.isEmpty()) {
+            if (isSystemLocationEnabled()) {
+                onResult(true)
+            } else {
+                pendingLocationAccessCallbacks.add(onResult)
+                showLocationSettingsDialog()
+            }
+            return
+        }
+        pendingLocationAccessCallbacks.add(onResult)
+        locationPermissionLauncher.launch(notGranted.toTypedArray())
+    }
+
+    private fun settleLocationAccess(granted: Boolean) {
+        val callbacks = pendingLocationAccessCallbacks.toList()
+        pendingLocationAccessCallbacks.clear()
+        callbacks.forEach { it(granted) }
     }
 
     fun handlePermissionRequest(request: PermissionRequest) {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
@@ -160,12 +160,17 @@ fun createShellWebViewCallbacks(
         ) {
 
             (context as? ShellActivity)?.handleGeolocationPermission(origin, callback)
-                ?: callback?.invoke(origin, true, false)
+                ?: callback?.invoke(origin, false, false)
         }
 
         override fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {
             (context as? ShellActivity)?.handleAndroidPermissionsRequest(permissions, onResult)
                 ?: onResult(true)
+        }
+
+        override fun requestGeolocationAccess(onResult: (Boolean) -> Unit) {
+            (context as? ShellActivity)?.requestGeolocationAccess(onResult)
+                ?: onResult(false)
         }
 
         override fun onPermissionRequest(request: PermissionRequest?) {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -137,6 +137,7 @@ class WebViewActivity : AppCompatActivity() {
     private var pendingPermissionRequest: PermissionRequest? = null
     private var pendingGeolocationOrigin: String? = null
     private var pendingGeolocationCallback: GeolocationPermissions.Callback? = null
+    private val pendingLocationAccessCallbacks = mutableListOf<(Boolean) -> Unit>()
     internal var geolocationPolicy: String = "ALWAYS_ASK"
     internal var geolocationAccuracy: String = "COARSE"
 
@@ -468,6 +469,12 @@ class WebViewActivity : AppCompatActivity() {
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         val granted = permissions.values.any { it }
+        if (pendingLocationAccessCallbacks.isNotEmpty()) {
+            if (granted && isSystemLocationEnabled()) settleLocationAccess(true)
+            else if (granted) showLocationSettingsDialog()
+            else settleLocationAccess(false)
+            return@registerForActivityResult
+        }
         if (granted && pendingGeolocationOrigin != null) {
             GeolocationPermissionsSingleton.addAllowedOrigin(pendingGeolocationOrigin!!)
             if (isSystemLocationEnabled()) {
@@ -487,6 +494,10 @@ class WebViewActivity : AppCompatActivity() {
     private val locationSettingsLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
+        if (pendingLocationAccessCallbacks.isNotEmpty()) {
+            settleLocationAccess(isSystemLocationEnabled())
+            return@registerForActivityResult
+        }
         val origin = pendingGeolocationOrigin
         val cb = pendingGeolocationCallback
         if (origin != null && cb != null && isSystemLocationEnabled()) {
@@ -516,18 +527,51 @@ class WebViewActivity : AppCompatActivity() {
                     )
                 } catch (e: Exception) {
                     AppLogger.w("WebViewActivity", "location settings intent failed: ${e.message}")
+                    settleLocationAccess(false)
                     pendingGeolocationCallback?.invoke(pendingGeolocationOrigin, false, false)
                     pendingGeolocationOrigin = null
                     pendingGeolocationCallback = null
                 }
             }
             .setNegativeButton(Strings.geolocationLocationOffCancel) { _, _ ->
+                settleLocationAccess(false)
                 pendingGeolocationCallback?.invoke(pendingGeolocationOrigin, false, false)
                 pendingGeolocationOrigin = null
                 pendingGeolocationCallback = null
             }
             .setCancelable(false)
             .show()
+    }
+
+    fun requestGeolocationAccess(onResult: (Boolean) -> Unit) {
+        val perms = if (geolocationAccuracy.equals("FINE", ignoreCase = true)) {
+            arrayOf(
+                android.Manifest.permission.ACCESS_FINE_LOCATION,
+                android.Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        } else {
+            arrayOf(android.Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+        val notGranted = perms.filter {
+            androidx.core.content.ContextCompat.checkSelfPermission(this, it) !=
+                android.content.pm.PackageManager.PERMISSION_GRANTED
+        }
+        if (notGranted.isEmpty()) {
+            if (isSystemLocationEnabled()) onResult(true)
+            else {
+                pendingLocationAccessCallbacks.add(onResult)
+                showLocationSettingsDialog()
+            }
+            return
+        }
+        pendingLocationAccessCallbacks.add(onResult)
+        locationPermissionLauncher.launch(notGranted.toTypedArray())
+    }
+
+    private fun settleLocationAccess(granted: Boolean) {
+        val callbacks = pendingLocationAccessCallbacks.toList()
+        pendingLocationAccessCallbacks.clear()
+        callbacks.forEach { it(granted) }
     }
 
     private val notificationPermissionLauncher = registerForActivityResult(
@@ -2316,7 +2360,12 @@ fun WebViewScreen(
             ) {
 
                 (activity as? WebViewActivity)?.handleGeolocationPermission(origin, callback)
-                    ?: callback?.invoke(origin, true, false)
+                    ?: callback?.invoke(origin, false, false)
+            }
+
+            override fun requestGeolocationAccess(onResult: (Boolean) -> Unit) {
+                (activity as? WebViewActivity)?.requestGeolocationAccess(onResult)
+                    ?: onResult(false)
             }
 
             override fun onPermissionRequest(request: PermissionRequest?) {

--- a/app/src/test/java/com/webtoapp/core/webview/GeolocationBridgeTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/GeolocationBridgeTest.kt
@@ -1,0 +1,192 @@
+package com.webtoapp.core.webview
+
+import android.Manifest
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class GeolocationBridgeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun shadowLocationManager() =
+        shadowOf(context.getSystemService(Context.LOCATION_SERVICE) as LocationManager)
+
+    private fun idleMain() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun denyLocationPermissions() {
+        shadowOf(ApplicationProvider.getApplicationContext<android.app.Application>()).denyPermissions(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        )
+    }
+
+    private fun grantLocationPermissions() {
+        shadowOf(ApplicationProvider.getApplicationContext<android.app.Application>()).grantPermissions(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        )
+    }
+
+    private fun freshLocation(lat: Double, lon: Double): Location =
+        Location(LocationManager.NETWORK_PROVIDER).apply {
+            latitude = lat
+            longitude = lon
+            accuracy = 10f
+            time = System.currentTimeMillis()
+        }
+
+    private fun newBridge(
+        policy: String = "ALWAYS_ASK",
+        js: MutableList<String> = mutableListOf(),
+        requester: ((Boolean) -> Unit) -> Unit = { it(false) }
+    ) = GeolocationBridge(
+        context = context,
+        policy = policy,
+        accuracy = "FINE",
+        webViewProvider = { null },
+        permissionRequester = requester,
+        jsSink = { js.add(it) }
+    ) to js
+
+    @Test
+    fun denyAllPolicyReportsPermissionDeniedWithoutRequesting() {
+        val requesterCalls = mutableListOf<(Boolean) -> Unit>()
+        val (bridge, js) = newBridge(
+            policy = "DENY_ALL",
+            requester = { cb -> requesterCalls.add(cb) }
+        )
+
+        bridge.requestPosition("1", "https://example.com", true)
+        idleMain()
+
+        assertTrue(requesterCalls.isEmpty())
+        assertEquals(1, js.size)
+        assertTrue(js[0].contains("onResult(\"1\",false,null,1,"))
+    }
+
+    @Test
+    fun deniedAndroidPermissionSettlesAsPermissionDenied() {
+        denyLocationPermissions()
+        var captured: ((Boolean) -> Unit)? = null
+        val (bridge, js) = newBridge(requester = { cb -> captured = cb })
+
+        bridge.requestPosition("1", "https://example.com", true)
+        idleMain()
+        assertTrue(captured != null)
+
+        captured?.invoke(false)
+        idleMain()
+
+        assertEquals(1, js.size)
+        assertTrue(js[0].contains("onResult(\"1\",false,null,1,"))
+    }
+
+    @Test
+    fun grantedAccessWithFreshLastKnownEmitsPositionImmediately() {
+        grantLocationPermissions()
+        val (bridge, js) = newBridge()
+        shadowLocationManager().apply {
+            setProviderEnabled(LocationManager.GPS_PROVIDER, false)
+            setProviderEnabled(LocationManager.NETWORK_PROVIDER, true)
+            setLastKnownLocation(LocationManager.NETWORK_PROVIDER, freshLocation(35.7, 51.4))
+        }
+
+        bridge.requestPosition("7", "https://example.com", false)
+        idleMain()
+
+        assertEquals(1, js.size)
+        assertTrue(js[0].contains("onResult(\"7\",true,"))
+        assertTrue(js[0].contains("\"latitude\":35.7"))
+        assertTrue(js[0].contains("\"longitude\":51.4"))
+    }
+
+    @Test
+    fun noEnabledProvidersReportsUnavailable() {
+        denyLocationPermissions()
+        var captured: ((Boolean) -> Unit)? = null
+        val (bridge, js) = newBridge(requester = { cb -> captured = cb })
+        shadowLocationManager().apply {
+            setProviderEnabled(LocationManager.GPS_PROVIDER, false)
+            setProviderEnabled(LocationManager.NETWORK_PROVIDER, false)
+            setProviderEnabled(LocationManager.PASSIVE_PROVIDER, false)
+        }
+
+        bridge.requestPosition("1", "https://example.com", true)
+        idleMain()
+        captured?.invoke(true)
+        idleMain()
+
+        assertEquals(1, js.size)
+        assertTrue(js[0].contains("onResult(\"1\",false,null,2,"))
+        assertTrue(js[0].contains("Location services are disabled"))
+    }
+
+    @Test
+    fun watchEmitsUpdatesAndStopsAfterClearWatch() {
+        grantLocationPermissions()
+        val (bridge, js) = newBridge()
+        val shadowLm = shadowLocationManager()
+        shadowLm.setProviderEnabled(LocationManager.NETWORK_PROVIDER, true)
+
+        bridge.startWatch("w1", "https://example.com", false)
+        idleMain()
+
+        shadowLm.simulateLocation(freshLocation(35.71, 51.41))
+        idleMain()
+        val emittedAfterUpdate = js.size
+        assertTrue(emittedAfterUpdate >= 1)
+        assertTrue(js.any { it.contains("onResult(\"w1\",true,") && it.contains("\"latitude\":35.71") })
+
+        bridge.stopWatch("w1")
+        idleMain()
+        val sizeAfterStop = js.size
+
+        shadowLm.simulateLocation(freshLocation(35.72, 51.42))
+        idleMain()
+
+        assertEquals(sizeAfterStop, js.size)
+    }
+
+    @Test
+    fun destroyStopsEmitting() {
+        grantLocationPermissions()
+        val (bridge, js) = newBridge()
+        val shadowLm = shadowLocationManager()
+        shadowLm.setProviderEnabled(LocationManager.NETWORK_PROVIDER, true)
+
+        bridge.startWatch("w1", "https://example.com", false)
+        idleMain()
+        bridge.destroy()
+        idleMain()
+
+        val sizeAfterDestroy = js.size
+        shadowLm.simulateLocation(freshLocation(35.73, 51.43))
+        idleMain()
+
+        assertEquals(sizeAfterDestroy, js.size)
+    }
+
+    @Test
+    fun shimScriptOverridesNavigatorGeolocationAndQueriesPermissions() {
+        val script = GeolocationBridge.getShimScript()
+        assertTrue(script.contains("window._wtaGeoShimmed"))
+        assertTrue(script.contains("getCurrentPosition"))
+        assertTrue(script.contains("watchPosition"))
+        assertTrue(script.contains("clearWatch"))
+        assertTrue(script.contains("permissions.query"))
+        assertFalse(script.contains("\${"))
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the System WebView `navigator.geolocation` backend with a native `LocationManager` bridge so that location works on devices without reachable Google Play Services.

Chromium's WebView serves `navigator.geolocation` exclusively through GMS' fused location provider, with no fallback: on de-Googled ROMs or sanctioned networks (e.g. Iran), the Android permission is granted but a fix never arrives and pages silently time out. This is the real root cause behind the recurring location reports (#187, #292, #344, #581) — the app-side permission chain has been correct since v2.4.0; the failure was always one layer deeper inside the WebView.

When `webViewConfig.geolocationEnabled` is on (host preview and generated apps alike):

- A `GeolocationBridge` (`WtaGeolocation` JS interface) serves positions from GPS / network / passive providers — no Google services involved, with a fresh-last-known fast path and watch/clearWatch lifecycle.
- A document-start shim (onPageStarted fallback) rewrites `getCurrentPosition` / `watchPosition` / `clearWatch`, mirroring `Position` / `PositionError` semantics including `timeout`, `maximumAge`, `enableHighAccuracy`, and `permissions.query('geolocation')`.
- Permission prompts go through the new `WebViewCallbacks.requestGeolocationAccess`, reusing the same system permission dialog + "location services are off" dialog as the Chromium prompt path (queued settle for concurrent requests).

Secondary fixes traced along the way:

- Non-Activity fallback paths in `ShellWebViewCallbacks` / `WebViewActivity` auto-granted geolocation without any permission check; they now deny.
- Default `geolocationAccuracy` changes `COARSE` → `FINE` so taxi/navigation PWAs (Tapsi, Snapp) receive street-level fixes instead of ~2km approximations.

No new config fields — existing `geolocationEnabled` / `geolocationPolicy` / `geolocationAccuracy` are reused, so there is no config drift. Shell template rebuilt with the new class (`core/webview/**` is shell-synced).

Fixes #581

## Test plan

- [x] New `GeolocationBridgeTest` (Robolectric, 7 cases): DENY_ALL policy short-circuits to `PERMISSION_DENIED`; denied Android permission settles as denied; fresh last-known emits a position immediately; no enabled provider reports `POSITION_UNAVAILABLE` with the services-off message; watch emits updates and stops after `clearWatch`; `destroy()` stops emissions; shim script overrides `navigator.geolocation` and patches `permissions.query`.
- [x] `:app:compileStandardDebugKotlin` clean.
- [x] `:app:checkConfigFieldDrift` clean.
- [x] `:shell:assembleRelease` + `:app:syncShellTemplateApk` — template rebuilt, `GeolocationBridge` confirmed in shell DEX.
- [ ] CI `check` job (compile + full unit tests + drift gate).