### PR TITLE
feat(python): restore host preview on targetSdk>=29 via patched musl exec bridge

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -349,12 +349,135 @@ abstract class SyncNativeExecutableJniLibsTask : DefaultTask() {
     }
 }
 
+/**
+ * Builds the patched musl dynamic linker (libmusl-linker.so) into generated
+ * jniLibs for arm64-v8a / x86_64. The linker carries the W^X exec bridge:
+ * app_data library fds that SELinux refuses to exec-map are copied into an
+ * executable memfd and mapped from there, restoring Python host previews on
+ * targetSdk>=29 builds. Source provenance: upstream musl tarball +
+ * scripts/patches/musl-1.2.5-wta-exec-bridge.patch +
+ * scripts/musl-bridge/wta_mulxc3.c (NDK compiler-rt drops x86_80 routines).
+ */
+abstract class BuildMuslBridgeTask : DefaultTask() {
+    @get:Input
+    abstract val muslVersion: org.gradle.api.provider.Property<String>
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val patchFile: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val x80ShimFile: RegularFileProperty
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val ndkToolchainDir: DirectoryProperty
+
+    @get:Internal
+    abstract val workDir: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    private fun run(cmd: List<String>, cwd: File? = null, env: Map<String, String> = emptyMap()) {
+        val proc = ProcessBuilder(cmd).apply {
+            if (cwd != null) directory(cwd)
+            environment().putAll(env)
+            redirectErrorStream(true)
+        }.start()
+        val out = proc.inputStream.bufferedReader().readText()
+        val code = proc.waitFor()
+        if (code != 0) throw GradleException("command failed ($code): ${cmd.joinToString(" ")}\n$out")
+    }
+
+    @TaskAction
+    fun build() {
+        val tc = ndkToolchainDir.get().asFile
+        if (!File(tc, "bin/clang").isFile) {
+            throw GradleException("NDK toolchain not found at $tc (set NDKVersion or install the NDK)")
+        }
+        val libccDir = File(tc, "lib/clang")
+            .listFiles { f -> f.isDirectory }?.map { File(it, "lib/linux") }.orEmpty()
+        fun libcc(name: String): String =
+            libccDir.firstOrNull { File(it, name).isFile }?.resolve(name)?.absolutePath
+                ?: throw GradleException("compiler-rt $name not found under $tc")
+
+        val work = workDir.get().asFile.apply { mkdirs() }
+        val version = muslVersion.get()
+        val tarball = File(work, "musl-$version.tar.gz")
+        if (!tarball.isFile) {
+            run(
+                listOf(
+                    "curl", "-fsSL", "--max-time", "180", "-o", tarball.absolutePath,
+                    "https://musl.libc.org/releases/musl-$version.tar.gz"
+                )
+            )
+        }
+        val src = File(work, "musl-$version")
+        src.deleteRecursively()
+        run(listOf("tar", "xzf", tarball.absolutePath, "-C", work.absolutePath))
+        run(listOf("patch", "-p1", "-d", src.absolutePath, "--input", patchFile.get().asFile.absolutePath))
+        File(src, "src/math/x86_64").also { it.mkdirs() }
+            .resolve(x80ShimFile.get().asFile.name).run {
+                x80ShimFile.get().asFile.copyTo(this, overwrite = true)
+            }
+
+        val clang = File(tc, "bin/clang").absolutePath
+        val strip = File(tc, "bin/llvm-strip").absolutePath
+        val jobs = Runtime.getRuntime().availableProcessors().toString()
+        val targets = listOf(
+            "arm64-v8a" to ("aarch64-linux-musl" to "libclang_rt.builtins-aarch64-android.a"),
+            "x86_64" to ("x86_64-linux-musl" to "libclang_rt.builtins-x86_64-android.a")
+        )
+        val out = outputDir.get().asFile
+        out.deleteRecursively()
+        for ((abi, target) in targets) {
+            val (triple, rt) = target
+            val buildDir = File(work, "build-$abi").apply { deleteRecursively(); mkdirs() }
+            val libccPath = libcc(rt)
+            val configureEnv = mapOf(
+                "CC" to "$clang --target=$triple",
+                "CROSS_COMPILE" to "${File(tc, "bin/llvm-").absolutePath}",
+                "CFLAGS" to "-O2",
+                "LDFLAGS" to "-Wl,-z,max-page-size=16384"
+            )
+            run(listOf("../musl-$version/configure", "--target=$triple"), cwd = buildDir, env = configureEnv)
+            run(listOf("make", "-j$jobs", "LIBCC=$libccPath"), cwd = buildDir, env = configureEnv)
+            val dest = File(out, "$abi/libmusl-linker.so")
+            dest.parentFile.mkdirs()
+            run(listOf(strip, File(buildDir, "lib/libc.so").absolutePath, "-o", dest.absolutePath))
+            dest.setExecutable(true, false)
+        }
+    }
+}
+
+val muslBridgeTask = tasks.register<BuildMuslBridgeTask>("buildMuslBridge") {
+    group = "build"
+    description = "Builds the patched musl dynamic linker (libmusl-linker.so) with the W^X exec bridge into generated jniLibs."
+    muslVersion.set("1.2.5")
+    patchFile.set(rootProject.file("scripts/patches/musl-1.2.5-wta-exec-bridge.patch"))
+    x80ShimFile.set(rootProject.file("scripts/musl-bridge/wta_mulxc3.c"))
+    val hostTag = if (System.getProperty("os.name").lowercase().contains("mac")) "darwin-x86_64" else "linux-x86_64"
+    ndkToolchainDir.set(File(android.ndkDirectory, "toolchains/llvm/prebuilt/$hostTag"))
+    workDir.set(layout.buildDirectory.dir("musl-bridge"))
+    outputDir.set(layout.buildDirectory.dir("generated/jniLibs/muslBridge"))
+}
+
 androidComponents {
     onVariants { variant ->
         val capName = variant.name.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
         val variantBuildTypeName = variant.buildType ?: "release"
         val cxxBuildType = if (variantBuildTypeName.equals("debug", ignoreCase = true)) "Debug" else "RelWithDebInfo"
         val nativeBuildTaskName = "buildCMake$cxxBuildType"
+
+        tasks.matching { it.name == "merge${capName}NativeLibs" }.configureEach {
+            dependsOn(muslBridgeTask)
+        }
+        variant.sources.jniLibs?.addGeneratedSourceDirectory(
+            muslBridgeTask,
+            BuildMuslBridgeTask::outputDir
+        )
         val syncNodeLauncherTask = tasks.register<SyncNativeExecutableJniLibsTask>("syncNodeLauncherJniLibs$capName") {
             group = "build"
             description = "Copies ABI-specific node launcher executables into generated jniLibs for ${variant.name}."

--- a/app/src/main/java/com/webtoapp/core/linux/RuntimeExecPolicy.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/RuntimeExecPolicy.kt
@@ -1,15 +1,19 @@
 package com.webtoapp.core.linux
 
 import android.content.Context
+import java.io.File
 
 /**
  * SELinux W^X policy gate for on-device fork+exec runtimes.
  *
- * Apps targeting SDK 29+ lose the ability to exec (or mmap PROT_EXEC) files in app
- * data storage — which is exactly where the on-demand server runtimes (Python / PHP /
- * WordPress) are downloaded and extracted. Binaries shipped as APK native libs
- * (Node.js via the JNI bridge) and memfd-exec loaders (Go) are not affected.
+ * Apps targeting SDK 29+ lose the ability to exec (or exec-map) files in app
+ * data storage — which is exactly where the on-demand server runtimes (Python /
+ * PHP / WordPress / Go) are downloaded and extracted. execveat on memfds is
+ * blocked too (no execute_no_trans on memfd labels, verified on API 35), so
+ * memfd-exec loaders do not bypass the gate; mmap PROT_EXEC on memfds stays
+ * allowed (same class ART JIT uses), which is what [hasMuslExecBridge] rides on.
  *
+ * Node.js host previews are unaffected (JNI native lib, no fork+exec).
  * Generated APKs keep targetSdk 28, so this only ever gates the *host preview*
  * runtimes; inside a generated app the probe always passes.
  */
@@ -22,6 +26,17 @@ object RuntimeExecPolicy {
             28
         }
         return target < 29
+    }
+
+    /**
+     * True when the patched musl linker is installed as a native lib. It execs
+     * from nativeLibraryDir (SELinux allows) and bridges exec-mapping of
+     * app_data ELFs through executable memfds, so musl-linked runtimes
+     * (Python) can start even where [canExecAppDataBinaries] is false.
+     */
+    fun hasMuslExecBridge(context: Context): Boolean {
+        val linker = File(context.applicationInfo.nativeLibraryDir, "libmusl-linker.so")
+        return linker.exists() && linker.canExecute()
     }
 
     /**

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -318,7 +318,9 @@ object PythonDependencyManager {
         extraEnv: Map<String, String> = emptyMap(),
         onOutput: ((String) -> Unit)? = null
     ): Boolean = withContext(Dispatchers.IO) {
-        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context) &&
+            !com.webtoapp.core.linux.RuntimeExecPolicy.hasMuslExecBridge(context)
+        ) {
             val msg = com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("Python")
             AppLogger.w(TAG, msg)
             onOutput?.invoke(msg)

--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -79,7 +79,9 @@ class PythonRuntime(private val context: Context) {
         customPythonExtensions: List<com.webtoapp.data.model.CustomPythonExtension> = emptyList()
     ): Int = withContext(Dispatchers.IO) {
         try {
-            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context) &&
+                !com.webtoapp.core.linux.RuntimeExecPolicy.hasMuslExecBridge(context)
+            ) {
                 val msg = com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("Python")
                 AppLogger.w(TAG, msg)
                 ShellLogger.w(TAG, msg)

--- a/app/src/test/java/com/webtoapp/core/linux/RuntimeExecPolicyTest.kt
+++ b/app/src/test/java/com/webtoapp/core/linux/RuntimeExecPolicyTest.kt
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -33,5 +34,28 @@ class RuntimeExecPolicyTest {
         assertThat(RuntimeExecPolicy.canExecAppDataBinaries(contextWithTargetSdk(35))).isFalse()
         assertThat(RuntimeExecPolicy.hostPreviewBlockedMessage("Python")).contains("Python")
         assertThat(RuntimeExecPolicy.restrictionNote()).isNotEmpty()
+    }
+
+    @Test
+    fun `exec bridge is absent without the native musl linker`() {
+        val app = contextWithTargetSdk(35)
+        val linker = File(app.applicationInfo.nativeLibraryDir, "libmusl-linker.so")
+        linker.delete()
+        assertThat(RuntimeExecPolicy.hasMuslExecBridge(app)).isFalse()
+    }
+
+    @Test
+    fun `exec bridge unlocks a high targetSdk build when the native musl linker exists`() {
+        val app = contextWithTargetSdk(35)
+        val linker = File(app.applicationInfo.nativeLibraryDir, "libmusl-linker.so")
+        linker.parentFile?.mkdirs()
+        linker.writeBytes(byteArrayOf(0x7f, 'E'.code.toByte(), 'L'.code.toByte(), 'F'.code.toByte()))
+        linker.setExecutable(true, false)
+        try {
+            assertThat(RuntimeExecPolicy.canExecAppDataBinaries(app)).isFalse()
+            assertThat(RuntimeExecPolicy.hasMuslExecBridge(app)).isTrue()
+        } finally {
+            linker.delete()
+        }
     }
 }

--- a/scripts/musl-bridge/wta_mulxc3.c
+++ b/scripts/musl-bridge/wta_mulxc3.c
@@ -1,0 +1,42 @@
+/* Android NDK's compiler-rt drops the x86_80 soft routines, so the linker
+ * misses __mulxc3 (complex long double multiply lowered by clang as a
+ * libcall). Equivalent of compiler-rt lib/builtins/mulxc3.c. */
+#include <math.h>
+
+long double _Complex __mulxc3(long double a, long double b,
+                              long double c, long double d)
+{
+	long double ac = a * c, bd = b * d, ad = a * d, bc = b * c;
+	long double _Complex z;
+	__real__ z = ac - bd;
+	__imag__ z = ad + bc;
+	if (isnan(__real__ z) && isnan(__imag__ z)) {
+		int recalc = 0;
+		if (isinf(a) || isinf(b)) {
+			a = copysignl(isinf(a) ? 1 : 0, a);
+			b = copysignl(isinf(b) ? 1 : 0, b);
+			if (isnan(c)) c = copysignl(0, c);
+			if (isnan(d)) d = copysignl(0, d);
+			recalc = 1;
+		}
+		if (isinf(c) || isinf(d)) {
+			c = copysignl(isinf(c) ? 1 : 0, c);
+			d = copysignl(isinf(d) ? 1 : 0, d);
+			if (isnan(a)) a = copysignl(0, a);
+			if (isnan(b)) b = copysignl(0, b);
+			recalc = 1;
+		}
+		if (!recalc && (isinf(ac) || isinf(bd) || isinf(ad) || isinf(bc))) {
+			if (isnan(a)) a = copysignl(0, a);
+			if (isnan(b)) b = copysignl(0, b);
+			if (isnan(c)) c = copysignl(0, c);
+			if (isnan(d)) d = copysignl(0, d);
+			recalc = 1;
+		}
+		if (recalc) {
+			__real__ z = INFINITY * (a * c - b * d);
+			__imag__ z = INFINITY * (a * d + b * c);
+		}
+	}
+	return z;
+}

--- a/scripts/patches/musl-1.2.5-wta-exec-bridge.patch
+++ b/scripts/patches/musl-1.2.5-wta-exec-bridge.patch
@@ -1,0 +1,71 @@
+Android targetSdk>=29 SELinux W^X denies exec-mapping app_data files, which
+kills every on-device runtime that keeps its ELF libraries in app storage.
+Bridge such fds into an executable memfd (the same permission class ART JIT
+relies on) before mapping. The probe keeps unrestricted environments
+(generated APKs stay at targetSdk 28) on the zero-overhead direct path.
+--- a/ldso/dynlink.c
++++ b/ldso/dynlink.c
+@@ -684,7 +684,11 @@
+ 	}
+ }
+ 
+-static void *map_library(int fd, struct dso *dso)
++#ifndef MFD_EXEC
++#define MFD_EXEC 0x0010U
++#endif
++
++static void *map_library_inner(int fd, struct dso *dso)
+ {
+ 	Ehdr buf[(896+sizeof(Ehdr))/sizeof(Ehdr)];
+ 	void *allocated_buf=0;
+@@ -868,8 +872,50 @@
+ 	if (map!=MAP_FAILED) unmap_library(dso);
+ 	free(allocated_buf);
+ 	return 0;
++}
++
++/* W^X bridge: if the fd cannot be exec-mapped, copy it into an executable
++ * memfd and map from there. Returns fd unchanged when mapping is allowed
++ * or the bridge is unavailable. */
++static int wta_exec_bridge(int fd)
++{
++	void *t = mmap(0, PAGE_SIZE, PROT_READ|PROT_EXEC, MAP_PRIVATE, fd, 0);
++	if (t != MAP_FAILED) {
++		munmap(t, PAGE_SIZE);
++		return fd;
++	}
++	int m = memfd_create("wta-lib", MFD_CLOEXEC | MFD_EXEC);
++	if (m < 0 && errno == EINVAL)
++		m = memfd_create("wta-lib", MFD_CLOEXEC);
++	if (m < 0) return fd;
++	off_t save = lseek(fd, 0, SEEK_CUR);
++	lseek(fd, 0, SEEK_SET);
++	char buf[65536];
++	ssize_t r;
++	while ((r = read(fd, buf, sizeof buf)) > 0) {
++		ssize_t off = 0;
++		while (off < r) {
++			ssize_t w = write(m, buf+off, r-off);
++			if (w < 0) { r = -1; break; }
++			off += w;
++		}
++		if (r < 0) break;
++	}
++	lseek(fd, save == (off_t)-1 ? 0 : save, SEEK_SET);
++	if (r < 0) { close(m); return fd; }
++	lseek(m, 0, SEEK_SET);
++	return m;
+ }
+ 
++static void *map_library(int fd, struct dso *dso)
++{
++	int bfd = wta_exec_bridge(fd);
++	if (bfd == fd) return map_library_inner(fd, dso);
++	void *res = map_library_inner(bfd, dso);
++	close(bfd);
++	return res;
++}
++
+ static int path_open(const char *name, const char *s, char *buf, size_t buf_size)
+ {
+ 	size_t l;


### PR DESCRIPTION
## Summary

- Patches musl 1.2.5's `map_library()` with a W^X exec bridge: when a library fd cannot be exec-mapped under SELinux (targetSdk>=29 app_data), it is copied into an executable memfd and mapped from there. `map_library` is the single choke point for the main binary, DT_NEEDED dependencies, and dlopen, so the whole Python process tree crosses the gate. Probe-first design keeps unrestricted environments (generated APKs, targetSdk 28) on the zero-overhead direct path — zero behavioral change for exports.
- New `buildMuslBridge` Gradle task builds the patched linker from source (download tarball → apply `scripts/patches/musl-1.2.5-wta-exec-bridge.patch` → NDK clang cross-compile arm64-v8a + x86_64 → strip into generated jniLibs). Same generated-artifact pattern as `go_exec_loader`; no binaries committed.
- `RuntimeExecPolicy.hasMuslExecBridge()`; Python server/pip gates become `canExecAppDataBinaries || hasMuslExecBridge`. The existing `resolveMuslLinker` native-first priority routes all launch paths (server command, pip wrapper, sitecustomize subprocess rewrites) onto the patched linker with zero path changes.
- Corrects the `RuntimeExecPolicy` class doc: memfd-execveat does NOT bypass W^X (aligns with the API 35 verification from #550).
- Design rests on the SELinux matrix: `execveat(memfd)` needs execute_no_trans (denied), `execve(nativeLibs)` allowed, `mmap(memfd, PROT_EXEC)` allowed (ART JIT's class), `mmap(app_data, PROT_EXEC)` denied.

Fixes #589

## Test plan

- [x] `:app:packageStandardDebug` — APK contains `libmusl-linker.so` (arm64-v8a + x86_64) built by the Gradle task from the patch; task incremental (UP-TO-DATE) on rerun
- [x] Bridge code verified inside the built artifacts (`wta-lib` memfd name present after strip); LOAD segments 16KB-aligned
- [x] `:app:testStandardDebugUnitTest` full suite green (incl. new `RuntimeExecPolicyTest` cases: bridge absent / bridge overrides high-targetSdk block)
- [x] CI NDK match: workflow pins `ndk;28.2.13676358`, the exact toolchain validated locally; check job does not trigger native merge, so no network need there
- [ ] **On-device validation pending**: install on an API 29+ device and run a Python preview end-to-end (documented in #589; core assumption `mmap(memfd, PROT_EXEC)` allowed for apps rests on the ART JIT permission class)

Host-side change; shell sync copies `RuntimeExecPolicy` automatically and generated APKs short-circuit at `canExecAppDataBinaries` (targetSdk 28), so no template repack is required for correctness.