### PR TITLE
feat(runtime): restore Go/PHP host preview on targetSdk>=29 via musl program mode and user-mode exec

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -128,6 +128,34 @@ add_executable(
     go_exec_loader.c
 )
 
+# User-mode exec loader for static ELFs (pmmp PHP) under SELinux W^X —
+# host-preview only; a real JNI shared library, loaded lazily by
+# StaticExecBridge when plain execve is unavailable. AArch64 only: the
+# child trampoline is AArch64 asm, and the loader parses AArch64 ELFs.
+if (ANDROID_ABI STREQUAL "arm64-v8a")
+    add_library(
+        static_exec
+        SHARED
+        static_exec_loader.c
+    )
+
+    target_link_libraries(
+        static_exec
+        ${log-lib}
+    )
+
+    target_compile_options(static_exec PRIVATE
+        -ffunction-sections
+        -fdata-sections
+        -O2
+        -DNDEBUG
+    )
+
+    set_target_properties(static_exec PROPERTIES
+        LINK_FLAGS "-Wl,--gc-sections -Wl,-z,max-page-size=16384"
+    )
+endif()
+
 set_property(TARGET node_launcher PROPERTY C_STANDARD 11)
 
 target_compile_options(node_launcher PRIVATE

--- a/app/src/main/cpp/static_exec_loader.c
+++ b/app/src/main/cpp/static_exec_loader.c
@@ -1,0 +1,695 @@
+/*
+ * static_exec_loader — user-mode exec for static ELFs under SELinux W^X.
+ *
+ * targetSdk>=29 apps cannot exec (or exec-map) files in app storage, so the
+ * pmmp static PHP binary can never go through execve(2). This loader rebuilds
+ * what the kernel does for execve, entirely in user mode:
+ *
+ *   1. fork a clean child (raw syscall; no atfork handlers run)
+ *   2. map the ELF's PT_LOAD segments from an executable memfd — the same
+ *      permission class ART JIT and the patched-musl bridge (#590) ride on;
+ *      direct exec-maps of app_data are what W^X denies
+ *   3. build the initial stack (argc/argv/envp/auxv) per the AArch64 ELF ABI
+ *   4. jump to e_entry
+ *
+ * Everything after fork() uses only raw syscalls plus lock-free libc string
+ * helpers writing into freshly mmap'd regions — async-signal-safe by
+ * construction. ELF parsing, the memfd copy, and argv/envp blob assembly all
+ * happen in the parent before the fork.
+ *
+ * Host preview only: exported APKs (targetSdk 28) keep plain execve.
+ */
+#ifndef WTA_CLI_HARNESS
+
+#include <jni.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#else /* WTA_CLI_HARNESS */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#endif
+
+#define WTA_PAGE 4096UL
+#define WTA_MAX_PHDR 64
+#define WTA_STACK_SIZE (8UL << 20)
+
+#define PT_LOAD      1
+#define PT_TLS       7
+#define PT_GNU_RELRO 0x6474e552U
+
+typedef struct {
+    uint32_t p_type;
+    uint32_t p_flags;
+    uint64_t p_offset;
+    uint64_t p_vaddr;
+    uint64_t p_paddr;
+    uint64_t p_filesz;
+    uint64_t p_memsz;
+    uint64_t p_align;
+} WtaPhdr;
+
+typedef struct {
+    uint8_t  e_ident[16];
+    uint16_t e_type;
+    uint16_t e_machine;
+    uint32_t e_version;
+    uint64_t e_entry;
+    uint64_t e_phoff;
+    uint64_t e_shoff;
+    uint32_t e_flags;
+    uint16_t e_ehsize;
+    uint16_t e_phentsize;
+    uint16_t e_phnum;
+    uint16_t e_shentsize;
+    uint16_t e_shnum;
+    uint16_t e_shstrndx;
+} WtaEhdr;
+
+typedef struct {
+    int      ok;
+    char     err[160];
+    uint64_t entry;
+    uint64_t phoff;
+    uint16_t phentsize;
+    uint16_t phnum;
+    WtaPhdr  ph[WTA_MAX_PHDR];
+    uint64_t map_start;
+    uint64_t map_end;
+    int      has_tls;
+} WtaElf;
+
+static uint64_t wta_round_down(uint64_t v, uint64_t a) { return v & ~(a - 1); }
+static uint64_t wta_round_up(uint64_t v, uint64_t a) { return (v + a - 1) & ~(a - 1); }
+
+static int wta_parse_elf(const uint8_t *image, size_t len, WtaElf *out)
+{
+    memset(out, 0, sizeof *out);
+    if (len < sizeof(WtaEhdr)) {
+        snprintf(out->err, sizeof out->err, "file too small (%zu bytes)", len);
+        return 0;
+    }
+    const WtaEhdr *eh = (const WtaEhdr *)image;
+    if (memcmp(eh->e_ident, "\x7f" "ELF", 4) != 0) {
+        snprintf(out->err, sizeof out->err, "not an ELF");
+        return 0;
+    }
+    if (eh->e_ident[4] != 2 || eh->e_ident[5] != 1) {
+        snprintf(out->err, sizeof out->err, "only ELF64 little-endian is supported");
+        return 0;
+    }
+    if (eh->e_type != 2) {
+        snprintf(out->err, sizeof out->err, "only static ET_EXEC images are supported (e_type=%u)", eh->e_type);
+        return 0;
+    }
+    if (eh->e_machine != 183) {
+        snprintf(out->err, sizeof out->err, "only AArch64 images are supported (e_machine=%u)", eh->e_machine);
+        return 0;
+    }
+    if (eh->e_phnum == 0 || eh->e_phnum > WTA_MAX_PHDR) {
+        snprintf(out->err, sizeof out->err, "bad phnum %u", eh->e_phnum);
+        return 0;
+    }
+    if (eh->e_phentsize != sizeof(WtaPhdr)) {
+        snprintf(out->err, sizeof out->err, "bad phentsize %u", eh->e_phentsize);
+        return 0;
+    }
+    size_t phbytes = (size_t)eh->e_phnum * sizeof(WtaPhdr);
+    if (eh->e_phoff + phbytes > len) {
+        snprintf(out->err, sizeof out->err, "program headers out of range");
+        return 0;
+    }
+    out->entry = eh->e_entry;
+    out->phoff = eh->e_phoff;
+    out->phentsize = eh->e_phentsize;
+    out->phnum = eh->e_phnum;
+
+    uint64_t lo = UINT64_MAX, hi = 0;
+    uint64_t first_load_off = UINT64_MAX;
+    int loads = 0;
+    for (int i = 0; i < eh->e_phnum; i++) {
+        const WtaPhdr *ph = (const WtaPhdr *)(image + eh->e_phoff + (size_t)i * sizeof(WtaPhdr));
+        out->ph[i] = *ph;
+        if (ph->p_type == PT_TLS) out->has_tls = 1;
+        if (ph->p_type != PT_LOAD) continue;
+        loads++;
+        if (ph->p_filesz > ph->p_memsz) {
+            snprintf(out->err, sizeof out->err, "phdr %d: filesz > memsz", i);
+            return 0;
+        }
+        if (ph->p_vaddr < WTA_PAGE) {
+            snprintf(out->err, sizeof out->err, "phdr %d: vaddr below page 1", i);
+            return 0;
+        }
+        if (ph->p_vaddr < lo) lo = ph->p_vaddr;
+        if (ph->p_vaddr + ph->p_memsz > hi) hi = ph->p_vaddr + ph->p_memsz;
+        if (ph->p_offset < first_load_off) {
+            first_load_off = ph->p_offset;
+        }
+    }
+    if (loads == 0) {
+        snprintf(out->err, sizeof out->err, "no PT_LOAD segments");
+        return 0;
+    }
+    if (first_load_off != 0) {
+        snprintf(out->err, sizeof out->err,
+                 "first PT_LOAD does not start at file offset 0 (found 0x%llx)",
+                 (unsigned long long)first_load_off);
+        return 0;
+    }
+    /* The phdr table must live inside a mapped PT_LOAD so AT_PHDR resolves. */
+    {
+        int inside = 0;
+        for (int i = 0; i < eh->e_phnum; i++) {
+            const WtaPhdr *ph = &out->ph[i];
+            if (ph->p_type != PT_LOAD) continue;
+            if (eh->e_phoff >= ph->p_offset &&
+                eh->e_phoff + phbytes <= ph->p_offset + ph->p_filesz) {
+                inside = 1;
+                break;
+            }
+        }
+        if (!inside) {
+            snprintf(out->err, sizeof out->err, "program headers not inside any PT_LOAD");
+            return 0;
+        }
+    }
+
+    out->map_start = wta_round_down(lo, WTA_PAGE);
+    out->map_end = wta_round_up(hi, WTA_PAGE);
+    out->ok = 1;
+    return 1;
+}
+
+/* Map the image at its fixed vaddrs from an already-prepared executable
+ * memfd. musl map_library strategy: one RW file mapping over the whole span,
+ * zero the bss tails, then mprotect each segment to its final prot — that
+ * mprotect is where PROT_EXEC arrives, via the memfd permission class, never
+ * as an exec-map of app_data. */
+__attribute__((unused))
+static int wta_map_image(int memfd, const WtaElf *elf, char *err, size_t errlen)
+{
+    size_t span = (size_t)(elf->map_end - elf->map_start);
+    void *base = mmap((void *)elf->map_start, span, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_FIXED, memfd, 0);
+    if (base == MAP_FAILED) {
+        snprintf(err, errlen, "mmap span %zu at 0x%llx failed: %s",
+                 span, (unsigned long long)elf->map_start, strerror(errno));
+        return 0;
+    }
+    for (int i = 0; i < elf->phnum; i++) {
+        const WtaPhdr *ph = &elf->ph[i];
+        if (ph->p_type != PT_LOAD) continue;
+        if (ph->p_memsz > ph->p_filesz) {
+            memset((void *)(ph->p_vaddr + ph->p_filesz), 0, ph->p_memsz - ph->p_filesz);
+        }
+    }
+    for (int i = 0; i < elf->phnum; i++) {
+        const WtaPhdr *ph = &elf->ph[i];
+        if (ph->p_type != PT_LOAD) continue;
+        int prot = ((ph->p_flags & 4) ? PROT_EXEC : 0) |
+                   ((ph->p_flags & 2) ? PROT_WRITE : 0) |
+                   ((ph->p_flags & 1) ? PROT_READ : 0);
+        uint64_t s = wta_round_down(ph->p_vaddr, WTA_PAGE);
+        uint64_t e = wta_round_up(ph->p_vaddr + ph->p_memsz, WTA_PAGE);
+        if (mprotect((void *)s, (size_t)(e - s), prot) != 0) {
+            snprintf(err, errlen, "mprotect phdr %d at 0x%llx: %s",
+                     i, (unsigned long long)s, strerror(errno));
+            return 0;
+        }
+    }
+    for (int i = 0; i < elf->phnum; i++) {
+        const WtaPhdr *ph = &elf->ph[i];
+        if (ph->p_type != PT_GNU_RELRO || ph->p_memsz == 0) continue;
+        uint64_t s = wta_round_down(ph->p_vaddr, WTA_PAGE);
+        uint64_t e = wta_round_up(ph->p_vaddr + ph->p_memsz, WTA_PAGE);
+        mprotect((void *)s, (size_t)(e - s), PROT_READ);
+    }
+    return 1;
+}
+
+/* ---- initial-stack assembly ------------------------------------------- */
+#define WTA_AT_NULL         0
+#define WTA_AT_PHDR         3
+#define WTA_AT_PHENT        4
+#define WTA_AT_PHNUM        5
+#define WTA_AT_PAGESZ       6
+#define WTA_AT_BASE         7
+#define WTA_AT_FLAGS        8
+#define WTA_AT_ENTRY        9
+#define WTA_AT_UID          11
+#define WTA_AT_EUID         12
+#define WTA_AT_GID          13
+#define WTA_AT_EGID         14
+#define WTA_AT_PLATFORM     15
+#define WTA_AT_HWCAP        16
+#define WTA_AT_CLKTCK       17
+#define WTA_AT_SECURE       23
+#define WTA_AT_RANDOM       25
+#define WTA_AT_EXECFN       31
+#define WTA_AT_SYSINFO_EHDR 33
+
+#define WTA_AUX_COUNT 19 /* incl. terminating AT_NULL */
+
+typedef struct {
+    uint64_t hwcap;
+    uint64_t sysinfo_ehdr;
+    char     platform[16];
+} WtaParentAux;
+
+typedef struct {
+    uint32_t argc;
+    uint32_t envc;
+    size_t   blob_len;
+} WtaStackInfo;
+
+static size_t wta_stack_total(const WtaStackInfo *si)
+{
+    size_t ptrs = 8UL * (1 + (si->argc + 1) + (si->envc + 1) + 2 * WTA_AUX_COUNT);
+    return ptrs + 16 + si->blob_len;
+}
+
+#ifndef WTA_CLI_HARNESS
+
+static inline long sys_read(int fd, void *b, size_t n) { return syscall(SYS_read, fd, b, n); }
+static inline long sys_write(int fd, const void *b, size_t n) { return syscall(SYS_write, fd, b, n); }
+static inline int sys_close(int fd) { return (int)syscall(SYS_close, fd); }
+/* aarch64 has no SYS_fork; plain fork(2) is clone(SIGCHLD, ...). */
+static inline pid_t sys_fork(void) { return (pid_t)syscall(SYS_clone, SIGCHLD, 0, 0, 0, 0); }
+
+#define WTA_CHILD_ERR_STDIO 1
+#define WTA_CHILD_ERR_CHDIR 2
+#define WTA_CHILD_ERR_MAP   3
+#define WTA_CHILD_ERR_STACK 4
+
+static void wta_child_fail(int sync_wr, int code)
+{
+    sys_write(sync_wr, &code, 1);
+    sys_close(sync_wr);
+    syscall(SYS_exit_group, 127);
+    for (;;) syscall(SYS_exit, 127);
+}
+
+static void wta_child_run(int memfd, const WtaElf *elf,
+                          const char *blob, const WtaStackInfo *si,
+                          const WtaParentAux *paux,
+                          const char *cwd,
+                          int fd_in, int fd_out, int fd_err, int sync_wr)
+{
+    char errbuf[160];
+
+    if (fd_in < 0) {
+        fd_in = open("/dev/null", O_RDONLY);
+        if (fd_in < 0) wta_child_fail(sync_wr, WTA_CHILD_ERR_STDIO);
+    }
+    if (dup2(fd_in, 0) < 0 || dup2(fd_out, 1) < 0 || dup2(fd_err, 2) < 0) {
+        wta_child_fail(sync_wr, WTA_CHILD_ERR_STDIO);
+    }
+    if (fd_in > 2) sys_close(fd_in);
+    if (fd_out > 2) sys_close(fd_out);
+    if (fd_err > 2) sys_close(fd_err);
+    if (cwd && cwd[0] && syscall(SYS_chdir, cwd) != 0) {
+        wta_child_fail(sync_wr, WTA_CHILD_ERR_CHDIR);
+    }
+
+    for (int sig = 1; sig <= 64; sig++) {
+        struct sigaction sa;
+        memset(&sa, 0, sizeof sa);
+        sa.sa_handler = SIG_DFL;
+        syscall(SYS_rt_sigaction, sig, &sa, NULL, 8);
+    }
+    {
+        uint64_t empty = 0;
+        syscall(SYS_rt_sigprocmask, SIG_SETMASK, &empty, NULL, 8);
+    }
+
+    if (!wta_map_image(memfd, elf, errbuf, sizeof errbuf)) {
+        size_t n = strlen(errbuf);
+        sys_write(2, errbuf, n);
+        sys_write(2, "\n", 1);
+        wta_child_fail(sync_wr, WTA_CHILD_ERR_MAP);
+    }
+    sys_close(memfd);
+
+    void *stack = (void *)syscall(SYS_mmap, NULL, WTA_STACK_SIZE,
+                                  PROT_READ | PROT_WRITE,
+                                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if ((long)stack == -1) wta_child_fail(sync_wr, WTA_CHILD_ERR_STACK);
+
+    size_t total = wta_stack_total(si);
+    char *top = (char *)stack + WTA_STACK_SIZE;
+    uint64_t sp = ((uint64_t)(size_t)top - total) & ~0xFUL;
+    char *strings = (char *)(sp + total - 16 - si->blob_len);
+    memcpy(strings, blob, si->blob_len);
+
+    const char *p = strings;
+    for (uint32_t i = 0; i < si->argc; i++) p += strlen(p) + 1;
+    for (uint32_t i = 0; i < si->envc; i++) p += strlen(p) + 1;
+    const char *platform = p; p += strlen(p) + 1;
+    const char *random16 = p; p += 16;
+    const char *execfn = p;
+
+    uint64_t *w = (uint64_t *)sp;
+    *w++ = si->argc;
+    const char *q = strings;
+    for (uint32_t i = 0; i < si->argc; i++) { *w++ = (uint64_t)(size_t)q; q += strlen(q) + 1; }
+    *w++ = 0;
+    for (uint32_t i = 0; i < si->envc; i++) { *w++ = (uint64_t)(size_t)q; q += strlen(q) + 1; }
+    *w++ = 0;
+
+    const uint64_t keys[WTA_AUX_COUNT] = {
+        WTA_AT_PHDR, WTA_AT_PHENT, WTA_AT_PHNUM, WTA_AT_PAGESZ, WTA_AT_BASE,
+        WTA_AT_FLAGS, WTA_AT_ENTRY, WTA_AT_UID, WTA_AT_EUID, WTA_AT_GID,
+        WTA_AT_EGID, WTA_AT_PLATFORM, WTA_AT_HWCAP, WTA_AT_CLKTCK, WTA_AT_SECURE,
+        WTA_AT_RANDOM, WTA_AT_EXECFN, WTA_AT_SYSINFO_EHDR, WTA_AT_NULL
+    };
+    const uint64_t vals[WTA_AUX_COUNT] = {
+        elf->map_start + elf->phoff,
+        elf->phentsize,
+        elf->phnum,
+        WTA_PAGE,
+        0,
+        0,
+        elf->entry,
+        (uint64_t)getuid(),
+        (uint64_t)geteuid(),
+        (uint64_t)getgid(),
+        (uint64_t)getegid(),
+        (uint64_t)(size_t)platform,
+        paux->hwcap,
+        100,
+        0,
+        (uint64_t)(size_t)random16,
+        (uint64_t)(size_t)execfn,
+        paux->sysinfo_ehdr,
+        0
+    };
+    for (int i = 0; i < WTA_AUX_COUNT; i++) { *w++ = keys[i]; *w++ = vals[i]; }
+
+    sys_close(sync_wr);
+
+    register uint64_t x_sp asm("x0") = sp;
+    register uint64_t x_entry asm("x1") = elf->entry;
+    asm volatile(
+        "mov sp, x0\n"
+        "mov x0, xzr\n"
+        "mov x1, xzr\n"
+        "mov x2, xzr\n"
+        "mov x3, xzr\n"
+        "mov x4, xzr\n"
+        "mov x5, xzr\n"
+        "mov x6, xzr\n"
+        "mov x7, xzr\n"
+        "mov x8, xzr\n"
+        "mov x9, xzr\n"
+        "mov x10, xzr\n"
+        "mov x11, xzr\n"
+        "mov x12, xzr\n"
+        "mov x13, xzr\n"
+        "mov x14, xzr\n"
+        "mov x15, xzr\n"
+        "mov x17, xzr\n"
+        "mov x18, xzr\n"
+        "br x1\n"
+        :: "r"(x_sp), "r"(x_entry) : "memory");
+    __builtin_unreachable();
+}
+
+/* ---- parent-side preparation ------------------------------------------ */
+
+static int wta_copy_to_memfd(int src_fd, off_t resume_at, const uint8_t *head, size_t head_len, int *out)
+{
+    int m;
+#ifdef SYS_memfd_create
+    /* MFD_CLOEXEC(2) | MFD_EXEC(0x10); older kernels reject MFD_EXEC(EINVAL). */
+    m = (int)syscall(SYS_memfd_create, "wta-static-exec", 2 | 0x10);
+    if (m < 0 && errno == EINVAL) m = (int)syscall(SYS_memfd_create, "wta-static-exec", 2);
+#else
+    m = -1; errno = ENOSYS;
+#endif
+    if (m < 0) return 0;
+    if (lseek(m, 0, SEEK_SET) != 0) { close(m); return 0; }
+    if (resume_at > 0 && lseek(src_fd, resume_at, SEEK_SET) == (off_t)-1) { close(m); return 0; }
+    if (head_len && write(m, head, head_len) != (ssize_t)head_len) { close(m); return 0; }
+    char buf[65536];
+    ssize_t r;
+    while ((r = read(src_fd, buf, sizeof buf)) > 0) {
+        ssize_t off = 0;
+        while (off < r) {
+            ssize_t w2 = write(m, buf + off, (size_t)(r - off));
+            if (w2 < 0) { close(m); return 0; }
+            off += w2;
+        }
+    }
+    if (r < 0) { close(m); return 0; }
+    *out = m;
+    return 1;
+}
+
+static void wta_read_parent_aux(WtaParentAux *paux)
+{
+    memset(paux, 0, sizeof *paux);
+    strcpy(paux->platform, "aarch64");
+    int fd = open("/proc/self/auxv", O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return;
+    uint64_t kv[2];
+    while (read(fd, kv, sizeof kv) == (ssize_t)sizeof kv) {
+        if (kv[0] == WTA_AT_HWCAP) paux->hwcap = kv[1];
+        else if (kv[0] == WTA_AT_SYSINFO_EHDR) paux->sysinfo_ehdr = kv[1];
+        else if (kv[0] == WTA_AT_PLATFORM && kv[1]) {
+            const char *s = (const char *)(size_t)kv[1];
+            size_t i = 0;
+            while (s[i] && i < sizeof paux->platform - 1) { paux->platform[i] = s[i]; i++; }
+            paux->platform[i] = 0;
+        } else if (kv[0] == WTA_AT_NULL) break;
+    }
+    close(fd);
+}
+
+/* Serialize [argv strings][envp strings][platform][16B random][execfn]. */
+static char *wta_build_blob(JNIEnv *env, jobjectArray jargv, jobjectArray jenvp,
+                            uint32_t *argc_out, uint32_t *envc_out, size_t *blob_len_out,
+                            const WtaParentAux *paux)
+{
+    uint32_t argc = (uint32_t)(*env)->GetArrayLength(env, jargv);
+    uint32_t envc = (uint32_t)(*env)->GetArrayLength(env, jenvp);
+
+    if ((*env)->PushLocalFrame(env, (jint)(argc + envc + 16)) != 0) return NULL;
+
+    char **avs = calloc(argc + 1, sizeof(char *));
+    char **evs = calloc(envc + 1, sizeof(char *));
+    if (!avs || !evs) {
+        free(avs); free(evs);
+        (*env)->PopLocalFrame(env, NULL);
+        return NULL;
+    }
+    size_t need = 1;
+    for (uint32_t i = 0; i < argc; i++) {
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, jargv, i);
+        avs[i] = (char *)(*env)->GetStringUTFChars(env, s, NULL);
+        need += strlen(avs[i]) + 1;
+    }
+    for (uint32_t i = 0; i < envc; i++) {
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, jenvp, i);
+        evs[i] = (char *)(*env)->GetStringUTFChars(env, s, NULL);
+        need += strlen(evs[i]) + 1;
+    }
+    need += strlen(paux->platform) + 1 + 16 + strlen(avs[0]) + 1;
+
+    char *blob = malloc(need);
+    char *w = blob;
+    if (blob) {
+        for (uint32_t i = 0; i < argc; i++) { size_t l = strlen(avs[i]) + 1; memcpy(w, avs[i], l); w += l; }
+        for (uint32_t i = 0; i < envc; i++) { size_t l = strlen(evs[i]) + 1; memcpy(w, evs[i], l); w += l; }
+        { size_t l = strlen(paux->platform) + 1; memcpy(w, paux->platform, l); w += l; }
+        {
+            int ur = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+            if (ur >= 0) {
+                if (read(ur, w, 16) != 16) memset(w, 0x42, 16);
+                close(ur);
+            } else {
+                memset(w, 0x42, 16);
+            }
+            w += 16;
+        }
+        { size_t l = strlen(avs[0]) + 1; memcpy(w, avs[0], l); w += l; }
+    }
+
+    for (uint32_t i = 0; i < argc; i++) {
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, jargv, i);
+        (*env)->ReleaseStringUTFChars(env, s, avs[i]);
+    }
+    for (uint32_t i = 0; i < envc; i++) {
+        jstring s = (jstring)(*env)->GetObjectArrayElement(env, jenvp, i);
+        (*env)->ReleaseStringUTFChars(env, s, evs[i]);
+    }
+    free(avs); free(evs);
+    (*env)->PopLocalFrame(env, NULL);
+
+    if (!blob) return NULL;
+    *argc_out = argc;
+    *envc_out = envc;
+    *blob_len_out = (size_t)(w - blob);
+    return blob;
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_webtoapp_core_linux_StaticExecBridge_nativeSpawn(
+        JNIEnv *env, jclass clazz,
+        jstring jpath, jobjectArray jargv, jobjectArray jenvp, jstring jcwd,
+        jint fd_in, jint fd_out, jint fd_err, jintArray jerr)
+{
+    (void)clazz;
+    jint err_code = 0, err_detail = 0;
+    pid_t pid = -1;
+    int src = -1, memfd = -1;
+    char *blob = NULL;
+    int sync_pipe[2] = { -1, -1 };
+    const char *path = (*env)->GetStringUTFChars(env, jpath, NULL);
+    const char *cwd = jcwd ? (*env)->GetStringUTFChars(env, jcwd, NULL) : NULL;
+
+    do {
+        src = open(path, O_RDONLY | O_CLOEXEC);
+        if (src < 0) { err_code = 1; err_detail = errno; break; }
+
+        uint8_t head[sizeof(WtaEhdr) + WTA_MAX_PHDR * sizeof(WtaPhdr)];
+        ssize_t got = read(src, head, sizeof head);
+        if (got < (ssize_t)sizeof(WtaEhdr)) { err_code = 2; err_detail = errno; break; }
+
+        WtaElf elf;
+        if (!wta_parse_elf(head, (size_t)got, &elf)) { err_code = 3; err_detail = 0; break; }
+
+        if (!wta_copy_to_memfd(src, (off_t)got, head, (size_t)got, &memfd)) {
+            err_code = 5; err_detail = errno; break;
+        }
+        close(src); src = -1;
+
+        WtaParentAux paux;
+        wta_read_parent_aux(&paux);
+
+        WtaStackInfo si;
+        blob = wta_build_blob(env, jargv, jenvp, &si.argc, &si.envc, &si.blob_len, &paux);
+        if (!blob) { err_code = 6; err_detail = errno; break; }
+
+        if (pipe(sync_pipe) != 0) { err_code = 7; err_detail = errno; break; }
+
+        pid = sys_fork();
+        if (pid < 0) { err_code = 8; err_detail = errno; break; }
+        if (pid == 0) {
+            close(sync_pipe[0]);
+            wta_child_run(memfd, &elf, blob, &si, &paux, cwd, fd_in, fd_out, fd_err, sync_pipe[1]);
+            __builtin_unreachable();
+        }
+
+        close(sync_pipe[1]); sync_pipe[1] = -1;
+        uint8_t child_err = 0;
+        ssize_t n = read(sync_pipe[0], &child_err, 1);
+        close(sync_pipe[0]); sync_pipe[0] = -1;
+        if (n == 1) {
+            int status;
+            waitpid(pid, &status, 0);
+            err_code = 100 + (int)child_err;
+            pid = -1;
+        }
+    } while (0);
+
+    if (sync_pipe[0] >= 0) close(sync_pipe[0]);
+    if (sync_pipe[1] >= 0) close(sync_pipe[1]);
+    if (src >= 0) close(src);
+    if (memfd >= 0) close(memfd);
+    free(blob);
+    (*env)->ReleaseStringUTFChars(env, jpath, path);
+    if (cwd) (*env)->ReleaseStringUTFChars(env, jcwd, cwd);
+    if (jerr && err_code != 0) {
+        jint buf[2] = { err_code, err_detail };
+        (*env)->SetIntArrayRegion(env, jerr, 0, 2, buf);
+    }
+    return (jlong)pid;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_webtoapp_core_linux_StaticExecBridge_nativeWaitpid(
+        JNIEnv *env, jclass clazz, jlong pid, jintArray statusOut, jboolean blocking)
+{
+    (void)clazz;
+    int status = 0;
+    pid_t r = waitpid((pid_t)pid, &status, blocking ? 0 : WNOHANG);
+    if (r == 0) return 0; /* still running (non-blocking poll) */
+    if (r < 0) return -1;
+    if (statusOut) {
+        jint s = (jint)status;
+        (*env)->SetIntArrayRegion(env, statusOut, 0, 1, &s);
+    }
+    return 1; /* reaped */
+}
+
+JNIEXPORT jint JNICALL
+Java_com_webtoapp_core_linux_StaticExecBridge_nativeKill(
+        JNIEnv *env, jclass clazz, jlong pid, jint sig)
+{
+    (void)env; (void)clazz;
+    return kill((pid_t)pid, sig);
+}
+
+#else /* WTA_CLI_HARNESS */
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) { fprintf(stderr, "usage: %s <static-elf>\n", argv[0]); return 2; }
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0) { perror("open"); return 2; }
+    static uint8_t img[64 << 20];
+    ssize_t total = 0;
+    while (1) {
+        ssize_t r = read(fd, img + total, sizeof img - (size_t)total);
+        if (r < 0) { perror("read"); return 2; }
+        if (r == 0) break;
+        total += r;
+    }
+    close(fd);
+
+    WtaElf elf;
+    if (!wta_parse_elf(img, (size_t)total, &elf)) {
+        fprintf(stderr, "parse failed: %s\n", elf.err);
+        return 1;
+    }
+    printf("entry      : 0x%llx\n", (unsigned long long)elf.entry);
+    printf("phoff      : 0x%llx phnum %u phentsize %u\n",
+           (unsigned long long)elf.phoff, elf.phnum, elf.phentsize);
+    printf("map span   : [0x%llx, 0x%llx) (%zu pages)\n",
+           (unsigned long long)elf.map_start, (unsigned long long)elf.map_end,
+           (size_t)((elf.map_end - elf.map_start) / WTA_PAGE));
+    printf("at_phdr    : 0x%llx\n", (unsigned long long)(elf.map_start + elf.phoff));
+    printf("tls        : %s\n", elf.has_tls ? "PT_TLS present" : "none");
+    for (int i = 0; i < elf.phnum; i++) {
+        const WtaPhdr *ph = &elf.ph[i];
+        printf("phdr[%d]    : type=%#x flags=%u off=0x%llx vaddr=0x%llx filesz=0x%llx memsz=0x%llx\n",
+               i, ph->p_type, ph->p_flags,
+               (unsigned long long)ph->p_offset, (unsigned long long)ph->p_vaddr,
+               (unsigned long long)ph->p_filesz, (unsigned long long)ph->p_memsz);
+    }
+    WtaStackInfo si = { .argc = 2, .envc = 2, .blob_len = 128 };
+    printf("stack      : %zu bytes (argc=%u envc=%u)\n", wta_stack_total(&si), si.argc, si.envc);
+    printf("OK\n");
+    return 0;
+}
+
+#endif /* WTA_CLI_HARNESS */

--- a/app/src/main/java/com/webtoapp/core/golang/GoDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoDependencyManager.kt
@@ -120,6 +120,25 @@ object GoDependencyManager {
         }
     }
 
+    /**
+     * W^X escape hatch for host previews: `go build` for android (CGO_ENABLED=0,
+     * internal linking) emits PIE ELFs with PT_DYNAMIC and no DT_NEEDED, which the
+     * patched musl linker can load in program mode — exec-mapped segments of the
+     * app_data binary are bridged through executable memfds. argv is
+     * [linker, target, *args]; the target sees itself as argv[0].
+     */
+    internal fun buildMuslBridgeCommand(
+        context: Context,
+        executablePath: String,
+        arguments: List<String>
+    ): List<String> {
+        return buildList {
+            add(File(context.applicationInfo.nativeLibraryDir, "libmusl-linker.so").absolutePath)
+            add(executablePath)
+            addAll(arguments)
+        }
+    }
+
     internal fun configureGoBinaryEnvironment(
         context: Context,
         processEnv: MutableMap<String, String>,

--- a/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoRuntime.kt
@@ -28,13 +28,14 @@ class GoRuntime(private val context: Context) {
     }
 
     /**
-     * Go execs via memfd_create + execveat, which SELinux fully blocks under targetSdk 29+
-     * (memfd_file open is denied, verified on API 35). Kept as a failure-note fallback for
-     * OEM-specific policies; the startServer precheck handles the standard case.
+     * Failure-note fallback for OEM-specific policies that deny even the memfd
+     * exec-map bridge; the startServer precheck handles the standard W^X case.
      * Runtime-layer string (shell-synced); intentionally not routed through Strings i18n.
      */
     private fun channelNote(): String =
-        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+        if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context) &&
+            !com.webtoapp.core.linux.RuntimeExecPolicy.hasMuslExecBridge(context)
+        ) {
             com.webtoapp.core.linux.RuntimeExecPolicy.restrictionNote()
         } else ""
 
@@ -98,8 +99,11 @@ class GoRuntime(private val context: Context) {
             // The loader's three-tier fallback (direct exec -> system linker -> memfd
             // execveat) is fully blocked under SELinux W^X at targetSdk 29+: exec and
             // execute_no_trans on app_data_file, and open on memfd_file are all denied
-            // (verified on an API 35 emulator). Only generated APKs (targetSdk 28) pass.
-            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+            // (verified on an API 35 emulator). Android Go binaries are PIE with
+            // PT_DYNAMIC and no DT_NEEDED, so the patched musl linker can load them
+            // in program mode and bridge exec-mapped segments through memfds.
+            val wxRestricted = !com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)
+            if (wxRestricted && !com.webtoapp.core.linux.RuntimeExecPolicy.hasMuslExecBridge(context)) {
                 _serverState.value = ServerState.Error(
                     com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("Go")
                 )
@@ -135,7 +139,7 @@ class GoRuntime(private val context: Context) {
             }
             currentPort = serverPort
 
-            if (!GoDependencyManager.isGoExecLoaderReady(context)) {
+            if (!wxRestricted && !GoDependencyManager.isGoExecLoaderReady(context)) {
                 val path = GoDependencyManager.getGoExecLoaderPath(context)
                 _serverState.value = ServerState.Error(
                     "Go executable loader 未就绪 ($path)。导出的 GO_APP 需包含 libgo_exec_loader.so；请用含原生 loader 的构建器重新导出。"
@@ -143,7 +147,11 @@ class GoRuntime(private val context: Context) {
                 return@withContext -1
             }
 
-            val command = GoDependencyManager.buildBinaryCommand(context, binaryPath, emptyList())
+            val command = if (wxRestricted) {
+                GoDependencyManager.buildMuslBridgeCommand(context, binaryPath, emptyList())
+            } else {
+                GoDependencyManager.buildBinaryCommand(context, binaryPath, emptyList())
+            }
 
             AppLogger.i(TAG, "启动 Go 服务器: $binaryPath")
             AppLogger.i(TAG, "工作目录: $projectDir, 端口: $serverPort")

--- a/app/src/main/java/com/webtoapp/core/linux/HostProcessLauncher.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/HostProcessLauncher.kt
@@ -1,0 +1,43 @@
+package com.webtoapp.core.linux
+
+import java.io.File
+
+/**
+ * Launch fork+exec runtimes with the right channel for the current build:
+ * plain ProcessBuilder when execve works (generated APKs, targetSdk 28), or
+ * the user-mode exec loader under host W^X (targetSdk>=29).
+ */
+object HostProcessLauncher {
+
+    data class Result(
+        val process: Process?,
+        val error: String?
+    )
+
+    fun start(
+        context: android.content.Context,
+        command: List<String>,
+        env: Map<String, String>,
+        cwd: File?,
+        runtimeLabel: String = "PHP"
+    ): Result {
+        val wxRestricted = !RuntimeExecPolicy.canExecAppDataBinaries(context)
+        if (!wxRestricted) {
+            val pb = ProcessBuilder(command)
+            if (cwd != null) pb.directory(cwd)
+            val pbEnv = pb.environment()
+            env.forEach { (k, v) -> pbEnv[k] = v }
+            return Result(pb.start(), null)
+        }
+        if (!RuntimeExecPolicy.hasStaticExecBridge(context)) {
+            return Result(null, RuntimeExecPolicy.hostPreviewBlockedMessage(runtimeLabel))
+        }
+        // Match ProcessBuilder.environment() semantics: the caller's vars are
+        // an overlay on the parent environment, not a replacement for it.
+        val fullEnv = System.getenv().toMutableMap()
+        fullEnv.putAll(env)
+        var spawnError: String? = null
+        val proc = StaticExecProcess.start(command, fullEnv, cwd) { msg -> spawnError = msg }
+        return Result(proc, spawnError)
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
@@ -204,13 +204,17 @@ object LocalBuildEnvironment {
         return try {
             val execPrefix = com.webtoapp.core.wordpress.WordPressDependencyManager.buildPhpExecPrefix(context)
             val cmd = execPrefix + listOf(phar.absolutePath, "--version")
-            val pb = ProcessBuilder(cmd)
-            pb.redirectErrorStream(true)
-
-            pb.environment()["USE_ZEND_ALLOC"] = "0"
-            pb.environment()["TMPDIR"] = context.cacheDir.absolutePath
-            val proc = pb.start()
-            val out = proc.inputStream.bufferedReader().readText()
+            val launch = HostProcessLauncher.start(
+                context, cmd,
+                mapOf(
+                    "USE_ZEND_ALLOC" to "0",
+                    "TMPDIR" to context.cacheDir.absolutePath
+                ),
+                null
+            )
+            val proc = launch.process ?: return null
+            // `composer --version` prints to stdout; drain it, then wait.
+            val out = proc.inputStream.bufferedReader().use { it.readText() }
             val finished = proc.waitForCompat(5_000)
             if (!finished) {
                 proc.destroyForciblyCompat()

--- a/app/src/main/java/com/webtoapp/core/linux/RuntimeExecPolicy.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/RuntimeExecPolicy.kt
@@ -40,6 +40,21 @@ object RuntimeExecPolicy {
     }
 
     /**
+     * True when the user-mode exec loader (libstatic_exec.so) is installed as
+     * a native lib. It rebuilds execve in user mode (memfd image + AArch64
+     * initial stack + jump to entry), so static ELFs (pmmp PHP) can start
+     * even where [canExecAppDataBinaries] is false. AArch64 devices only —
+     * the loader neither parses nor trampolines any other architecture, so
+     * other ABIs get the plain blocked message instead of a spawn error.
+     */
+    fun hasStaticExecBridge(context: Context): Boolean {
+        val primaryAbi = android.os.Build.SUPPORTED_ABIS.firstOrNull() ?: return false
+        if (!primaryAbi.startsWith("arm64-v8a")) return false
+        val lib = File(context.applicationInfo.nativeLibraryDir, "libstatic_exec.so")
+        return lib.exists() && lib.canRead()
+    }
+
+    /**
      * Runtime-layer suffix appended to launch failures under the restriction.
      * (shell-synced runtime string; intentionally not routed through Strings i18n)
      */
@@ -47,5 +62,6 @@ object RuntimeExecPolicy {
         " [受 targetSdk≥29 SELinux 限制，无法执行应用数据目录中的本地运行时]"
 
     fun hostPreviewBlockedMessage(runtimeName: String): String =
-        "当前构建 targetSdk≥29，系统安全策略禁止从应用数据目录启动 $runtimeName 运行时，本地服务器预览不可用"
+        "当前构建 targetSdk≥29，系统安全策略禁止从应用数据目录启动 $runtimeName 运行时，本地服务器预览不可用。" +
+            "导出的 APK（targetSdk 28）不受此限制，可用导出安装验证"
 }

--- a/app/src/main/java/com/webtoapp/core/linux/StaticExecProcess.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/StaticExecProcess.kt
@@ -1,0 +1,199 @@
+package com.webtoapp.core.linux
+
+import android.os.ParcelFileDescriptor
+import com.webtoapp.core.logging.AppLogger
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * JNI binding for libstatic_exec.so — the user-mode exec loader that starts
+ * static ELFs (pmmp PHP) under SELinux W^X by mapping PT_LOAD segments from
+ * an executable memfd, building the AArch64 initial stack, and jumping to
+ * e_entry. Host preview only; exported APKs (targetSdk 28) keep execve.
+ */
+internal object StaticExecBridge {
+    private var loaded = false
+
+    @Synchronized
+    fun ensureLoaded(): Boolean {
+        if (loaded) return true
+        return try {
+            System.loadLibrary("static_exec")
+            loaded = true
+            true
+        } catch (t: Throwable) {
+            AppLogger.e("StaticExecBridge", "libstatic_exec.so unavailable: ${t.message}", t)
+            false
+        }
+    }
+
+    /** Returns pid, or -1 with [err] = {code, detail} on failure. */
+    external fun nativeSpawn(
+        path: String, argv: Array<String>, envp: Array<String>, cwd: String?,
+        fdIn: Int, fdOut: Int, fdErr: Int, err: IntArray
+    ): Long
+
+    /** 1 = reaped (status written), 0 = still running, -1 = error. */
+    external fun nativeWaitpid(pid: Long, statusOut: IntArray?, blocking: Boolean): Int
+
+    external fun nativeKill(pid: Long, sig: Int): Int
+}
+
+/**
+ * Drop-in [Process] for processes started via [StaticExecBridge]. Mirrors the
+ * surface the runtimes use: inputStream/errorStream readers, isAlive /
+ * waitFor / exitValue, graceful + forcible destroy, and a reflectable `pid`
+ * field (getProcessPid implementations read it via reflection).
+ */
+class StaticExecProcess private constructor(
+    private val pidLong: Long,
+    stdoutFd: Int,
+    stderrFd: Int
+) : Process() {
+
+    @Suppress("unused") // read via reflection by getProcessPid
+    private val pid: Int = pidLong.toInt()
+
+    private val stdout = ParcelFileDescriptor.adoptFd(stdoutFd)
+    private val stderr = ParcelFileDescriptor.adoptFd(stderrFd)
+    private val latch = CountDownLatch(1)
+    private val exitCodeHolder = AtomicInteger(Int.MIN_VALUE)
+
+    override fun getOutputStream(): OutputStream = FileOutputStream(File("/dev/null"))
+
+    override fun getInputStream(): InputStream = FileInputStream(stdout.fileDescriptor)
+
+    override fun getErrorStream(): InputStream = FileInputStream(stderr.fileDescriptor)
+
+    override fun waitFor(): Int {
+        latch.await()
+        return exitCodeHolder.get()
+    }
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = latch.await(timeout, unit)
+
+    override fun exitValue(): Int {
+        pollOnce()
+        val exited = exitCodeHolder.get()
+        if (exited == Int.MIN_VALUE) throw IllegalThreadStateException("process $pidLong has not exited")
+        return exited
+    }
+
+    override fun destroy() {
+        StaticExecBridge.nativeKill(pidLong, 15) /* SIGTERM */
+    }
+
+    override fun destroyForcibly(): Process {
+        StaticExecBridge.nativeKill(pidLong, 9) /* SIGKILL */
+        return this
+    }
+
+    override fun isAlive(): Boolean {
+        pollOnce()
+        return exitCodeHolder.get() == Int.MIN_VALUE
+    }
+
+    fun pidValue(): Long = pidLong
+
+    /** Start the background reaper; call once after a successful spawn. */
+    private fun startReaper() {
+        Thread {
+            try {
+                val status = IntArray(1)
+                val r = StaticExecBridge.nativeWaitpid(pidLong, status, true)
+                if (r == 1) finish(status[0]) else finish(128 + 15)
+            } catch (_: Throwable) {
+                finish(128 + 9)
+            }
+        }.apply { isDaemon = true; name = "wta-staticexec-reaper-$pidLong"; start() }
+    }
+
+    private fun pollOnce() {
+        if (exitCodeHolder.get() != Int.MIN_VALUE) return
+        val status = IntArray(1)
+        if (StaticExecBridge.nativeWaitpid(pidLong, status, false) == 1) finish(status[0])
+    }
+
+    private fun finish(rawStatus: Int) {
+        val code = if ((rawStatus and 0x7f) == 0) (rawStatus shr 8) and 0xff else 128 + (rawStatus and 0x7f)
+        exitCodeHolder.compareAndSet(Int.MIN_VALUE, code)
+        latch.countDown()
+    }
+
+    companion object {
+        /**
+         * Start [command] via the user-mode exec loader. [env] is the full
+         * environment (caller builds it like ProcessBuilder.environment()).
+         * Returns null when the loader is unavailable or the spawn fails; in
+         * the latter case [errorMessage] receives a diagnostic. stdin is
+         * wired to /dev/null inside the child.
+         */
+        fun start(
+            command: List<String>,
+            env: Map<String, String>,
+            cwd: File?,
+            errorMessage: ((String) -> Unit)? = null
+        ): StaticExecProcess? {
+            if (command.isEmpty()) return null
+            if (!StaticExecBridge.ensureLoaded()) {
+                errorMessage?.invoke("libstatic_exec.so 不可用，无法在 targetSdk≥29 构建中启动静态 PHP 运行时")
+                return null
+            }
+
+            val outPipe = ParcelFileDescriptor.createPipe() // [read, write]
+            val errPipe = ParcelFileDescriptor.createPipe()
+            val errInfo = IntArray(2)
+            val envp = env.entries.map { "${it.key}=${it.value}" }.toTypedArray()
+            val pid = try {
+                StaticExecBridge.nativeSpawn(
+                    command[0], command.toTypedArray(), envp,
+                    cwd?.absolutePath, -1,
+                    outPipe[1].fd, errPipe[1].fd, errInfo
+                )
+            } catch (t: Throwable) {
+                AppLogger.e("StaticExecProcess", "nativeSpawn threw: ${t.message}", t)
+                outPipe[0].close(); outPipe[1].close()
+                errPipe[0].close(); errPipe[1].close()
+                errorMessage?.invoke("启动失败: ${t.message}")
+                return null
+            }
+
+            if (pid <= 0) {
+                outPipe[0].close(); outPipe[1].close()
+                errPipe[0].close(); errPipe[1].close()
+                errorMessage?.invoke(spawnErrorMessage(errInfo))
+                return null
+            }
+
+            // Close our write ends: the child holds its own copies since fork,
+            // and EOF must reach the readers when the child exits. Keeping the
+            // parent copies open would block readers forever after child death.
+            outPipe[1].close()
+            errPipe[1].close()
+
+            // Read ends are adopted below; their PFD wrappers must be left
+            // untouched from here on.
+            val proc = StaticExecProcess(pid, outPipe[0].fd, errPipe[0].fd)
+            proc.startReaper()
+            return proc
+        }
+
+        private fun spawnErrorMessage(err: IntArray): String = when (val code = err.getOrElse(0) { 0 }) {
+            1 -> "无法打开 PHP 二进制 (errno ${err.getOrElse(1) { 0 }})"
+            2 -> "读取 PHP 二进制失败 (errno ${err.getOrElse(1) { 0 }})"
+            3 -> "PHP 二进制不是受支持的静态 AArch64 ELF"
+            5 -> "memfd 桥创建失败 (errno ${err.getOrElse(1) { 0 }})"
+            6 -> "启动参数构造失败 (errno ${err.getOrElse(1) { 0 }})"
+            7 -> "同步管道创建失败 (errno ${err.getOrElse(1) { 0 }})"
+            8 -> "fork 失败 (errno ${err.getOrElse(1) { 0 }})"
+            in 101..199 -> "子进程加载失败 (stage ${code - 100})"
+            else -> "未知错误 (code $code)"
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/php/PhpAppRuntime.kt
@@ -75,7 +75,9 @@ class PhpAppRuntime(private val context: Context) {
         customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()
     ): Int = withContext(Dispatchers.IO) {
         try {
-            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context) &&
+                !com.webtoapp.core.linux.RuntimeExecPolicy.hasStaticExecBridge(context)
+            ) {
                 _serverState.value = ServerState.Error(
                     com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("PHP")
                 )
@@ -145,16 +147,13 @@ class PhpAppRuntime(private val context: Context) {
             AppLogger.i(TAG, "项目目录: $projectDir")
             AppLogger.i(TAG, "Document root: $actualDocRoot")
 
-            val processBuilder = ProcessBuilder(command)
-            processBuilder.directory(File(projectDir))
-
-            val env = processBuilder.environment()
-            env["HOME"] = context.filesDir.absolutePath
-            env["TMPDIR"] = context.cacheDir.absolutePath
-            env["PHP_INI_SCAN_DIR"] = ""
-            env["APP_ENV"] = "production"
-            env["APP_DEBUG"] = "false"
-
+            val env = mutableMapOf(
+                "HOME" to context.filesDir.absolutePath,
+                "TMPDIR" to context.cacheDir.absolutePath,
+                "PHP_INI_SCAN_DIR" to "",
+                "APP_ENV" to "production",
+                "APP_DEBUG" to "false"
+            )
             envVars.forEach { (k, v) -> env[k] = v }
 
             val proxyPort = LocalDnsBridgeProxy.start()
@@ -166,7 +165,15 @@ class PhpAppRuntime(private val context: Context) {
 
             phpOutputBuffer.setLength(0)
             phpStderrBuffer.setLength(0)
-            phpProcess = processBuilder.start()
+            val launch = com.webtoapp.core.linux.HostProcessLauncher.start(
+                context, command, env, File(projectDir)
+            )
+            if (launch.process == null) {
+                stopServer()
+                _serverState.value = ServerState.Error(launch.error ?: "PHP 进程启动失败")
+                return@withContext -1
+            }
+            phpProcess = launch.process
 
             phpProcess?.inputStream?.let { stream ->
                 Thread {

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -621,6 +621,48 @@ if _MUSL and _LIB:
             return _oexecve(p, a, e)
 
         os.execve = _mexecve
+
+    if hasattr(os, 'posix_spawn'):
+        _opspawn = os.posix_spawn
+
+        def _mpspawn(p, a, e, **kw):
+            if _is_py(p):
+                a = [_MUSL, '--library-path', _LIB] + list(a)
+                p = _MUSL
+            elif p != _MUSL and _is_loader(p):
+                a = list(a)
+                p = _MUSL
+            return _opspawn(p, a, e, **kw)
+
+        os.posix_spawn = _mpspawn
+
+    if hasattr(os, 'spawnv'):
+        _ospawnv = os.spawnv
+
+        def _mspawnv(m, p, a):
+            if _is_py(p):
+                a = [_MUSL, '--library-path', _LIB] + list(a)
+                p = _MUSL
+            elif p != _MUSL and _is_loader(p):
+                a = list(a)
+                p = _MUSL
+            return _ospawnv(m, p, a)
+
+        os.spawnv = _mspawnv
+
+    if hasattr(os, 'spawnve'):
+        _ospawnve = os.spawnve
+
+        def _mspawnve(m, p, a, e):
+            if _is_py(p):
+                a = [_MUSL, '--library-path', _LIB] + list(a)
+                p = _MUSL
+            elif p != _MUSL and _is_loader(p):
+                a = list(a)
+                p = _MUSL
+            return _ospawnve(m, p, a, e)
+
+        os.spawnve = _mspawnve
 """.trimIndent()
 
     private fun runPipWithWrapper(

--- a/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonRuntime.kt
@@ -231,6 +231,16 @@ class PythonRuntime(private val context: Context) {
             AppLogger.i(TAG, "=========================")
 
             env["PATH"] = "${File(pythonHome, "bin").absolutePath}:${env["PATH"] ?: "/usr/bin"}"
+            if (muslLinker != null) {
+                // Activate the sitecustomize subprocess rewrite for server-lifetime
+                // children: under host W^X (targetSdk>=29) the PT_INTERP baked into
+                // the python binaries lives in app storage and cannot be kernel
+                // exec'd, so children must be routed through the native (patched)
+                // linker instead. resolveMuslLinker already prefers the native copy.
+                env["_WTA_MUSL_LINKER"] = muslLinker
+                env["_WTA_MUSL_LIB_PATH"] = "$pythonHome/lib"
+                env["_WTA_PYTHON_BIN"] = pythonBin
+            }
 
             envVars.forEach { (k, v) -> env[k] = v }
 

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressPhpRuntime.kt
@@ -56,7 +56,9 @@ class WordPressPhpRuntime(private val context: Context) {
 
     suspend fun startServer(documentRoot: String, port: Int = 0, portConflictMode: com.webtoapp.data.model.PortConflictMode = com.webtoapp.data.model.PortConflictMode.AUTO_KILL, customPhpExtensions: List<com.webtoapp.data.model.CustomPhpExtension> = emptyList()): Int = withContext(Dispatchers.IO) {
         try {
-            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context)) {
+            if (!com.webtoapp.core.linux.RuntimeExecPolicy.canExecAppDataBinaries(context) &&
+                !com.webtoapp.core.linux.RuntimeExecPolicy.hasStaticExecBridge(context)
+            ) {
                 _serverState.value = ServerState.Error(
                     com.webtoapp.core.linux.RuntimeExecPolicy.hostPreviewBlockedMessage("WordPress (PHP)")
                 )
@@ -103,14 +105,11 @@ class WordPressPhpRuntime(private val context: Context) {
 
             AppLogger.i(TAG, "启动 PHP 服务器: ${command.joinToString(" ")}")
 
-            val processBuilder = ProcessBuilder(command)
-            processBuilder.directory(File(documentRoot))
-            processBuilder.redirectErrorStream(false)
-
-            val env = processBuilder.environment()
-            env["HOME"] = context.filesDir.absolutePath
-            env["TMPDIR"] = context.cacheDir.absolutePath
-            env["PHP_INI_SCAN_DIR"] = ""
+            val env = mutableMapOf(
+                "HOME" to context.filesDir.absolutePath,
+                "TMPDIR" to context.cacheDir.absolutePath,
+                "PHP_INI_SCAN_DIR" to ""
+            )
 
             val proxyPort = LocalDnsBridgeProxy.start()
             if (proxyPort > 0) {
@@ -120,7 +119,15 @@ class WordPressPhpRuntime(private val context: Context) {
             }
 
             phpOutputBuffer.setLength(0)
-            phpProcess = processBuilder.start()
+            val launch = com.webtoapp.core.linux.HostProcessLauncher.start(
+                context, command, env, File(documentRoot), "WordPress (PHP)"
+            )
+            if (launch.process == null) {
+                stopServer()
+                _serverState.value = ServerState.Error(launch.error ?: "WordPress PHP 进程启动失败")
+                return@withContext -1
+            }
+            phpProcess = launch.process
 
             phpProcess?.inputStream?.let { stream ->
                 Thread {

--- a/app/src/test/java/com/webtoapp/core/golang/GoMuslBridgeCommandTest.kt
+++ b/app/src/test/java/com/webtoapp/core/golang/GoMuslBridgeCommandTest.kt
@@ -1,0 +1,39 @@
+package com.webtoapp.core.golang
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GoMuslBridgeCommandTest {
+
+    @Test
+    fun `bridge command routes the target through the native musl linker`() {
+        val app = RuntimeEnvironment.getApplication()
+        val linker = File(app.applicationInfo.nativeLibraryDir, "libmusl-linker.so")
+        linker.parentFile?.mkdirs()
+        linker.writeBytes(byteArrayOf(0x7f, 'E'.code.toByte(), 'L'.code.toByte(), 'F'.code.toByte()))
+        try {
+            val cmd = GoDependencyManager.buildMuslBridgeCommand(app, "/data/go_bins/server", listOf("-v"))
+            assertThat(cmd).containsExactly(linker.absolutePath, "/data/go_bins/server", "-v").inOrder()
+        } finally {
+            linker.delete()
+        }
+    }
+
+    @Test
+    fun `bridge command keeps argv semantics of program-mode loader invocation`() {
+        val app = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val cmd = GoDependencyManager.buildMuslBridgeCommand(app, "bin", emptyList())
+        // Program mode: [linker, target, *args] — target sees itself as argv[0].
+        assertThat(cmd.size).isEqualTo(2)
+        assertThat(cmd[0]).endsWith("libmusl-linker.so")
+        assertThat(cmd[1]).isEqualTo("bin")
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/linux/HostProcessLauncherTest.kt
+++ b/app/src/test/java/com/webtoapp/core/linux/HostProcessLauncherTest.kt
@@ -1,0 +1,45 @@
+package com.webtoapp.core.linux
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class HostProcessLauncherTest {
+
+    @Test
+    fun `unrestricted builds spawn through ProcessBuilder and overlay the env`() {
+        val app = RuntimeEnvironment.getApplication()
+        app.applicationInfo.targetSdkVersion = 28
+        val workdir = File(app.filesDir, "wd").apply { mkdirs() }
+        val result = HostProcessLauncher.start(
+            app,
+            listOf("sh", "-c", "echo marker-\$WTA_TEST_FOO; pwd"),
+            mapOf("WTA_TEST_FOO" to "42"),
+            workdir
+        )
+        val out = result.process!!.inputStream.bufferedReader().readText()
+        result.process!!.waitFor()
+        assertThat(result.error).isNull()
+        assertThat(out).contains("marker-42")
+        assertThat(out.trim().endsWith(workdir.name)).isTrue()
+    }
+
+    @Test
+    fun `restricted builds without the static bridge surface the blocked message`() {
+        val app = RuntimeEnvironment.getApplication()
+        app.applicationInfo.targetSdkVersion = 35
+        File(app.applicationInfo.nativeLibraryDir, "libstatic_exec.so").delete()
+        val result = HostProcessLauncher.start(
+            app, listOf("sh", "-c", "echo never"), emptyMap(), null, "WordPress (PHP)"
+        )
+        assertThat(result.process).isNull()
+        assertThat(result.error).contains("WordPress (PHP)")
+        assertThat(result.error).contains("targetSdk")
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/linux/RuntimeExecPolicyTest.kt
+++ b/app/src/test/java/com/webtoapp/core/linux/RuntimeExecPolicyTest.kt
@@ -58,4 +58,26 @@ class RuntimeExecPolicyTest {
             linker.delete()
         }
     }
+
+    @Test
+    fun `static exec bridge requires the native loader on an arm64 device`() {
+        val app = contextWithTargetSdk(35)
+        val lib = File(app.applicationInfo.nativeLibraryDir, "libstatic_exec.so")
+        lib.parentFile?.mkdirs()
+        lib.writeBytes(byteArrayOf(0x7f, 'E'.code.toByte(), 'L'.code.toByte(), 'F'.code.toByte()))
+        val saved = android.os.Build.SUPPORTED_ABIS.copyOf()
+        try {
+            android.os.Build.SUPPORTED_ABIS[0] = "arm64-v8a"
+            assertThat(RuntimeExecPolicy.hasStaticExecBridge(app)).isTrue()
+            // The loader cannot parse or trampoline non-AArch64 images; other
+            // primary ABIs must fall back to the plain blocked message.
+            android.os.Build.SUPPORTED_ABIS[0] = "x86_64"
+            assertThat(RuntimeExecPolicy.hasStaticExecBridge(app)).isFalse()
+            android.os.Build.SUPPORTED_ABIS[0] = "armeabi-v7a"
+            assertThat(RuntimeExecPolicy.hasStaticExecBridge(app)).isFalse()
+        } finally {
+            System.arraycopy(saved, 0, android.os.Build.SUPPORTED_ABIS, 0, saved.size)
+            lib.delete()
+        }
+    }
 }

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -138,6 +138,10 @@ android {
             excludes += "**/libplugin-container.so"
 
             excludes += "**/libphp.so"
+
+            // Host-preview-only user-mode exec loader; generated APKs
+            // (targetSdk 28) always execve directly and never load it.
+            excludes += "**/libstatic_exec.so"
         }
     }
     androidResources {


### PR DESCRIPTION
Fixes #591

## What

Completes the W^X escape hatch family for host previews (Python landed in #590):

| Runtime | Shape | Channel under W^X |
|---|---|---|
| Go | PIE, PT_DYNAMIC, no DT_NEEDED | patched musl linker, program mode |
| PHP / WordPress / composer | static ET_EXEC, no PT_DYNAMIC | user-mode exec loader (`libstatic_exec.so`, AArch64) |
| Python | musl-linked | #590 bridge + subprocess env propagation |

## How

**Go** — android builds (CGO_ENABLED=0) are PIE with PT_DYNAMIC and no DT_NEEDED (verified by parsing a GOOS=android/arm64 build). `buildMuslBridgeCommand` launches `[linker, target, *args]`; the linker bridges exec-mapped app_data segments through executable memfds. The go_exec_loader gate now only applies to the unrestricted path.

**PHP family** — pmmp PHP is a static ELF the musl linker cannot load. `libstatic_exec.so` rebuilds execve in user mode:

- parent parses the ELF, copies the image into an executable memfd, serializes the argv/envp blob
- fork via raw `clone` syscall (aarch64 has no SYS_fork); child is async-signal-safe by construction (raw syscalls + lock-free string helpers on freshly mmap'd regions)
- child maps PT_LOAD at fixed vaddrs from the memfd, zeroes bss, mprotects per-segment flags, applies RELRO, assembles the AArch64 initial stack (argc/argv/envp/auxv incl. AT_PHDR/AT_RANDOM/AT_EXECFN/AT_SYSINFO_EHDR, 16-byte aligned sp), and jumps to e_entry

`StaticExecProcess` is a drop-in `Process` (streams, waitFor, graceful/forcible destroy, reflectable `pid` field so existing `getProcessPid` reflection keeps working). `HostProcessLauncher` keeps plain ProcessBuilder wherever execve works; the restricted path overlays the caller env on `System.getenv()` to match `ProcessBuilder.environment()` semantics, and the parent closes pipe write-ends after fork so readers see EOF when the child exits.

**Python** — server-lifetime children inherit `_WTA_MUSL_*`; sitecustomize rewrite now also covers `posix_spawn` / `spawnv` / `spawnve`.

## Safety rails

- Host preview only: generated APKs keep targetSdk 28 and plain execve; `libstatic_exec.so` is excluded from the shell template packaging.
- Loader is AArch64-only (CMake ABI guard; x86/armeabi-v7a hosts keep the clean blocked message instead of a spawn error).
- Parser rejects ET_DYN / non-AArch64 / misplaced phdr tables; child failures propagate through a sync pipe as `100+stage` codes surfaced in the launch error message.

## Validation

- `:app:compileStandardDebugKotlin` + `:shell:assembleRelease` + `:app:syncShellTemplateApk` green; template contains no `libstatic_exec.so`
- macOS CLI harness (built from the same file with `-DWTA_CLI_HARNESS`) validates ELF parse + stack math against synthetic static ELFs, including ET_DYN / bad-offset rejections
- New/updated tests: `HostProcessLauncherTest` (ProcessBuilder path + blocked message), `RuntimeExecPolicyTest` (static bridge ABI gate), `GoMuslBridgeCommandTest` (argv semantics); full targeted suite 14/14 green
- `check_config_field_drift`: OK