### PR TITLE
fix(agent): stop plan-mode permission leak and truncated-arg silent execution

### DIFF
--- a/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/engine/AgentEngine.kt
@@ -192,7 +192,12 @@ class AgentEngine(
                     send(AgentEvent.Notice(Strings.agentOutputTruncated))
                 }
 
+                // Keep the raw (pre-sanitised) arguments per call: a truncated
+                // arguments stream must be reported to the model as such, not
+                // silently coerced to "{}" and executed with missing params.
+                val rawArgsById = HashMap<String, String>()
                 val assistantToolCalls = pending.entries.map { (id, pair) ->
+                    rawArgsById[id] = pair.second.toString()
                     LlmToolCall(id, pair.first, sanitizeArgumentsJson(pair.second.toString()))
                 }
                 messages += LlmMessage(
@@ -216,13 +221,13 @@ class AgentEngine(
                 for (batch in batches) {
                     if (abortController.aborted) { send(AgentEvent.Aborted); return@channelFlow }
                     if (batch.parallel) {
-                        val results = runParallel(batch.calls, input, channel)
+                        val results = runParallel(batch.calls, input, channel, rawArgsById)
                         for ((call, result) in results) {
                             totalToolCalls++
                             emitToolFinish(call, result, channel)
                             toolMessages += LlmMessage(
                                 role = LlmMessage.Role.TOOL,
-                                content = trimToolText(result.text),
+                                content = trimToolText(result.text).ifEmpty { NO_TOOL_OUTPUT },
                                 toolCallId = call.id,
                                 name = call.name,
                                 images = result.images
@@ -239,12 +244,12 @@ class AgentEngine(
                     } else {
                         for (call in batch.calls) {
                             if (abortController.aborted) { send(AgentEvent.Aborted); return@channelFlow }
-                            val result = runSequential(call, input, channel)
+                            val result = runSequential(call, input, channel, rawArgsById)
                             totalToolCalls++
                             emitToolFinish(call, result, channel)
                             toolMessages += LlmMessage(
                                 role = LlmMessage.Role.TOOL,
-                                content = trimToolText(result.text),
+                                content = trimToolText(result.text).ifEmpty { NO_TOOL_OUTPUT },
                                 toolCallId = call.id,
                                 name = call.name,
                                 images = result.images
@@ -289,19 +294,33 @@ class AgentEngine(
     private suspend fun runSequential(
         call: LlmToolCall,
         input: Input,
-        out: SendChannel<AgentEvent>
+        out: SendChannel<AgentEvent>,
+        rawArgsById: Map<String, String>
     ): ToolResult {
         val tool = input.registry[call.name]
             ?: return ToolResult.error("Unknown tool: ${call.name}")
-        val args = parseArgs(call.argumentsJson)
 
         out.send(
             AgentEvent.ToolExecuting(
                 toolCallId = call.id,
                 name = call.name,
-                activity = tool.activityDescription(args) ?: call.name
+                activity = tool.activityDescription(parseArgs(call.argumentsJson)) ?: call.name
             )
         )
+
+        // Weak models frequently get cut off by the token limit mid-arguments,
+        // leaving invalid JSON. Coercing that to "{}" and executing anyway just
+        // produces confusing "missing parameter" errors the model cannot trace
+        // back to the truncation — reject with the real reason instead.
+        val rawArgs = rawArgsById[call.id]
+        if (!rawArgs.isNullOrBlank() && !isValidJsonObject(rawArgs)) {
+            return ToolResult.error(
+                "${call.name}: arguments JSON was invalid or truncated (likely cut off by the " +
+                    "token limit) and were NOT executed. Re-issue this tool call with complete arguments."
+            )
+        }
+
+        val args = parseArgs(call.argumentsJson)
 
         val decision = permissionChecker.check(tool, args, input.toolContext)
         if (decision == PermissionDecision.Deny) {
@@ -348,12 +367,13 @@ class AgentEngine(
     private suspend fun runParallel(
         calls: List<LlmToolCall>,
         input: Input,
-        out: SendChannel<AgentEvent>
+        out: SendChannel<AgentEvent>,
+        rawArgsById: Map<String, String>
     ): List<Pair<LlmToolCall, ToolResult>> =
         coroutineScope {
             val deferred = calls.map { call ->
                 async {
-                    call to runSequential(call, input, out)
+                    call to runSequential(call, input, out, rawArgsById)
                 }
             }
             deferred.map { it.await() }
@@ -390,6 +410,10 @@ class AgentEngine(
         return if (valid) json else "{}"
     }
 
+    private fun isValidJsonObject(json: String): Boolean = runCatching {
+        JsonParser.parseString(json).isJsonObject
+    }.getOrDefault(false)
+
     private fun trimToolText(text: String): String =
         if (text.length <= MAX_TOOL_RESULT_CHARS) text
         else text.substring(0, MAX_TOOL_RESULT_CHARS) + "\n… (tool result truncated)"
@@ -400,6 +424,10 @@ class AgentEngine(
         private const val TAG = "AgentEngine"
         private const val MAX_TOOL_RESULT_CHARS = 32_000
         private const val MAX_RATE_LIMIT_RETRIES = 5
+
+        // Some OpenAI-compat gateways reject tool messages with empty content;
+        // always send a placeholder instead of "".
+        private const val NO_TOOL_OUTPUT = "(no output)"
         // If the LLM stream emits nothing for this long, treat it as a stalled
         // connection and retry (some OpenAI-compat endpoints open the SSE channel,
         // send a partial response, then go silent without ever closing it). 90s is

--- a/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/llm/OpenAiCompatProvider.kt
@@ -142,7 +142,12 @@ internal class OpenAiCompatProvider(@Suppress("UNUSED_PARAMETER") context: Conte
         addProperty("model", req.model.id); addProperty("stream", true); addProperty("temperature", req.temperature)
         req.maxTokens?.let { addProperty("max_tokens", it) }
         add("messages", JsonArray().apply { req.messages.forEach { msg -> add(buildMsg(msg)) } })
-        if (req.useTools && req.tools.isNotEmpty()) add("tools", JsonArray().apply { req.tools.forEach { t -> add(buildTool(t)) } })
+        if (req.useTools && req.tools.isNotEmpty()) {
+            add("tools", JsonArray().apply { req.tools.forEach { t -> add(buildTool(t)) } })
+            // Some OpenAI-compat gateways (SenseNova etc.) don't default to "auto"
+            // and never emit tool calls unless tool_choice is explicit.
+            addProperty("tool_choice", "auto")
+        }
     }
     private fun buildMsg(msg: LlmMessage) = JsonObject().apply {
         addProperty("role", when(msg.role){LlmMessage.Role.SYSTEM->"system";LlmMessage.Role.USER->"user";LlmMessage.Role.ASSISTANT->"assistant";LlmMessage.Role.TOOL->"tool"})

--- a/app/src/main/java/com/webtoapp/core/agent/permission/PermissionChecker.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/permission/PermissionChecker.kt
@@ -12,6 +12,12 @@ class PermissionChecker(
     @Volatile var mode: PermissionMode = initialMode
         private set
 
+    // Baseline mode outside plan sessions. Plan mode is a temporary overlay on top
+    // of this baseline; approve()/resetToBaseline() return to it so an enabled
+    // auto-approve preference survives a plan round-trip, and a Plan mode left
+    // over from an abandoned plan review never leaks into later sessions.
+    @Volatile private var baselineMode: PermissionMode = initialMode
+
     private val alwaysAllow = mutableSetOf<String>()
 
     private val planAllowedTools = setOf(
@@ -28,6 +34,21 @@ class PermissionChecker(
 
     fun setMode(newMode: PermissionMode) {
         mode = newMode
+    }
+
+    /**
+     * Record the user's auto-approve preference as the baseline mode. Applied
+     * immediately only when no plan session is active — clobbering an active
+     * Plan mode here would silently re-allow writes the plan prompt forbids.
+     */
+    fun syncAutoApprove(enabled: Boolean) {
+        baselineMode = if (enabled) PermissionMode.AutoApprove else PermissionMode.Default
+        if (mode != PermissionMode.Plan) mode = baselineMode
+    }
+
+    /** Drop any active Plan overlay and return to the baseline mode. */
+    fun resetToBaseline() {
+        mode = baselineMode
     }
 
     fun isAlwaysAllowed(toolName: String): Boolean = toolName in alwaysAllow

--- a/app/src/main/java/com/webtoapp/core/agent/plan/PlanManager.kt
+++ b/app/src/main/java/com/webtoapp/core/agent/plan/PlanManager.kt
@@ -48,7 +48,7 @@ class PlanManager(
     }
 
     fun approve() {
-        permissionChecker.setMode(PermissionMode.Default)
+        permissionChecker.resetToBaseline()
         _state.value = State(active = false)
     }
 

--- a/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentViewModel.kt
@@ -159,10 +159,7 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun applyAutoApproveToService(enabled: Boolean) {
         val checker = service?.permissionChecker ?: return
-        checker.setMode(
-            if (enabled) com.webtoapp.core.agent.permission.PermissionMode.AutoApprove
-            else com.webtoapp.core.agent.permission.PermissionMode.Default
-        )
+        checker.syncAutoApprove(enabled)
     }
 
     private fun observeCurrentModel() {
@@ -1841,6 +1838,11 @@ class AgentViewModel(application: Application) : AndroidViewModel(application) {
         val session = sessionStore.get(id) ?: return
         val checker = service?.permissionChecker
         if (checker != null) {
+            // Fresh PlanManager per session — the checker's mode must follow suit.
+            // Without this reset, a Plan mode left over from an abandoned plan
+            // review in a previous session denies all writes while the prompt
+            // (and this fresh manager) say "not in plan mode".
+            checker.resetToBaseline()
             planManager = PlanManager(session.id, files, checker)
             registryFactory = ToolRegistryFactory(planManager!!, imageRegistry)
         } else {


### PR DESCRIPTION
## Summary

- Introduce a **baseline mode** in `PermissionChecker`: `syncAutoApprove()` records the auto-approve preference and applies it only outside an active plan session; `resetToBaseline()` drops stale Plan overlays. Previously an abandoned plan review left the checker stuck in Plan mode forever — later sessions had a prompt saying "not in plan mode" while every write was denied, and the deny hint pointed at `ExitPlanMode` which then returned "not currently in plan mode" (contradictory loop; only manually re-entering plan mode washed the state clean).
- `PlanManager.approve()` returns to the baseline instead of hardcoded `Default`, so an enabled auto-approve preference survives a plan round-trip.
- `AgentViewModel.attachSession()` resets the checker to baseline when rebuilding the per-session `PlanManager`, cutting the cross-session leak.
- `AgentEngine` now rejects tool calls whose arguments JSON is invalid/truncated (token-limit cutoff) instead of silently executing `{}` and reporting confusing "missing parameter" errors; empty tool results send a `(no output)` placeholder for gateways that reject empty tool-message content.
- `OpenAiCompatProvider` declares `tool_choice: "auto"` when tools are present — some OpenAI-compat gateways never emit tool calls without it.

Fixes #586

## Test plan

- [x] `./gradlew :app:compileStandardDebugKotlin -x syncCloneHostDex --no-configuration-cache` passes
- [x] Change review: tool names in `planAllowedTools` match registered tool `name` values; `resolveSafePath` output format matches `activePlanFile` relative-path format
- [ ] CI (android-ci) green

Host-only change (all under `core/agent` + `ui/agent`); no shell sync, no template rebuild, no config fields touched.