### PR TITLE
fix(engine): seed ThreadUtils.sGeckoHandler before GeckoRuntime creation (GeckoView launch NPE)

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -315,7 +315,33 @@ class GeckoViewEngine(
             else -> "\"" + value.toString().replace("\\", "\\\\").replace("\"", "\\\"") + "\""
         }
 
+        /**
+         * GeckoView 142 race workaround (#582). GeckoRuntime.init() calls
+         * ProcessLifecycleOwner.addObserver(LifecycleListener) right after
+         * GeckoThread.launch(). When the process lifecycle is already RESUMED at that
+         * moment (generated apps create the engine from Compose's first layout, after
+         * the activity has resumed), LifecycleRegistry synchronously dispatches
+         * ON_RESUME and LifecycleListener.onResume() dereferences
+         * ThreadUtils.sGeckoHandler — a field the native side only assigns later on
+         * the gecko thread, so the dereference is a guaranteed NPE. Seed it with the
+         * main handler; the only runnable ever posted through this path
+         * (Clipboard.updateSequenceNumber) is main-thread safe, and native overwrites
+         * the field with the real gecko-thread handler once the thread boots.
+         */
+        internal fun ensureGeckoHandlerSeeded() {
+            try {
+                if (org.mozilla.gecko.util.ThreadUtils.sGeckoHandler == null) {
+                    org.mozilla.gecko.util.ThreadUtils.sGeckoHandler =
+                        android.os.Handler(android.os.Looper.getMainLooper())
+                    AppLogger.i(TAG, "Seeded ThreadUtils.sGeckoHandler with main handler (lifecycle race workaround)")
+                }
+            } catch (t: Throwable) {
+                AppLogger.w(TAG, "sGeckoHandler seed failed: ${t.message}")
+            }
+        }
+
         private fun createRuntime(context: Context): GeckoRuntime {
+            ensureGeckoHandlerSeeded()
             val settingsBuilder = GeckoRuntimeSettings.Builder()
                 .javaScriptEnabled(true)
                 .consoleOutput(true)

--- a/app/src/test/java/com/webtoapp/core/engine/GeckoViewEngineSeedTest.kt
+++ b/app/src/test/java/com/webtoapp/core/engine/GeckoViewEngineSeedTest.kt
@@ -1,0 +1,55 @@
+package com.webtoapp.core.engine
+
+import android.os.Handler
+import android.os.Looper
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeckoViewEngineSeedTest {
+
+    @After
+    fun restoreHandler() {
+        org.mozilla.gecko.util.ThreadUtils.sGeckoHandler = null
+    }
+
+    @Test
+    fun `seed installs main handler when sGeckoHandler is null`() {
+        org.mozilla.gecko.util.ThreadUtils.sGeckoHandler = null
+
+        GeckoViewEngine.ensureGeckoHandlerSeeded()
+
+        val handler = org.mozilla.gecko.util.ThreadUtils.sGeckoHandler
+        assertNotNull(handler)
+        assertEquals(Looper.getMainLooper(), handler!!.looper)
+    }
+
+    @Test
+    fun `seed keeps an already-assigned handler untouched`() {
+        val preset = Handler(Looper.getMainLooper())
+        org.mozilla.gecko.util.ThreadUtils.sGeckoHandler = preset
+
+        GeckoViewEngine.ensureGeckoHandlerSeeded()
+
+        assertSame(preset, org.mozilla.gecko.util.ThreadUtils.sGeckoHandler)
+    }
+
+    @Test
+    fun `seed is idempotent and postable before native assignment`() {
+        org.mozilla.gecko.util.ThreadUtils.sGeckoHandler = null
+
+        GeckoViewEngine.ensureGeckoHandlerSeeded()
+        val first = org.mozilla.gecko.util.ThreadUtils.sGeckoHandler
+        GeckoViewEngine.ensureGeckoHandlerSeeded()
+
+        assertSame(first, org.mozilla.gecko.util.ThreadUtils.sGeckoHandler)
+
+        // The ON_RESUME dispatch does exactly this before native boots; must not throw.
+        org.mozilla.gecko.util.ThreadUtils.sGeckoHandler!!.post {}
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the 100%-reproducible launch crash of generated GeckoView APKs reported in #582.

GeckoView 142's `GeckoRuntime.init()` calls `GeckoThread.launch()` and then registers `LifecycleListener` on `ProcessLifecycleOwner`. If the process lifecycle is **already RESUMED** at registration, `LifecycleRegistry` synchronously replays ON_CREATE → ON_START → ON_RESUME into the new observer, and `LifecycleListener.onResume()` dereferences `ThreadUtils.sGeckoHandler` — a field with no Java initializer that native code assigns asynchronously on the gecko thread. The UI thread always wins that race, so the replayed ON_RESUME NPEs on the null handler (verified against the GeckoView 142 bytecode: `launch()` at offset 479, `addObserver` at 573, and zero Java-side writes to `sGeckoHandler` in the whole DEX).

Why the host preview survived while generated APKs crashed: the host creates its runtime before the process reaches RESUMED (or reuses an existing one), so the replay never included ON_RESUME. Generated apps show a splash and create the engine from Compose's first layout — strictly after the activity has resumed — which is exactly the replay condition. Not device-specific.

**Fix:** seed `ThreadUtils.sGeckoHandler` with the main-thread handler (only when still null) before `GeckoRuntime.create()`:

- The only runnable ever posted through this path is `Clipboard.updateSequenceNumber` (confirmed by disassembly) — main-thread safe.
- Native overwrites the field with the real gecko-thread handler once the thread boots, so post-startup behavior is unchanged.
- `org.mozilla.gecko.**` is fully kept in both proguard configs, so the field access is stable under R8.
- Shell template rebuilt with the fix.

Fixes #582

## Test plan

- [x] New `GeckoViewEngineSeedTest` (Robolectric, 3 cases): seed installs the main handler when null; seed keeps an already-assigned handler untouched; seed is idempotent and the handler is postable before native assignment.
- [x] `:app:compileStandardDebugKotlin` clean.
- [x] `:app:checkConfigFieldDrift` clean.
- [x] `:shell:assembleRelease` + `:app:syncShellTemplateApk` — template rebuilt, fix confirmed in synced shell sources.
- [ ] CI `check` job.
- [ ] Reporter verification on the repro from the issue (GeckoView APK on Android 16/LineageOS) once a build with this fix ships.