### PR TITLE
feat(download): slow-source switching, bandwidth probing, full mirror coverage

### DIFF
--- a/app/src/main/java/com/webtoapp/core/download/DependencyDownloadEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/download/DependencyDownloadEngine.kt
@@ -31,6 +31,19 @@ object DependencyDownloadEngine {
 
     private const val PAUSE_CHECK_MS = 200L
 
+    // Slow-source watchdog: a throttling mirror never errors — it trickles at
+    // a few KB/s forever, holding the download hostage. Below this sustained
+    // speed (after the grace window, past the minimum byte floor, only for
+    // files big enough to matter) the call is cancelled so the caller can
+    // switch to the next mirror; partial bytes stay in .tmp for resume.
+    private const val SLOW_THRESHOLD_BYTES_PER_SEC = 64L * 1024
+    private const val SLOW_GRACE_MS = 15_000L
+    private const val SLOW_MIN_BYTES = 1L * 1024 * 1024
+    private const val SLOW_MIN_TOTAL_BYTES = 2L * 1024 * 1024
+    private const val SLOW_POLL_MS = 2_000L
+
+    enum class Outcome { SUCCESS, FAILED, SLOW }
+
     val DEFAULT_TASK: TaskId = "__default__"
 
     sealed class State {
@@ -113,26 +126,30 @@ object DependencyDownloadEngine {
             .build()
     }
 
+    // Read by the watchdog thread while the copy loop mutates it — deque keeps
+    // both sides safe without locking the hot path.
     private class SpeedTracker {
-        private val speedSamples = mutableListOf<Pair<Long, Long>>()
+        private val samples = java.util.concurrent.ConcurrentLinkedDeque<Pair<Long, Long>>()
 
         fun recordSample(totalDownloaded: Long) {
             val now = System.currentTimeMillis()
-            speedSamples.add(now to totalDownloaded)
-            while (speedSamples.isNotEmpty() && now - speedSamples.first().first > SPEED_WINDOW_MS) {
-                speedSamples.removeAt(0)
+            samples.addLast(now to totalDownloaded)
+            while (true) {
+                val head = samples.peekFirst() ?: break
+                if (now - head.first > SPEED_WINDOW_MS) samples.pollFirst() else break
             }
         }
 
         fun calculateSpeed(): Long {
-            if (speedSamples.size < 2) return 0L
-            val oldest = speedSamples.first()
-            val newest = speedSamples.last()
-            val timeDelta = newest.first - oldest.first
+            val first = samples.peekFirst() ?: return 0L
+            val last = samples.peekLast() ?: return 0L
+            val timeDelta = last.first - first.first
             if (timeDelta <= 0) return 0L
-            val bytesDelta = newest.second - oldest.second
+            val bytesDelta = last.second - first.second
             return (bytesDelta * 1000 / timeDelta).coerceAtLeast(0)
         }
+
+        fun latestBytes(): Long = samples.peekLast()?.second ?: 0L
     }
 
     private fun calculateEta(remaining: Long, speed: Long): Long {
@@ -175,19 +192,22 @@ object DependencyDownloadEngine {
         AppLogger.i(TAG, "下载已取消 [task=$taskId]")
     }
 
-    suspend fun downloadFile(
+    suspend fun downloadFileEx(
         url: String,
         destFile: File,
         displayName: String,
         context: Context? = null,
         taskId: TaskId = DEFAULT_TASK,
-    ): Boolean = withContext(Dispatchers.IO) {
+    ): Outcome = withContext(Dispatchers.IO) {
         downloadMutex.withLock {
             val fileName = url.substringAfterLast("/")
             val tempFile = File(destFile.parentFile, "${destFile.name}.tmp")
             var downloadedBytes = 0L
             val startTime = System.currentTimeMillis()
             val speedTracker = SpeedTracker()
+            val totalHint = java.util.concurrent.atomic.AtomicLong(-1L)
+            val slowAbort = java.util.concurrent.atomic.AtomicBoolean(false)
+            val watchdogDone = java.util.concurrent.atomic.AtomicBoolean(false)
 
             _paused.set(false)
             _cancelled.set(false)
@@ -204,104 +224,222 @@ object DependencyDownloadEngine {
                     AppLogger.i(TAG, "断点续传: 从 $downloadedBytes 字节继续 ($displayName)")
                 }
 
-                val response = httpClient.newCall(requestBuilder.build()).execute()
+                val call = httpClient.newCall(requestBuilder.build())
 
-                if (!response.isSuccessful && response.code != 206) {
-                    AppLogger.e(TAG, "下载失败: HTTP ${response.code} - $url [task=$taskId]")
-                    emit(taskId, State.Error(Strings.downloadFailedHttp.replace("%d", response.code.toString())))
-                    response.close()
-                    return@withLock false
-                }
+                val watchdog = Thread {
+                    try {
+                        while (!watchdogDone.get()) {
+                            Thread.sleep(SLOW_POLL_MS)
+                            if (watchdogDone.get() || _paused.get() || _cancelled.get()) continue
+                            val total = totalHint.get()
+                            if (total in 1 until SLOW_MIN_TOTAL_BYTES) continue
+                            val elapsed = System.currentTimeMillis() - startTime
+                            val speed = speedTracker.calculateSpeed()
+                            if (elapsed > SLOW_GRACE_MS &&
+                                speedTracker.latestBytes() > SLOW_MIN_BYTES &&
+                                speed in 1 until SLOW_THRESHOLD_BYTES_PER_SEC
+                            ) {
+                                slowAbort.set(true)
+                                AppLogger.w(
+                                    TAG,
+                                    "$displayName 源速度 ${formatSpeed(speed)} 持续低于 ${formatSpeed(SLOW_THRESHOLD_BYTES_PER_SEC)}，放弃该源 [task=$taskId]"
+                                )
+                                call.cancel()
+                                break
+                            }
+                        }
+                    } catch (_: InterruptedException) {
+                    }
+                }.apply { isDaemon = true; name = "wta-dl-watchdog"; start() }
 
-                val body = response.body ?: run {
-                    emit(taskId, State.Error(Strings.downloadReturnedEmpty))
-                    response.close()
-                    return@withLock false
-                }
+                try {
+                    val response = call.execute()
 
-                body.use { responseBody ->
-                    val contentLength = responseBody.contentLength()
-                    val totalBytes = if (response.code == 206) {
-                        downloadedBytes + contentLength
-                    } else {
-                        contentLength
+                    if (!response.isSuccessful && response.code != 206) {
+                        AppLogger.e(TAG, "下载失败: HTTP ${response.code} - $url [task=$taskId]")
+                        emit(taskId, State.Error(Strings.downloadFailedHttp.replace("%d", response.code.toString())))
+                        response.close()
+                        return@withLock Outcome.FAILED
                     }
 
-                    val outputStream = if (response.code == 206) {
-                        FileOutputStream(tempFile, true)
-                    } else {
-                        downloadedBytes = 0
-                        FileOutputStream(tempFile)
+                    val body = response.body ?: run {
+                        emit(taskId, State.Error(Strings.downloadReturnedEmpty))
+                        response.close()
+                        return@withLock Outcome.FAILED
                     }
 
-                    var lastThrottleTime = 0L
+                    body.use { responseBody ->
+                        val contentLength = responseBody.contentLength()
+                        val totalBytes = if (response.code == 206) {
+                            downloadedBytes + contentLength
+                        } else {
+                            contentLength
+                        }
+                        totalHint.set(totalBytes)
 
-                    outputStream.use { fos ->
-                        val buffer = ByteArray(8192)
-                        responseBody.byteStream().use { inputStream ->
-                            var bytesRead: Int
+                        val outputStream = if (response.code == 206) {
+                            FileOutputStream(tempFile, true)
+                        } else {
+                            downloadedBytes = 0
+                            FileOutputStream(tempFile)
+                        }
 
-                            while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                        var lastThrottleTime = 0L
 
-                                while (_paused.get()) {
+                        outputStream.use { fos ->
+                            val buffer = ByteArray(8192)
+                            responseBody.byteStream().use { inputStream ->
+                                var bytesRead: Int
+
+                                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+
+                                    while (_paused.get()) {
+                                        if (_cancelled.get()) {
+                                            throw kotlinx.coroutines.CancellationException("cancelled by user [task=$taskId]")
+                                        }
+                                        delay(PAUSE_CHECK_MS)
+                                        if (!isActive) return@withLock Outcome.FAILED
+                                    }
                                     if (_cancelled.get()) {
                                         throw kotlinx.coroutines.CancellationException("cancelled by user [task=$taskId]")
                                     }
-                                    delay(PAUSE_CHECK_MS)
-                                    if (!isActive) return@withLock false
-                                }
-                                if (_cancelled.get()) {
-                                    throw kotlinx.coroutines.CancellationException("cancelled by user [task=$taskId]")
-                                }
 
-                                fos.write(buffer, 0, bytesRead)
-                                downloadedBytes += bytesRead
+                                    fos.write(buffer, 0, bytesRead)
+                                    downloadedBytes += bytesRead
 
-                                speedTracker.recordSample(downloadedBytes)
+                                    speedTracker.recordSample(downloadedBytes)
 
-                                val now = System.currentTimeMillis()
-                                if (now - lastThrottleTime >= THROTTLE_MS) {
-                                    lastThrottleTime = now
+                                    val now = System.currentTimeMillis()
+                                    if (now - lastThrottleTime >= THROTTLE_MS) {
+                                        lastThrottleTime = now
 
-                                    val speed = speedTracker.calculateSpeed()
-                                    val remaining = if (totalBytes > 0) totalBytes - downloadedBytes else -1
-                                    val eta = calculateEta(remaining, speed)
-                                    val progress = if (totalBytes > 0) {
-                                        (downloadedBytes.toFloat() / totalBytes).coerceIn(0f, 1f)
-                                    } else 0f
+                                        val speed = speedTracker.calculateSpeed()
+                                        val remaining = if (totalBytes > 0) totalBytes - downloadedBytes else -1
+                                        val eta = calculateEta(remaining, speed)
+                                        val progress = if (totalBytes > 0) {
+                                            (downloadedBytes.toFloat() / totalBytes).coerceIn(0f, 1f)
+                                        } else 0f
 
-                                    emit(taskId, State.Downloading(
-                                        url = url,
-                                        displayName = displayName,
-                                        fileName = fileName,
-                                        bytesDownloaded = downloadedBytes,
-                                        totalBytes = totalBytes,
-                                        progress = progress,
-                                        speedBytesPerSec = speed,
-                                        etaSeconds = eta,
-                                        startTimeMillis = startTime,
-                                        isPaused = false
-                                    ))
+                                        emit(taskId, State.Downloading(
+                                            url = url,
+                                            displayName = displayName,
+                                            fileName = fileName,
+                                            bytesDownloaded = downloadedBytes,
+                                            totalBytes = totalBytes,
+                                            progress = progress,
+                                            speedBytesPerSec = speed,
+                                            etaSeconds = eta,
+                                            startTimeMillis = startTime,
+                                            isPaused = false
+                                        ))
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                tempFile.renameTo(destFile)
-                AppLogger.i(TAG, "$displayName 下载完成: ${destFile.length()} 字节")
-                true
+                    val expected = totalHint.get()
+                    if (expected > 0 && tempFile.length() != expected) {
+                        AppLogger.e(TAG, "$displayName 大小不匹配: expected=$expected actual=${tempFile.length()} [task=$taskId]")
+                        tempFile.delete()
+                        emit(taskId, State.Error(
+                            Strings.downloadNameFailed
+                                .replaceFirst("%s", displayName)
+                                .replaceFirst("%s", "size mismatch: expected $expected bytes, got ${tempFile.length()}")
+                        ))
+                        return@withLock Outcome.FAILED
+                    }
+
+                    tempFile.renameTo(destFile)
+                    AppLogger.i(TAG, "$displayName 下载完成: ${destFile.length()} 字节")
+                    Outcome.SUCCESS
+                } finally {
+                    watchdogDone.set(true)
+                    watchdog.interrupt()
+                }
 
             } catch (e: kotlinx.coroutines.CancellationException) {
                 AppLogger.i(TAG, "$displayName 被取消,保留临时文件以便断点续传 [task=$taskId]")
                 _states.value = _states.value - taskId
                 throw e
             } catch (e: Exception) {
-                AppLogger.e(TAG, "下载 $displayName 失败 [task=$taskId]", e)
-                emit(taskId, State.Error(Strings.downloadNameFailed.replaceFirst("%s", displayName).replaceFirst("%s", e.message ?: "")))
-                false
+                if (slowAbort.get()) {
+                    // Keep .tmp: bytes are valid, the next mirror resumes from here.
+                    AppLogger.w(TAG, "$displayName 源过慢已中断，交由调用方切换源 [task=$taskId]")
+                    Outcome.SLOW
+                } else {
+                    AppLogger.e(TAG, "下载 $displayName 失败 [task=$taskId]", e)
+                    emit(taskId, State.Error(Strings.downloadNameFailed.replaceFirst("%s", displayName).replaceFirst("%s", e.message ?: "")))
+                    Outcome.FAILED
+                }
             }
         }
+    }
+
+    /**
+     * Multi-source download with uniform retry / slow-switch / resume policy.
+     * - FAILED: retried up to [maxRetryPerUrl] times, then .tmp is dropped and
+     *   the next source starts clean.
+     * - SLOW: the source is abandoned immediately but .tmp is kept, so the next
+     *   mirror resumes from the stalled byte offset. On the last source a SLOW
+     *   abort is retried — each resume still makes forward progress.
+     */
+    suspend fun downloadFileWithFallback(
+        urls: List<String>,
+        destFile: File,
+        displayName: String,
+        context: Context? = null,
+        maxRetryPerUrl: Int = 2,
+        retryDelayMs: Long = 2_000L,
+        fetch: suspend (url: String, sourceName: String) -> Outcome = { url, sourceName ->
+            downloadFileEx(url, destFile, sourceName, context)
+        },
+    ): Boolean {
+        var lastOutcome = Outcome.FAILED
+        for ((urlIndex, url) in urls.withIndex()) {
+            val sourceName = if (urls.size > 1) {
+                String.format(Strings.pyDownloadSourceLabel, displayName, urlIndex + 1, urls.size)
+            } else displayName
+            AppLogger.i(TAG, "Attempting to download $sourceName: $url")
+
+            var attempt = 0
+            while (true) {
+                lastOutcome = fetch(url, sourceName)
+                if (lastOutcome == Outcome.SUCCESS) return true
+
+                val hasMoreSources = urlIndex < urls.lastIndex
+                if (lastOutcome == Outcome.SLOW) {
+                    if (hasMoreSources) {
+                        AppLogger.i(TAG, "$sourceName 过慢，切换下一源（保留断点）")
+                        break
+                    }
+                    if (++attempt >= maxRetryPerUrl) {
+                        emit(DEFAULT_TASK, State.Error(
+                            Strings.downloadNameFailed
+                                .replaceFirst("%s", displayName)
+                                .replaceFirst("%s", "all sources too slow")
+                        ))
+                        return false
+                    }
+                    AppLogger.i(TAG, "$sourceName 过慢，保留断点重试 ($attempt/$maxRetryPerUrl)")
+                    continue
+                }
+
+                if (++attempt < maxRetryPerUrl) {
+                    AppLogger.i(TAG, "$sourceName download failed, retrying in ${retryDelayMs / 1000}s ($attempt/$maxRetryPerUrl)")
+                    kotlinx.coroutines.delay(retryDelayMs)
+                    publishState(State.Idle)
+                } else {
+                    if (hasMoreSources) {
+                        File(destFile.parentFile, "${destFile.name}.tmp").delete()
+                        AppLogger.i(TAG, "$sourceName failed, switching to next source...")
+                        publishState(State.Idle)
+                    }
+                    break
+                }
+            }
+        }
+        return false
     }
 
     fun formatSpeed(bytesPerSec: Long): String {

--- a/app/src/main/java/com/webtoapp/core/golang/GoToolchainManager.kt
+++ b/app/src/main/java/com/webtoapp/core/golang/GoToolchainManager.kt
@@ -313,18 +313,9 @@ object GoToolchainManager {
         destFile: File,
         displayName: String,
         context: Context?,
-    ): Boolean {
-        for (attempt in 1..MAX_RETRY_PER_URL) {
-            val ok = DependencyDownloadEngine.downloadFile(url, destFile, displayName, context)
-            if (ok) return true
-            if (attempt < MAX_RETRY_PER_URL) {
-                AppLogger.i(TAG, "$displayName 下载失败, ${RETRY_DELAY_MS / 1000}s 后重试 ($attempt/$MAX_RETRY_PER_URL)")
-                kotlinx.coroutines.delay(RETRY_DELAY_MS)
-                DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-            }
-        }
-        return false
-    }
+    ): Boolean = DependencyDownloadEngine.downloadFileWithFallback(
+        listOf(url), destFile, displayName, context, MAX_RETRY_PER_URL, RETRY_DELAY_MS
+    )
 
     internal fun selectGoArchiveUrls(preferChinaMirror: Boolean): List<String> {
         return if (preferChinaMirror) {
@@ -361,20 +352,9 @@ object GoToolchainManager {
             AppLogger.e(TAG, "$displayName 没有可用的下载源")
             return false
         }
-        urls.forEachIndexed { index, url ->
-            AppLogger.i(TAG, "$displayName 尝试源 ${index + 1}/${urls.size}: $url")
-            val ok = downloadWithRetry(url, destFile, displayName, context)
-            if (ok) {
-                if (index > 0) {
-                    AppLogger.i(TAG, "$displayName 从备选源下载成功: $url")
-                }
-                return true
-            }
-            AppLogger.w(TAG, "$displayName 源 $url 全部重试仍失败,切换下一源")
-            DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-        }
-        AppLogger.e(TAG, "$displayName 所有源均失败,共尝试 ${urls.size} 个")
-        return false
+        return DependencyDownloadEngine.downloadFileWithFallback(
+            urls, destFile, displayName, context, MAX_RETRY_PER_URL, RETRY_DELAY_MS
+        )
     }
 
     private fun extractGoArchiveToRoot(archiveFile: File, destGoRoot: File) {

--- a/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
@@ -102,10 +102,18 @@ object LocalBuildEnvironment {
 
     private const val COMPOSER_VERSION = "2.10.2"
 
-    private val COMPOSER_PHAR_URLS = listOf(
-        "https://getcomposer.org/download/$COMPOSER_VERSION/composer.phar",
-        "https://github.com/composer/composer/releases/download/$COMPOSER_VERSION/composer.phar"
-    )
+    private val COMPOSER_OFFICIAL_URL = "https://getcomposer.org/download/$COMPOSER_VERSION/composer.phar"
+    private val COMPOSER_GITHUB_URL = "https://github.com/composer/composer/releases/download/$COMPOSER_VERSION/composer.phar"
+
+    // CN: probed GitHub proxies first (release-asset throughput), then the
+    // slow official origin, then direct GitHub as the last resort.
+    private fun composerPharUrls(): List<String> {
+        val cn = com.webtoapp.core.wordpress.WordPressDependencyManager.getMirrorRegion() ==
+            com.webtoapp.core.wordpress.WordPressDependencyManager.MirrorRegion.CN
+        if (!cn) return listOf(COMPOSER_OFFICIAL_URL, COMPOSER_GITHUB_URL)
+        val proxied = com.webtoapp.core.network.GitHubMirror.proxiedCn(COMPOSER_GITHUB_URL)
+        return proxied.dropLast(1) + COMPOSER_OFFICIAL_URL + proxied.last()
+    }
 
     private val IGNORED_PLATFORM_REQS = listOf(
         "ext-session",
@@ -162,8 +170,8 @@ object LocalBuildEnvironment {
         }
 
         var lastError: Exception? = null
-        for ((idx, url) in COMPOSER_PHAR_URLS.withIndex()) {
-            val sourceLabel = if (idx == 0) Strings.localBuildComposerSourceOfficial else Strings.localBuildComposerSourceMirror
+        for (url in composerPharUrls()) {
+            val sourceLabel = if (url.contains("getcomposer.org")) Strings.localBuildComposerSourceOfficial else Strings.localBuildComposerSourceMirror
             onProgress(Strings.localBuildDownloadComposer.format(COMPOSER_VERSION, sourceLabel), 0.5f)
             target.parentFile?.mkdirs()
 
@@ -465,6 +473,13 @@ object LocalBuildEnvironment {
         throw IOException(Strings.nodeLauncherNotPackaged.format(packagedLauncher.absolutePath))
     }
 
+    private fun npmToolTarballUrls(path: String): List<String> =
+        com.webtoapp.core.network.GitHubMirror.npmTarballUrls(
+            "https://registry.npmjs.org/$path",
+            com.webtoapp.core.nodejs.NodeDependencyManager.getMirrorRegion() ==
+                com.webtoapp.core.nodejs.NodeDependencyManager.MirrorRegion.CN
+        )
+
     suspend fun ensureNpm(
         context: Context,
         onProgress: (String, Float) -> Unit = { _, _ -> }
@@ -473,7 +488,8 @@ object LocalBuildEnvironment {
         onProgress(Strings.localBuildInstallingNpm, 0.35f)
         installTarballPackage(
             context = context,
-            tarballUrl = "https://registry.npmjs.org/npm/-/npm-$NPM_VERSION.tgz",
+            tarballUrls = npmToolTarballUrls("npm/-/npm-$NPM_VERSION.tgz"),
+            displayName = "npm $NPM_VERSION",
             targetDir = File(getToolDir(context), "npm")
         )
     }
@@ -486,7 +502,8 @@ object LocalBuildEnvironment {
         onProgress(Strings.localBuildInstallingPnpm, 0.6f)
         installTarballPackage(
             context = context,
-            tarballUrl = "https://registry.npmjs.org/pnpm/-/pnpm-$PNPM_VERSION.tgz",
+            tarballUrls = npmToolTarballUrls("pnpm/-/pnpm-$PNPM_VERSION.tgz"),
+            displayName = "pnpm $PNPM_VERSION",
             targetDir = File(getToolDir(context), "pnpm")
         )
     }
@@ -499,7 +516,8 @@ object LocalBuildEnvironment {
         onProgress(Strings.localBuildInstallingYarn, 0.8f)
         installTarballPackage(
             context = context,
-            tarballUrl = "https://registry.npmjs.org/yarn/-/yarn-$YARN_VERSION.tgz",
+            tarballUrls = npmToolTarballUrls("yarn/-/yarn-$YARN_VERSION.tgz"),
+            displayName = "yarn $YARN_VERSION",
             targetDir = File(getToolDir(context), "yarn")
         )
     }
@@ -685,6 +703,20 @@ object LocalBuildEnvironment {
         processEnv["npm_config_cache"] = getNpmCacheDir(context).absolutePath
         processEnv["npm_config_prefix"] = getNpmPrefixDir(context).absolutePath
         processEnv["npm_config_userconfig"] = File(rootDir, "npmrc").absolutePath
+
+        // CN region: ride the npmmirror registry for every npm/pnpm/yarn
+        // invocation (install included) unless the project or the managed
+        // userconfig pins one already, or the caller supplied its own.
+        if (processEnv["npm_config_registry"] == null &&
+            !npmrcPinsRegistry(workingDir) &&
+            !npmrcPinsRegistry(File(rootDir, "npmrc")) &&
+            com.webtoapp.core.nodejs.NodeDependencyManager.getMirrorRegion() ==
+                com.webtoapp.core.nodejs.NodeDependencyManager.MirrorRegion.CN
+        ) {
+            processEnv["npm_config_registry"] =
+                com.webtoapp.core.network.GitHubMirror.NPM_MIRROR_REGISTRY
+        }
+
         processEnv["COREPACK_ENABLE_AUTO_PIN"] = "0"
         processEnv["CI"] = "1"
         env.forEach { (key, value) -> processEnv[key] = value }
@@ -759,19 +791,48 @@ object LocalBuildEnvironment {
 
     private suspend fun installTarballPackage(
         context: Context,
-        tarballUrl: String,
+        tarballUrls: List<String>,
+        displayName: String,
         targetDir: File
     ) = withContext(Dispatchers.IO) {
         targetDir.parentFile?.mkdirs()
         if (targetDir.exists()) targetDir.deleteRecursively()
         val tempFile = File.createTempFile("wta-tool", ".tgz", context.cacheDir)
         try {
-            downloadFile(tarballUrl, tempFile)
-            extractTarGz(tempFile, targetDir)
+            var lastError: Exception? = null
+            for (url in tarballUrls) {
+                try {
+                    downloadFile(url, tempFile)
+                    // A proxy may answer 200 with an HTML error page — only a
+                    // plausible gzip tarball proceeds to extraction.
+                    if (tempFile.length() < 10_000 || !isGzipFile(tempFile)) {
+                        throw IOException("invalid tarball from $url (${tempFile.length()} bytes)")
+                    }
+                    extractTarGz(tempFile, targetDir)
+                    return@withContext
+                } catch (e: Exception) {
+                    lastError = e
+                    AppLogger.w(TAG, "$displayName download from $url failed: ${e.message}")
+                }
+            }
+            throw IOException("$displayName 下载失败: ${lastError?.message}")
         } finally {
             tempFile.delete()
         }
     }
+
+    private fun isGzipFile(file: File): Boolean = runCatching {
+        FileInputStream(file).use { input ->
+            input.read() == 0x1f && input.read() == 0x8b
+        }
+    }.getOrDefault(false)
+
+    private fun npmrcPinsRegistry(npmrc: File): Boolean = runCatching {
+        npmrc.exists() && npmrc.readLines().any { line ->
+            val trimmed = line.trim()
+            trimmed.startsWith("registry") && trimmed.contains('=')
+        }
+    }.getOrDefault(false)
 
     private fun downloadFile(url: String, targetFile: File) {
         val connection = URL(url).openConnection() as HttpURLConnection

--- a/app/src/main/java/com/webtoapp/core/linux/NativeNodeEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/NativeNodeEngine.kt
@@ -22,31 +22,11 @@ object NativeNodeEngine {
 
     private const val NODE_VERSION = "18.20.4"
 
-    private val NODE_DOWNLOAD_URLS = mapOf(
-        "arm64-v8a" to "https://github.com/nicolo-ribaudo/pnpm-prebuilt-android/releases/download/v8.15.4/pnpm-android-arm64",
-        "armeabi-v7a" to "https://github.com/nicolo-ribaudo/pnpm-prebuilt-android/releases/download/v8.15.4/pnpm-android-arm"
-    )
-
     private val ESBUILD_DOWNLOAD_URLS = mapOf(
         "arm64-v8a" to "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz",
         "armeabi-v7a" to "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.20.0.tgz",
         "x86_64" to "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.20.0.tgz"
     )
-
-    private val GITHUB_CN_PROXIES = listOf(
-        "https://ghfast.top/",
-        "https://gh-proxy.com/"
-    )
-
-    private fun getNodeDownloadUrls(abi: String): List<String> {
-        val direct = NODE_DOWNLOAD_URLS[abi] ?: return emptyList()
-        return if (java.util.Locale.getDefault().language == "zh") {
-            val ordered = com.webtoapp.core.network.CnMirrorProbe.getOrderedProxies(GITHUB_CN_PROXIES)
-            ordered.map { proxy -> "$proxy$direct" } + direct
-        } else {
-            listOf(direct)
-        }
-    }
 
     private val _state = MutableStateFlow<NodeEngineState>(NodeEngineState.NotInitialized)
     val state: StateFlow<NodeEngineState> = _state

--- a/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
+++ b/app/src/main/java/com/webtoapp/core/network/CnMirrorProbe.kt
@@ -12,14 +12,22 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 import java.util.concurrent.TimeUnit
-import kotlin.system.measureTimeMillis
 
 object CnMirrorProbe {
 
     private const val TAG = "CnMirrorProbe"
     private const val CACHE_TTL_MS = 10L * 60 * 1000
 
-    private const val PROBE_SUFFIX = "https://raw.githubusercontent.com/github/gitignore/main/README.md"
+    // Probe through a real GitHub release asset — the exact path large runtime
+    // downloads take (proxy -> github release CDN). A HEAD on a README says
+    // nothing about release throughput, which is what actually matters.
+    private const val PROBE_TARGET =
+        "https://github.com/git-lfs/git-lfs/releases/download/v3.7.0/git-lfs-linux-amd64-v3.7.0.tar.gz"
+
+    // Measure sustained download speed on the first 256 KB, capped at ~3.5 s
+    // per proxy; mirrors are ordered by measured bandwidth, not RTT.
+    private const val PROBE_BYTES = 256L * 1024
+    private const val PROBE_BUDGET_MS = 3500L
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val mutex = Mutex()
@@ -64,17 +72,17 @@ object CnMirrorProbe {
         try {
             val results = withContext(Dispatchers.IO) {
                 baseList.map { proxy ->
-                    async { proxy to measureProxy(proxy) }
+                    async { proxy to measureProxyBandwidth(proxy) }
                 }.awaitAll()
             }
             val ordered = results
                 .filter { it.second > 0 }
-                .sortedBy { it.second }
+                .sortedByDescending { it.second }
                 .map { it.first }
             if (ordered.isNotEmpty()) {
                 cachedOrder = ordered
                 cachedAt = System.currentTimeMillis()
-                AppLogger.i(TAG, "Probed proxies: $ordered (rtt ms: ${results.filter { it.second > 0 }.joinToString { "${it.first.substringAfter("//").substringBefore("/")}=${it.second}" }})")
+                AppLogger.i(TAG, "Probed proxies: $ordered (KB/s: ${results.filter { it.second > 0 }.joinToString { "${it.first.substringAfter("//").substringBefore("/")}=${it.second / 1024}" }})")
             } else {
                 AppLogger.w(TAG, "All proxies failed probe; keeping previous order")
             }
@@ -83,18 +91,33 @@ object CnMirrorProbe {
         }
     }
 
-    private fun measureProxy(proxy: String): Long {
-        val url = "$proxy$PROBE_SUFFIX"
+    /** Sustained download speed in bytes/sec through the proxy; -1 when unusable. */
+    private fun measureProxyBandwidth(proxy: String): Long {
+        val url = "$proxy$PROBE_TARGET"
         return try {
-            var code = 0
-            val elapsed = measureTimeMillis {
-                val req = Request.Builder().url(url).head().build()
-                probeClient.newCall(req).execute().use { resp ->
-                    code = resp.code
+            val req = Request.Builder()
+                .url(url)
+                .header("Range", "bytes=0-${PROBE_BYTES - 1}")
+                .build()
+            probeClient.newCall(req).execute().use { resp ->
+                if (resp.code !in 200..399) return -1
+                val body = resp.body ?: return -1
+                body.byteStream().use { input ->
+                    val buffer = ByteArray(16 * 1024)
+                    var read = 0L
+                    val start = System.currentTimeMillis()
+                    while (read < PROBE_BYTES) {
+                        val left = (PROBE_BYTES - read).toInt().coerceAtMost(buffer.size)
+                        val n = input.read(buffer, 0, left)
+                        if (n == -1) break
+                        read += n
+                        if (System.currentTimeMillis() - start > PROBE_BUDGET_MS) break
+                    }
+                    val elapsed = System.currentTimeMillis() - start
+                    if (read <= 0L || elapsed <= 0L) -1 else read * 1000 / elapsed
                 }
             }
-            if (code in 200..399) elapsed else -1
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             -1
         }
     }

--- a/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
+++ b/app/src/main/java/com/webtoapp/core/network/GitHubMirror.kt
@@ -1,0 +1,39 @@
+package com.webtoapp.core.network
+
+/**
+ * Single source of truth for GitHub release / npm-registry mirror expansion.
+ * Every runtime downloader funnels through here so mirror ordering (probed by
+ * measured bandwidth via [CnMirrorProbe]) and the direct-URL fallback stay
+ * consistent across Node / Python / PHP / WordPress / Go toolchains.
+ */
+object GitHubMirror {
+
+    val CN_PROXIES = listOf(
+        "https://ghfast.top/",
+        "https://gh-proxy.com/"
+    )
+
+    const val NPM_REGISTRY = "https://registry.npmjs.org"
+    const val NPM_MIRROR_REGISTRY = "https://registry.npmmirror.com"
+
+    /**
+     * Bandwidth-ordered CN proxy URLs for a GitHub release asset, with the
+     * direct URL as the final fallback. Non-CN or non-GitHub URLs come back
+     * unchanged so callers can pass any URL through.
+     */
+    fun proxiedCn(url: String): List<String> {
+        if (!url.startsWith("https://github.com/")) return listOf(url)
+        return CnMirrorProbe.getOrderedProxies(CN_PROXIES).map { proxy -> proxy + url } + url
+    }
+
+    /**
+     * npm registry tarball URLs with the npmmirror CN variant first when
+     * [cn] is set; anything not hosted on registry.npmjs.org passes through.
+     */
+    fun npmTarballUrls(url: String, cn: Boolean): List<String> {
+        if (!url.startsWith("$NPM_REGISTRY/")) return listOf(url)
+        if (!cn) return listOf(url)
+        val mirrored = NPM_MIRROR_REGISTRY + url.removePrefix(NPM_REGISTRY)
+        return listOf(mirrored, url)
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/nodejs/NodeDependencyManager.kt
@@ -25,11 +25,6 @@ object NodeDependencyManager {
 
     enum class MirrorRegion { CN, GLOBAL }
 
-    private val GITHUB_CN_PROXIES = listOf(
-        "https://ghfast.top/",
-        "https://gh-proxy.com/"
-    )
-
     // capawesome-team fork: same Node 18.20.4 core, Android binaries pre-built with 16 KB page
     // alignment (upstream `release18-20-4+16kb-fix` branch) — no runtime ELF rewrite needed.
     private val NODE_GITHUB_URL = "https://github.com/capawesome-team/nodejs-mobile/releases/download/v18.20.4-capawesome.1/nodejs-mobile-v18.20.4-capawesome.1-android.zip"
@@ -39,12 +34,9 @@ object NodeDependencyManager {
         val nodeUrls: List<String>
     )
 
-    private fun buildCnMirror(): MirrorConfig {
-        val orderedProxies = com.webtoapp.core.network.CnMirrorProbe.getOrderedProxies(GITHUB_CN_PROXIES)
-        return MirrorConfig(
-            nodeUrls = orderedProxies.map { proxy -> "${proxy}${NODE_GITHUB_URL}" } + NODE_GITHUB_URL
-        )
-    }
+    private fun buildCnMirror(): MirrorConfig = MirrorConfig(
+        nodeUrls = com.webtoapp.core.network.GitHubMirror.proxiedCn(NODE_GITHUB_URL)
+    )
 
     private val GLOBAL_MIRROR = MirrorConfig(
         nodeUrls = listOf(NODE_GITHUB_URL)
@@ -227,31 +219,9 @@ object NodeDependencyManager {
         destFile: File,
         displayName: String,
         context: Context?
-    ): Boolean {
-        for ((urlIndex, url) in urls.withIndex()) {
-            val sourceName = if (urls.size > 1) "$displayName [源${urlIndex + 1}/${urls.size}]" else displayName
-            AppLogger.i(TAG, "Attempting to download $sourceName: $url")
-
-            for (attempt in 1..MAX_RETRY_PER_URL) {
-                val success = DependencyDownloadEngine.downloadFile(url, destFile, sourceName, context)
-                if (success) return true
-
-                if (attempt < MAX_RETRY_PER_URL) {
-                    AppLogger.i(TAG, "$sourceName download failed, retrying in ${RETRY_DELAY_MS / 1000}s ($attempt/$MAX_RETRY_PER_URL)")
-                    kotlinx.coroutines.delay(RETRY_DELAY_MS)
-                    DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-                }
-            }
-
-            if (urlIndex < urls.lastIndex) {
-                val tmpFile = File(destFile.parentFile, "${destFile.name}.tmp")
-                tmpFile.delete()
-                AppLogger.i(TAG, "$sourceName failed, switching to next source...")
-                DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-            }
-        }
-        return false
-    }
+    ): Boolean = DependencyDownloadEngine.downloadFileWithFallback(
+        urls, destFile, displayName, context, MAX_RETRY_PER_URL, RETRY_DELAY_MS
+    )
 
     private suspend fun downloadNode(context: Context, mirror: MirrorConfig): Boolean {
         val abi = getDeviceAbi()

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -61,11 +61,6 @@ object PythonDependencyManager {
 
     enum class MirrorRegion { CN, GLOBAL }
 
-    private val GITHUB_CN_PROXIES = listOf(
-        "https://ghfast.top/",
-        "https://gh-proxy.com/"
-    )
-
     private fun getPythonUrl(abi: String): String {
 
         val tripleMap = mapOf(
@@ -105,14 +100,10 @@ object PythonDependencyManager {
         val muslLinkerUrl: String? = null
     )
 
-    private fun getCnMirror(abi: String): MirrorConfig {
-        val baseUrl = getPythonUrl(abi)
-        val orderedProxies = com.webtoapp.core.network.CnMirrorProbe.getOrderedProxies(GITHUB_CN_PROXIES)
-        return MirrorConfig(
-            pythonUrls = orderedProxies.map { proxy -> "${proxy}${baseUrl}" } + baseUrl,
-            muslLinkerUrl = getMuslLinkerUrl(abi)
-        )
-    }
+    private fun getCnMirror(abi: String): MirrorConfig = MirrorConfig(
+        pythonUrls = com.webtoapp.core.network.GitHubMirror.proxiedCn(getPythonUrl(abi)),
+        muslLinkerUrl = getMuslLinkerUrl(abi)
+    )
 
     private fun getGlobalMirror(abi: String): MirrorConfig {
         return MirrorConfig(
@@ -955,31 +946,9 @@ sys.exit(main())
         destFile: File,
         displayName: String,
         context: Context?
-    ): Boolean {
-        for ((urlIndex, url) in urls.withIndex()) {
-            val sourceName = if (urls.size > 1) String.format(com.webtoapp.core.i18n.Strings.pyDownloadSourceLabel, displayName, urlIndex + 1, urls.size) else displayName
-            AppLogger.i(TAG, "Attempting to download $sourceName: $url")
-
-            for (attempt in 1..MAX_RETRY_PER_URL) {
-                val success = DependencyDownloadEngine.downloadFile(url, destFile, sourceName, context)
-                if (success) return true
-
-                if (attempt < MAX_RETRY_PER_URL) {
-                    AppLogger.i(TAG, "$sourceName download failed, retrying in ${RETRY_DELAY_MS / 1000}s ($attempt/$MAX_RETRY_PER_URL)")
-                    kotlinx.coroutines.delay(RETRY_DELAY_MS)
-                    DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-                }
-            }
-
-            if (urlIndex < urls.lastIndex) {
-                val tmpFile = File(destFile.parentFile, "${destFile.name}.tmp")
-                tmpFile.delete()
-                AppLogger.i(TAG, "$sourceName failed, trying next source...")
-                DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-            }
-        }
-        return false
-    }
+    ): Boolean = DependencyDownloadEngine.downloadFileWithFallback(
+        urls, destFile, displayName, context, MAX_RETRY_PER_URL, RETRY_DELAY_MS
+    )
 
     private suspend fun downloadPython(context: Context, mirror: MirrorConfig, abi: String): Boolean {
         val pythonUrls = mirror.pythonUrls

--- a/app/src/main/java/com/webtoapp/core/wordpress/WordPressDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/wordpress/WordPressDependencyManager.kt
@@ -26,11 +26,6 @@ object WordPressDependencyManager {
 
     enum class MirrorRegion { CN, GLOBAL }
 
-    private val GITHUB_CN_PROXIES = listOf(
-        "https://ghfast.top/",
-        "https://gh-proxy.com/"
-    )
-
     private val PHP_GITHUB_URL = "https://github.com/pmmp/PHP-Binaries/releases/download/pm5-php-${PHP_VERSION}-latest/PHP-${PHP_VERSION}-Android-arm64-PM5.tar.gz"
 
     data class MirrorConfig(
@@ -41,19 +36,16 @@ object WordPressDependencyManager {
         val sqlitePluginUrl: String
     )
 
-    private fun buildCnMirror(): MirrorConfig {
-        val orderedProxies = com.webtoapp.core.network.CnMirrorProbe.getOrderedProxies(GITHUB_CN_PROXIES)
-        return MirrorConfig(
-            phpUrls = orderedProxies.map { proxy -> "${proxy}${PHP_GITHUB_URL}" } + PHP_GITHUB_URL,
-            wordpressUrls = listOf(
-                "https://cn.wordpress.org/wordpress-${WORDPRESS_VERSION}-zh_CN.tar.gz",
-                "https://cn.wordpress.org/latest-zh_CN.tar.gz",
-                "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz",
-                "https://wordpress.org/latest.tar.gz"
-            ),
-            sqlitePluginUrl = "https://downloads.wordpress.org/plugin/"
-        )
-    }
+    private fun buildCnMirror(): MirrorConfig = MirrorConfig(
+        phpUrls = com.webtoapp.core.network.GitHubMirror.proxiedCn(PHP_GITHUB_URL),
+        wordpressUrls = listOf(
+            "https://cn.wordpress.org/wordpress-${WORDPRESS_VERSION}-zh_CN.tar.gz",
+            "https://cn.wordpress.org/latest-zh_CN.tar.gz",
+            "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz",
+            "https://wordpress.org/latest.tar.gz"
+        ),
+        sqlitePluginUrl = "https://downloads.wordpress.org/plugin/"
+    )
 
     private val GLOBAL_MIRROR = MirrorConfig(
         phpUrls = listOf(PHP_GITHUB_URL),
@@ -273,31 +265,9 @@ object WordPressDependencyManager {
         destFile: File,
         displayName: String,
         context: Context?
-    ): Boolean {
-        for ((urlIndex, url) in urls.withIndex()) {
-            val sourceName = if (urls.size > 1) "$displayName [源${urlIndex + 1}/${urls.size}]" else displayName
-            AppLogger.i(TAG, "Attempting to download $sourceName: $url")
-
-            for (attempt in 1..MAX_RETRY_PER_URL) {
-                val success = DependencyDownloadEngine.downloadFile(url, destFile, sourceName, context)
-                if (success) return true
-
-                if (attempt < MAX_RETRY_PER_URL) {
-                    AppLogger.i(TAG, "$sourceName download failed, retrying in ${RETRY_DELAY_MS / 1000}s ($attempt/$MAX_RETRY_PER_URL)")
-                    kotlinx.coroutines.delay(RETRY_DELAY_MS)
-                    DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-                }
-            }
-
-            if (urlIndex < urls.lastIndex) {
-                val tmpFile = File(destFile.parentFile, "${destFile.name}.tmp")
-                tmpFile.delete()
-                AppLogger.i(TAG, "$sourceName failed, switching to next source...")
-                DependencyDownloadEngine.publishState(DependencyDownloadEngine.State.Idle)
-            }
-        }
-        return false
-    }
+    ): Boolean = DependencyDownloadEngine.downloadFileWithFallback(
+        urls, destFile, displayName, context, MAX_RETRY_PER_URL, RETRY_DELAY_MS
+    )
 
     private suspend fun downloadWithRetry(
         url: String,

--- a/app/src/test/java/com/webtoapp/core/download/DownloadFallbackPolicyTest.kt
+++ b/app/src/test/java/com/webtoapp/core/download/DownloadFallbackPolicyTest.kt
@@ -1,0 +1,116 @@
+package com.webtoapp.core.download
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class DownloadFallbackPolicyTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun dest(): Pair<File, File> {
+        val destFile = tmp.newFile("pkg.zip")
+        destFile.delete()
+        val tmpFile = File(destFile.parentFile, "${destFile.name}.tmp")
+        return destFile to tmpFile
+    }
+
+    private fun engine() = DependencyDownloadEngine
+
+    @Test
+    fun `slow source keeps the partial tmp and switches to the next url`() = runBlocking {
+        val (destFile, tmpFile) = dest()
+        tmpFile.writeBytes(ByteArray(64))
+        val calls = mutableListOf<String>()
+
+        val ok = engine().downloadFileWithFallback(
+            listOf("https://slow/proxied", "https://fast/proxied"),
+            destFile, "Unit", null,
+            maxRetryPerUrl = 2, retryDelayMs = 0,
+            fetch = { url, _ ->
+                calls.add(url)
+                if (url.endsWith("slow/proxied")) {
+                    // Partial bytes must survive the slow switch.
+                    assertThat(tmpFile.exists()).isTrue()
+                    DependencyDownloadEngine.Outcome.SLOW
+                } else {
+                    assertThat(tmpFile.exists()).isTrue()
+                    DependencyDownloadEngine.Outcome.SUCCESS
+                }
+            }
+        )
+        assertThat(ok).isTrue()
+        assertThat(calls).containsExactly("https://slow/proxied", "https://fast/proxied").inOrder()
+    }
+
+    @Test
+    fun `failed source retries then drops tmp before switching`() = runBlocking {
+        val (destFile, tmpFile) = dest()
+        tmpFile.writeBytes(ByteArray(64))
+        val calls = mutableListOf<String>()
+
+        val ok = engine().downloadFileWithFallback(
+            listOf("https://bad/proxied", "https://good/proxied"),
+            destFile, "Unit", null,
+            maxRetryPerUrl = 2, retryDelayMs = 0,
+            fetch = { url, _ ->
+                calls.add(url)
+                if (url.endsWith("bad/proxied")) {
+                    DependencyDownloadEngine.Outcome.FAILED
+                } else {
+                    // Retries exhausted on the previous source: the partial
+                    // tmp must be gone so this source starts clean.
+                    assertThat(tmpFile.exists()).isFalse()
+                    DependencyDownloadEngine.Outcome.SUCCESS
+                }
+            }
+        )
+        assertThat(ok).isTrue()
+        assertThat(calls).containsExactly(
+            "https://bad/proxied", "https://bad/proxied", "https://good/proxied"
+        ).inOrder()
+    }
+
+    @Test
+    fun `slow on the last source resumes until retries are exhausted`() = runBlocking {
+        val (destFile, _) = dest()
+        var calls = 0
+
+        val ok = engine().downloadFileWithFallback(
+            listOf("https://only/proxied"),
+            destFile, "Unit", null,
+            maxRetryPerUrl = 3, retryDelayMs = 0,
+            fetch = { _, _ ->
+                calls++
+                DependencyDownloadEngine.Outcome.SLOW
+            }
+        )
+        assertThat(ok).isFalse()
+        assertThat(calls).isEqualTo(3)
+        assertThat(engine().state.value).isInstanceOf(DependencyDownloadEngine.State.Error::class.java)
+        engine().reset()
+    }
+
+    @Test
+    fun `success on first try makes a single call`() = runBlocking {
+        val (destFile, _) = dest()
+        var calls = 0
+
+        val ok = engine().downloadFileWithFallback(
+            listOf("https://good/proxied"),
+            destFile, "Unit", null,
+            fetch = { _, _ -> calls++; DependencyDownloadEngine.Outcome.SUCCESS }
+        )
+        assertThat(ok).isTrue()
+        assertThat(calls).isEqualTo(1)
+    }
+}

--- a/app/src/test/java/com/webtoapp/core/network/GitHubMirrorTest.kt
+++ b/app/src/test/java/com/webtoapp/core/network/GitHubMirrorTest.kt
@@ -1,0 +1,45 @@
+package com.webtoapp.core.network
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GitHubMirrorTest {
+
+    @Test
+    fun `proxiedCn expands a github release asset with direct fallback`() {
+        val urls = GitHubMirror.proxiedCn("https://github.com/oct/x/releases/download/v1/a.zip")
+        assertThat(urls).hasSize(GitHubMirror.CN_PROXIES.size + 1)
+        // No probe cache in tests: base order (proxies first), direct last.
+        GitHubMirror.CN_PROXIES.forEachIndexed { i, proxy ->
+            assertThat(urls[i]).isEqualTo(proxy + "https://github.com/oct/x/releases/download/v1/a.zip")
+        }
+        assertThat(urls.last()).isEqualTo("https://github.com/oct/x/releases/download/v1/a.zip")
+    }
+
+    @Test
+    fun `proxiedCn passes non-github urls through untouched`() {
+        assertThat(GitHubMirror.proxiedCn("https://wordpress.org/latest.tar.gz"))
+            .containsExactly("https://wordpress.org/latest.tar.gz")
+    }
+
+    @Test
+    fun `npmTarballUrls prefers npmmirror only in cn region`() {
+        val url = "https://registry.npmjs.org/npm/-/npm-10.9.0.tgz"
+        assertThat(GitHubMirror.npmTarballUrls(url, cn = true)).containsExactly(
+            "https://registry.npmmirror.com/npm/-/npm-10.9.0.tgz",
+            url
+        ).inOrder()
+        assertThat(GitHubMirror.npmTarballUrls(url, cn = false)).containsExactly(url)
+    }
+
+    @Test
+    fun `npmTarballUrls leaves foreign hosts alone`() {
+        assertThat(GitHubMirror.npmTarballUrls("https://example.com/x.tgz", cn = true))
+            .containsExactly("https://example.com/x.tgz")
+    }
+}


### PR DESCRIPTION
Fixes #594

## What

Large runtime downloads (Node ~80MB zip, Python, PHP/WordPress, Go toolchain) stuck to slow sources forever, and half the toolchain never used mirrors at all. Four fixes, one PR:

| Problem | Fix |
|---|---|
| Slow proxy never abandoned (KB/s crawl, no error → no switch) | Watchdog cancels under 64 KB/s sustained; SLOW outcome switches source **resuming from the stalled offset** |
| Probe ranked by HEAD RTT on a README | 256 KB Range GET on a real GitHub release asset — proxies ranked by measured bandwidth |
| 4 copies of proxy lists; composer + npm tarballs + `npm install` all direct-only | Single `GitHubMirror` helper; composer gains proxies; npm/pnpm/yarn tarballs + `npm_config_registry` ride npmmirror in CN region |
| Truncated/error-page responses pass silently | Post-download Content-Length verification + gzip magic check |

## How

**Engine** (`DependencyDownloadEngine`): `downloadFileEx` returns `SUCCESS/FAILED/SLOW`. A daemon watchdog polls the concurrent-deque SpeedTracker; sustained speed under 64 KB/s after a 15 s grace (and past a 1 MB floor, only for files > 2 MB) cancels the OkHttp call. `downloadFileWithFallback` is now the single retry/switch loop for all callers:
- `SLOW` → next source immediately, `.tmp` kept → next mirror sends `Range` from the stalled byte; on the last source it retries (each resume makes forward progress)
- `FAILED` → 2 retries, then `.tmp` dropped, next source clean

**Probe** (`CnMirrorProbe`): bandwidth-measured ordering replaces RTT ordering.

**Mirrors** (`GitHubMirror`): `proxiedCn(url)` = bandwidth-ordered proxies + direct fallback (non-GitHub URLs pass through); `npmTarballUrls(url, cn)` = npmmirror first. Node/Python/PHP/WordPress managers drop their duplicated lists and loops; Go's USTC list rides the same fallback entry.

**npm ecosystem** (`LocalBuildEnvironment`): tool tarballs validated by gzip magic before extraction; `executeNode` injects `npm_config_registry` in CN region unless the project `.npmrc`, the managed userconfig, or the caller env already pins a registry. Dead `NODE_DOWNLOAD_URLS` map in `NativeNodeEngine` removed.

Region detection honors the existing mirror-region user setting everywhere (RuntimeDepsScreen / WordPress settings). No new i18n strings, no config fields, no behavior change for GLOBAL-region users.

## Validation

- New `DownloadFallbackPolicyTest` (SLOW keeps tmp + switches; FAILED retries then drops tmp; last-source SLOW retries exhaust; happy path) — 4/4
- New `GitHubMirrorTest` (proxy expansion + fallback, pass-through, npmmirror CN-only) — 4/4
- Regression across download/linux/network/nodejs/python/wordpress/golang suites: **111/111 green**
- Shell sync verified for all runtime-synced touched files; `:shell:assembleRelease` + `:app:syncShellTemplateApk` green