### PR TITLE
fix(media): interpolate lock-screen progress and add GeckoView media session

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/BrowserSurface.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/BrowserSurface.kt
@@ -9,7 +9,7 @@ import android.webkit.WebView
 class BrowserSurface private constructor(
     val view: View,
     val webView: WebView?,
-    private val engine: BrowserEngine?
+    val engine: BrowserEngine?
 ) {
     val isGecko: Boolean
         get() = engine != null

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoMediaSessionAdapter.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoMediaSessionAdapter.kt
@@ -1,0 +1,162 @@
+package com.webtoapp.core.engine
+
+import android.app.Activity
+import android.media.session.PlaybackState
+import com.webtoapp.core.logging.AppLogger
+import com.webtoapp.core.webview.MediaSessionCore
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.MediaSession as GeckoMediaSession
+
+/**
+ * Feeds GeckoView's native Web Media Session events into the shared
+ * [MediaSessionCore] and routes native media commands back to the page (#593).
+ *
+ * GeckoView implements the web Media Session API itself (no JS polyfill
+ * needed, no frame arbitration — the engine reports the page-level session),
+ * so this adapter is a pure event/command translation: onPlay/onPause/onStop
+ * map to native playback states, `Metadata`/`PositionState` map to core
+ * metadata/position (which interpolates progress between position reports),
+ * `Feature` flags gate optional actions, and commands map to
+ * [GeckoMediaSession] controller calls.
+ */
+class GeckoMediaSessionAdapter(
+    activity: Activity,
+    private val engine: GeckoViewEngine
+) {
+
+    private val core = MediaSessionCore(activity, ::dispatchCommand)
+
+    /** Controller handle from delegate callbacks; null while inactive. */
+    private var controller: GeckoMediaSession? = null
+
+    private val delegate = object : GeckoMediaSession.Delegate {
+        override fun onActivated(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession
+        ) {
+            controller = mediaSession
+        }
+
+        override fun onDeactivated(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession
+        ) {
+            controller = null
+            core.clearPlayback()
+        }
+
+        override fun onMetadata(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession,
+            meta: GeckoMediaSession.Metadata
+        ) {
+            controller = mediaSession
+            core.updateMetadata(meta.title, meta.artist, meta.album, "")
+
+            // Image.getBitmap decodes asynchronously off the main thread.
+            meta.artwork?.getBitmap(ARTWORK_SIZE)?.accept(
+                { bitmap -> core.updateArtwork(bitmap) },
+                { error ->
+                    AppLogger.w(
+                        TAG,
+                        "media session artwork decode failed: ${error?.message}"
+                    )
+                    core.updateArtwork(null)
+                }
+            )
+        }
+
+        override fun onFeatures(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession,
+            features: Long
+        ) {
+            controller = mediaSession
+            core.setActionSupported(
+                "previoustrack",
+                features and GeckoMediaSession.Feature.PREVIOUS_TRACK != 0L
+            )
+            core.setActionSupported(
+                "nexttrack",
+                features and GeckoMediaSession.Feature.NEXT_TRACK != 0L
+            )
+            core.setActionSupported(
+                "seekbackward",
+                features and GeckoMediaSession.Feature.SEEK_BACKWARD != 0L
+            )
+            core.setActionSupported(
+                "seekforward",
+                features and GeckoMediaSession.Feature.SEEK_FORWARD != 0L
+            )
+        }
+
+        override fun onPlay(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession
+        ) {
+            controller = mediaSession
+            core.updatePlaybackState(PlaybackState.STATE_PLAYING)
+        }
+
+        override fun onPause(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession
+        ) {
+            controller = mediaSession
+            core.updatePlaybackState(PlaybackState.STATE_PAUSED)
+        }
+
+        override fun onStop(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession
+        ) {
+            controller = mediaSession
+            core.updatePlaybackState(PlaybackState.STATE_NONE)
+        }
+
+        override fun onPositionState(
+            session: GeckoSession,
+            mediaSession: GeckoMediaSession,
+            positionState: GeckoMediaSession.PositionState
+        ) {
+            controller = mediaSession
+            core.updatePosition(
+                positionState.duration,
+                positionState.position,
+                positionState.playbackRate
+            )
+        }
+    }
+
+    init {
+        engine.setMediaSessionDelegate(delegate)
+        AppLogger.i(TAG, "Gecko media session adapter attached")
+    }
+
+    fun release() {
+        engine.setMediaSessionDelegate(null)
+        core.release()
+        controller = null
+    }
+
+    private fun dispatchCommand(command: String, value: Double) {
+        val target = controller ?: return
+        when (command) {
+            "play" -> target.play()
+            "pause" -> target.pause()
+            "stop" -> target.stop()
+            "seekto" -> target.seekTo(value, false)
+            "previoustrack" -> target.previousTrack()
+            "nexttrack" -> target.nextTrack()
+            "seekbackward" -> target.seekBackward()
+            "seekforward" -> target.seekForward()
+        }
+    }
+
+    private companion object {
+        const val TAG = "GeckoMediaSession"
+
+        /** Lock-screen artwork target; SystemUI scales as needed. */
+        const val ARTWORK_SIZE = 512
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/GeckoViewEngine.kt
@@ -19,6 +19,7 @@ import org.mozilla.geckoview.GeckoView
 import org.mozilla.geckoview.StorageController
 import org.mozilla.geckoview.WebResponse
 import org.mozilla.geckoview.WebExtension
+import org.mozilla.geckoview.MediaSession as GeckoMediaSession
 
 data class ProxyConfig(
     val mode: String = "NONE",
@@ -394,6 +395,13 @@ class GeckoViewEngine(
     private var geckoView: GeckoView? = null
     private var session: GeckoSession? = null
     private var callback: BrowserEngineCallback? = null
+
+    /**
+     * Media session delegate to re-attach on every session (re)creation —
+     * GeckoView rebuilds sessions per createView, so a delegate installed
+     * once would be lost (#593).
+     */
+    private var mediaSessionDelegate: GeckoMediaSession.Delegate? = null
     private var currentUrl: String? = null
     private var currentTitle: String? = null
     private var canGoBackFlag = false
@@ -482,6 +490,16 @@ class GeckoViewEngine(
         return view
     }
 
+    /**
+     * Installs a media session delegate on the current session and every
+     * future (re)created one; pass null to detach. Callers own the delegate's
+     * lifecycle (see GeckoMediaSessionAdapter).
+     */
+    fun setMediaSessionDelegate(delegate: GeckoMediaSession.Delegate?) {
+        mediaSessionDelegate = delegate
+        session?.mediaSessionDelegate = delegate
+    }
+
     private fun setupDelegates(
         session: GeckoSession,
         callback: BrowserEngineCallback,
@@ -493,6 +511,7 @@ class GeckoViewEngine(
         setupProgressDelegate(session, callback)
         setupPermissionDelegate(session)
         setupPromptDelegate(session, callback, viewContext, config)
+        mediaSessionDelegate?.let { session.mediaSessionDelegate = it }
     }
 
     private fun setupContentDelegate(session: GeckoSession, callback: BrowserEngineCallback) {

--- a/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MediaSessionBridge.kt
@@ -1,74 +1,42 @@
 package com.webtoapp.core.webview
 
 import android.app.Activity
-import android.app.Notification
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.content.Context
-import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.media.MediaMetadata
-import android.media.session.MediaSession
 import android.media.session.PlaybackState
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
-import android.support.v4.media.session.MediaSessionCompat
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
-import androidx.core.app.NotificationCompat
-import androidx.media.app.NotificationCompat.MediaStyle
-import com.webtoapp.core.logging.AppLogger
 import org.json.JSONObject
-import java.lang.ref.WeakReference
-import java.net.HttpURLConnection
-import java.net.URL
-import java.util.concurrent.Executors
-import kotlin.math.abs
 
 /**
  * Bridges the web [Media Session API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API)
- * (`navigator.mediaSession`) to a native Android [MediaSession].
+ * (`navigator.mediaSession`) of an Android [WebView] to a native media
+ * session owned by [MediaSessionCore].
  *
- * Audio is NOT transferred — it keeps playing inside the WebView. This bridge only
- * carries metadata, position and control commands between the page and the system
- * media controls (notification, lock screen, Bluetooth, Android Auto), backed by
- * [WebMediaPlaybackService] for background playback and wake lock.
+ * Audio is NOT transferred — it keeps playing inside the WebView. This bridge
+ * only carries metadata, position and control commands between the page and
+ * the system media controls (notification, lock screen, Bluetooth, Android
+ * Auto), backed by [WebMediaPlaybackService] for background playback and
+ * wake lock.
  *
  * The bridge constructor already registers the `WtaMediaSession` JavaScript
  * interface; callers only need to install [INJECTION_SCRIPT] at document start
- * (plus [injectNow] from `onPageFinished` as a fallback).
+ * (plus [injectNow] from `onPageFinished` as a fallback). Frame arbitration
+ * (#566) lives here; the native session state machine (position interpolation,
+ * teardown, notification) lives in the engine-agnostic core (#593).
  */
 class MediaSessionBridge(
-    private val activity: Activity,
+    activity: Activity,
     private val webView: WebView
 ) {
 
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val artworkExecutor = Executors.newSingleThreadExecutor()
 
-    private val notificationManager =
-        activity.getSystemService(NotificationManager::class.java)
-
-    private val mediaSession = MediaSession(
+    private val core = MediaSessionCore(
         activity,
-        "WebToAppMediaSession"
+        ::dispatchCommand
     )
-
-    private var title = ""
-    private var artist = ""
-    private var album = ""
-    private var artworkUrl = ""
-
-    private var artworkBitmap: Bitmap? = null
-    private var loadedArtworkUrl = ""
-
-    private var durationSeconds = 0.0
-    private var positionSeconds = 0.0
-    private var playbackRate = 1.0f
-
-    private var playbackState = PlaybackState.STATE_NONE
 
     /**
      * Identity of the frame that currently owns the session. The injected script
@@ -81,75 +49,10 @@ class MediaSessionBridge(
     private var activeFrameId: String? = null
     private var activeFrameLastSeenMs = 0L
 
-    /**
-     * `true` once any non-`none` playback state has ever been reported. Used to
-     * guard [clearPlayback] so the initial `STATE_NONE` event (emitted during
-     * page load before any media exists) does not run full media-session
-     * teardown — which would otherwise stop the playback service on every cold
-     * start.
-     */
-    private var hasActivePlaybackSession = false
-
-    private var teardownRunnable: Runnable? = null
-
-    private val supportedActions = mutableSetOf<String>()
-
-    @Volatile
-    private var lastNotification: Notification? = null
-
     init {
-        activeBridge = WeakReference(this)
-
         webView.addJavascriptInterface(
             this,
             JAVASCRIPT_INTERFACE_NAME
-        )
-
-        createLaunchPendingIntent()?.let { pendingIntent ->
-            /*
-             * Opens or returns to the app when the user taps the
-             * notification, lock-screen media card, or system media player.
-             */
-            mediaSession.setSessionActivity(pendingIntent)
-        }
-
-        mediaSession.setCallback(
-            object : MediaSession.Callback() {
-                override fun onPlay() {
-                    dispatchCommand("play")
-                }
-
-                override fun onPause() {
-                    dispatchCommand("pause")
-                }
-
-                override fun onStop() {
-                    dispatchCommand("stop")
-                }
-
-                override fun onSeekTo(position: Long) {
-                    dispatchCommand(
-                        "seekto",
-                        position.toDouble() / 1000.0
-                    )
-                }
-
-                override fun onSkipToPrevious() {
-                    dispatchCommand("previoustrack")
-                }
-
-                override fun onSkipToNext() {
-                    dispatchCommand("nexttrack")
-                }
-
-                override fun onRewind() {
-                    dispatchCommand("seekbackward", 10.0)
-                }
-
-                override fun onFastForward() {
-                    dispatchCommand("seekforward", 10.0)
-                }
-            }
         )
     }
 
@@ -178,41 +81,7 @@ class MediaSessionBridge(
                 return@post
             }
 
-            val incomingBlank =
-                newTitle.isNullOrBlank() &&
-                    newArtist.isNullOrBlank() &&
-                    newAlbum.isNullOrBlank() &&
-                    newArtworkUrl.isNullOrBlank()
-
-            val currentBlank =
-                title.isBlank() &&
-                    artist.isBlank() &&
-                    album.isBlank() &&
-                    artworkUrl.isBlank()
-
-            /*
-             * A frame without media metadata used to send ("", "", "", "")
-             * every second, wiping real track info and falling back to the
-             * app label. Empty payloads never replace known metadata.
-             */
-            if (incomingBlank && !currentBlank) {
-                return@post
-            }
-
-            cancelTeardown()
-
-            title = newTitle.orEmpty()
-            artist = newArtist.orEmpty()
-            album = newAlbum.orEmpty()
-
-            val normalizedArtwork = newArtworkUrl.orEmpty()
-
-            if (artworkUrl != normalizedArtwork) {
-                artworkUrl = normalizedArtwork
-                loadArtwork(normalizedArtwork)
-            }
-
-            publish()
+            core.updateMetadata(newTitle, newArtist, newAlbum, newArtworkUrl)
         }
     }
 
@@ -249,13 +118,7 @@ class MediaSessionBridge(
                 return@post
             }
 
-            playbackState = resolved
-
-            if (resolved != PlaybackState.STATE_NONE) {
-                cancelTeardown()
-            }
-
-            publish()
+            core.updatePlaybackState(resolved)
         }
     }
 
@@ -275,32 +138,7 @@ class MediaSessionBridge(
                 activeFrameLastSeenMs = SystemClock.elapsedRealtime()
             }
 
-            val durationChanged =
-                abs(durationSeconds - duration) >= 0.5
-
-            durationSeconds =
-                duration.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
-
-            positionSeconds =
-                position.takeIf { it.isFinite() && it >= 0.0 } ?: 0.0
-
-            playbackRate =
-                rate.takeIf { it.isFinite() && it > 0.0 }
-                    ?.toFloat()
-                    ?: 1.0f
-
-            /*
-             * Playback state must be updated regularly for progress tracking.
-             * Metadata is also republished when duration changes so the
-             * duration is never stuck at 0 when metadata arrived first.
-             */
-            applyPlaybackState()
-
-            if (durationChanged) {
-                applyMetadata()
-            }
-
-            updateNotification()
+            core.updatePosition(duration, position, rate)
         }
     }
 
@@ -309,26 +147,10 @@ class MediaSessionBridge(
         action: String?,
         supported: Boolean
     ) {
-        if (action.isNullOrBlank()) {
-            return
-        }
-
-        mainHandler.post {
-            if (supported) {
-                supportedActions.add(action)
-            } else {
-                supportedActions.remove(action)
-            }
-
-            /*
-             * Apply immediately instead of waiting for another playback event.
-             */
-            applyPlaybackState()
-            updateNotification()
-        }
+        core.setActionSupported(action, supported)
     }
 
-    // ---- State publishing ----
+    // ---- Frame arbitration ----
 
     /**
      * A frame owns its updates while it is the active frame and has reported
@@ -341,290 +163,11 @@ class MediaSessionBridge(
         return SystemClock.elapsedRealtime() - activeFrameLastSeenMs > FRAME_TAKEOVER_MS
     }
 
-    private fun cancelTeardown() {
-        teardownRunnable?.let { runnable ->
-            mainHandler.removeCallbacks(runnable)
-        }
-        teardownRunnable = null
-    }
-
-    private fun scheduleTeardown() {
-        cancelTeardown()
-
-        val runnable = Runnable {
-            teardownRunnable = null
-
-            if (playbackState == PlaybackState.STATE_NONE &&
-                (
-                    hasActivePlaybackSession ||
-                        mediaSession.isActive ||
-                        lastNotification != null
-                    )
-            ) {
-                clearPlayback()
-            }
-        }
-
-        teardownRunnable = runnable
-        mainHandler.postDelayed(runnable, TEARDOWN_GRACE_MS)
-    }
-
-    private fun publish() {
-        if (playbackState == PlaybackState.STATE_NONE) {
-            /*
-             * "none" arrives from any frame whose media ended (or that never
-             * had any). Tearing down immediately let one ended ad element kill
-             * a session another frame was still playing (#566); wait out the
-             * grace period and cancel if anything reports activity again.
-             */
-            if (hasActivePlaybackSession || mediaSession.isActive || lastNotification != null) {
-                scheduleTeardown()
-            }
-            return
-        }
-
-        cancelTeardown()
-
-        hasActivePlaybackSession = true
-
-        applyMetadata()
-        applyPlaybackState()
-
-        mediaSession.isActive = true
-
-        updateNotification()
-
-        WebMediaPlaybackService.synchronize(
-            activity.applicationContext,
-            playbackState == PlaybackState.STATE_PLAYING
-        )
-    }
-
-    private fun applyMetadata() {
-        val metadata = MediaMetadata.Builder()
-            .putString(
-                MediaMetadata.METADATA_KEY_TITLE,
-                title.ifBlank { appLabel() }
-            )
-            .putString(
-                MediaMetadata.METADATA_KEY_ARTIST,
-                artist
-            )
-            .putString(
-                MediaMetadata.METADATA_KEY_ALBUM,
-                album
-            )
-            .putLong(
-                MediaMetadata.METADATA_KEY_DURATION,
-                (durationSeconds * 1000.0).toLong()
-            )
-
-        artworkBitmap?.let { bitmap ->
-            metadata.putBitmap(
-                MediaMetadata.METADATA_KEY_ART,
-                bitmap
-            )
-
-            metadata.putBitmap(
-                MediaMetadata.METADATA_KEY_ALBUM_ART,
-                bitmap
-            )
-
-            metadata.putBitmap(
-                MediaMetadata.METADATA_KEY_DISPLAY_ICON,
-                bitmap
-            )
-        }
-
-        mediaSession.setMetadata(metadata.build())
-    }
-
-    private fun applyPlaybackState() {
-        var actions =
-            PlaybackState.ACTION_PLAY or
-                PlaybackState.ACTION_PAUSE or
-                PlaybackState.ACTION_PLAY_PAUSE or
-                PlaybackState.ACTION_STOP or
-                PlaybackState.ACTION_SEEK_TO
-
-        if ("previoustrack" in supportedActions) {
-            actions = actions or PlaybackState.ACTION_SKIP_TO_PREVIOUS
-        }
-
-        if ("nexttrack" in supportedActions) {
-            actions = actions or PlaybackState.ACTION_SKIP_TO_NEXT
-        }
-
-        if ("seekbackward" in supportedActions) {
-            actions = actions or PlaybackState.ACTION_REWIND
-        }
-
-        if ("seekforward" in supportedActions) {
-            actions = actions or PlaybackState.ACTION_FAST_FORWARD
-        }
-
-        val state = PlaybackState.Builder()
-            .setActions(actions)
-            .setState(
-                playbackState,
-                (positionSeconds * 1000.0).toLong(),
-                playbackRate
-            )
-            .build()
-
-        mediaSession.setPlaybackState(state)
-    }
-
-    // ---- Notification ----
-
-    private fun updateNotification() {
-        if (playbackState == PlaybackState.STATE_NONE) {
-            notificationManager.cancel(
-                WebMediaPlaybackService.NOTIFICATION_ID
-            )
-
-            lastNotification = null
-            return
-        }
-
-        val notification = buildNotification()
-
-        lastNotification = notification
-
-        notificationManager.notify(
-            WebMediaPlaybackService.NOTIFICATION_ID,
-            notification
-        )
-    }
-
-    private fun buildNotification(): Notification {
-        val builder = NotificationCompat.Builder(
-            activity,
-            WebMediaPlaybackService.CHANNEL_ID
-        )
-            .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle(title.ifBlank { appLabel() })
-            .setContentText(
-                artist.ifBlank {
-                    album.ifBlank { "Media playback" }
-                }
-            )
-            .setSubText(album.takeIf { it.isNotBlank() })
-            .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setOnlyAlertOnce(true)
-            .setOngoing(
-                playbackState == PlaybackState.STATE_PLAYING
-            )
-            .setContentIntent(createLaunchPendingIntent())
-            .setDeleteIntent(
-                WebMediaPlaybackService.commandPendingIntent(
-                    activity,
-                    "stop"
-                )
-            )
-
-        artworkBitmap?.let(builder::setLargeIcon)
-
-        val compactActionIndexes = mutableListOf<Int>()
-        var actionIndex = 0
-
-        if ("previoustrack" in supportedActions) {
-            builder.addAction(
-                android.R.drawable.ic_media_previous,
-                "Previous",
-                WebMediaPlaybackService.commandPendingIntent(
-                    activity,
-                    "previoustrack"
-                )
-            )
-
-            compactActionIndexes.add(actionIndex)
-            actionIndex++
-        }
-
-        val isPlaying =
-            playbackState == PlaybackState.STATE_PLAYING
-
-        builder.addAction(
-            if (isPlaying) {
-                android.R.drawable.ic_media_pause
-            } else {
-                android.R.drawable.ic_media_play
-            },
-            if (isPlaying) "Pause" else "Play",
-            WebMediaPlaybackService.commandPendingIntent(
-                activity,
-                if (isPlaying) "pause" else "play"
-            )
-        )
-
-        compactActionIndexes.add(actionIndex)
-        actionIndex++
-
-        if ("nexttrack" in supportedActions) {
-            builder.addAction(
-                android.R.drawable.ic_media_next,
-                "Next",
-                WebMediaPlaybackService.commandPendingIntent(
-                    activity,
-                    "nexttrack"
-                )
-            )
-
-            compactActionIndexes.add(actionIndex)
-        }
-
-        val mediaStyle = MediaStyle()
-            .setMediaSession(
-                MediaSessionCompat.Token.fromToken(mediaSession.sessionToken)
-            )
-            .setShowCancelButton(true)
-            .setCancelButtonIntent(
-                WebMediaPlaybackService.commandPendingIntent(
-                    activity,
-                    "stop"
-                )
-            )
-
-        if (compactActionIndexes.isNotEmpty()) {
-            mediaStyle.setShowActionsInCompactView(
-                *compactActionIndexes
-                    .take(3)
-                    .toIntArray()
-            )
-        }
-
-        builder.setStyle(mediaStyle)
-
-        return builder.build()
-    }
-
-    private fun createLaunchPendingIntent(): PendingIntent? {
-        val launchIntent =
-            activity.packageManager.getLaunchIntentForPackage(
-                activity.packageName
-            ) ?: return null
-
-        launchIntent.addFlags(
-            Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                Intent.FLAG_ACTIVITY_CLEAR_TOP
-        )
-
-        return PendingIntent.getActivity(
-            activity,
-            3101,
-            launchIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or
-                PendingIntent.FLAG_IMMUTABLE
-        )
-    }
-
     // ---- Android → JS commands ----
 
     private fun dispatchCommand(
         command: String,
-        value: Double = 0.0
+        value: Double
     ) {
         val escapedCommand = JSONObject.quote(command)
 
@@ -638,107 +181,8 @@ class MediaSessionBridge(
         }
     }
 
-    // ---- Artwork ----
-
-    private fun loadArtwork(url: String) {
-        if (url.isBlank()) {
-            artworkBitmap = null
-            loadedArtworkUrl = ""
-            publish()
-            return
-        }
-
-        if (url == loadedArtworkUrl && artworkBitmap != null) {
-            return
-        }
-
-        artworkExecutor.execute {
-            val bitmap = downloadBitmap(url)
-
-            mainHandler.post {
-                /*
-                 * Ignore an old request when the website changed tracks while
-                 * the image was still downloading.
-                 */
-                if (artworkUrl != url) {
-                    return@post
-                }
-
-                artworkBitmap = bitmap
-                loadedArtworkUrl = url
-
-                if (playbackState != PlaybackState.STATE_NONE) {
-                    applyMetadata()
-                    updateNotification()
-                }
-            }
-        }
-    }
-
-    private fun downloadBitmap(url: String): Bitmap? {
-        return try {
-            val connection = URL(url).openConnection()
-                as HttpURLConnection
-
-            connection.connectTimeout = 8_000
-            connection.readTimeout = 8_000
-            connection.instanceFollowRedirects = true
-            connection.doInput = true
-            connection.connect()
-
-            connection.inputStream.use {
-                BitmapFactory.decodeStream(it)
-            }.also {
-                connection.disconnect()
-            }
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    private fun appLabel(): String {
-        return activity.applicationInfo
-            .loadLabel(activity.packageManager)
-            .toString()
-    }
-
-    private fun clearPlayback() {
-        cancelTeardown()
-
-        hasActivePlaybackSession = false
-
-        activeFrameId = null
-        activeFrameLastSeenMs = 0L
-
-        playbackState = PlaybackState.STATE_NONE
-        positionSeconds = 0.0
-        durationSeconds = 0.0
-
-        mediaSession.setPlaybackState(
-            PlaybackState.Builder()
-                .setState(
-                    PlaybackState.STATE_NONE,
-                    0L,
-                    1.0f
-                )
-                .build()
-        )
-
-        mediaSession.isActive = false
-
-        notificationManager.cancel(
-            WebMediaPlaybackService.NOTIFICATION_ID
-        )
-
-        lastNotification = null
-
-        WebMediaPlaybackService.stop(
-            activity.applicationContext
-        )
-    }
-
     fun release() {
-        clearPlayback()
+        core.release()
 
         try {
             webView.removeJavascriptInterface(
@@ -746,13 +190,6 @@ class MediaSessionBridge(
             )
         } catch (_: Exception) {
             // WebView may already be destroyed.
-        }
-
-        artworkExecutor.shutdownNow()
-        mediaSession.release()
-
-        if (activeBridge?.get() === this) {
-            activeBridge = null
         }
     }
 
@@ -762,31 +199,9 @@ class MediaSessionBridge(
 
         /**
          * How long the active frame's reports stay authoritative after the
-         * last one, and how long a `none` report must survive before the
-         * session is torn down.
+         * last one.
          */
         private const val FRAME_TAKEOVER_MS = 3_000L
-        private const val TEARDOWN_GRACE_MS = 2_500L
-
-        @Volatile
-        private var activeBridge:
-            WeakReference<MediaSessionBridge>? = null
-
-        internal fun dispatchFromService(
-            command: String,
-            value: Double
-        ) {
-            activeBridge?.get()?.dispatchCommand(
-                command,
-                value
-            )
-        }
-
-        internal fun getForegroundNotification(
-            context: Context
-        ): Notification? {
-            return activeBridge?.get()?.lastNotification
-        }
 
         /** The document-start JS polyfill that hooks navigator.mediaSession. */
         fun getInjectionScript(): String = INJECTION_SCRIPT
@@ -1369,7 +784,9 @@ class MediaSessionBridge(
 
               /*
                * A one-second heartbeat keeps lock-screen progress accurate and
-               * detects metadata changes made by the website.
+               * detects metadata changes made by the website. The native core
+               * deduplicates unchanged state reports and interpolates position
+               * between them (#593).
                */
               window.__wtaMediaHeartbeat =
                 window.setInterval(

--- a/app/src/main/java/com/webtoapp/core/webview/MediaSessionCore.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/MediaSessionCore.kt
@@ -1,0 +1,743 @@
+package com.webtoapp.core.webview
+
+import android.app.Activity
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.media.MediaMetadata
+import android.media.session.MediaSession
+import android.media.session.PlaybackState
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.support.v4.media.session.MediaSessionCompat
+import androidx.core.app.NotificationCompat
+import androidx.media.app.NotificationCompat.MediaStyle
+import java.lang.ref.WeakReference
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.Executors
+
+/**
+ * Engine-agnostic native [MediaSession] state machine shared by the WebView
+ * bridge (JS polyfill, [MediaSessionBridge]) and the GeckoView adapter
+ * (Gecko's own media session events).
+ *
+ * Position continuity (#593): SystemUI interpolates progress from the last
+ * `setState(position, speed)` anchor, but pages that manage position via
+ * `setPositionState()` only report on play/pause/seek — never per second.
+ * The core therefore anchors every reported position with
+ * [lastPositionUpdateMs] and re-publishes *interpolated* positions while
+ * playing, so heartbeat republishes can never drag the bar backwards, and
+ * identical state reports are deduplicated instead of re-anchoring the
+ * SystemUI baseline to a stale position.
+ */
+class MediaSessionCore(
+    private val activity: Activity,
+    private val onCommand: (command: String, value: Double) -> Unit
+) {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val artworkExecutor = Executors.newSingleThreadExecutor()
+
+    private val notificationManager =
+        activity.getSystemService(NotificationManager::class.java)
+
+    private val mediaSession = MediaSession(
+        activity,
+        "WebToAppMediaSession"
+    )
+
+    private var title = ""
+    private var artist = ""
+    private var album = ""
+    private var artworkUrl = ""
+
+    private var artworkBitmap: Bitmap? = null
+    private var loadedArtworkUrl = ""
+
+    private var durationSeconds = 0.0
+    private var positionSeconds = 0.0
+    private var playbackRate = 1.0f
+
+    /** elapsedRealtime anchor of [positionSeconds]; 0 while unknown. */
+    private var lastPositionUpdateMs = 0L
+
+    private var playbackState = PlaybackState.STATE_NONE
+
+    /**
+     * `true` once any non-`none` playback state has ever been reported. Used to
+     * guard [clearPlayback] so the initial `STATE_NONE` event (emitted during
+     * page load before any media exists) does not run full media-session
+     * teardown — which would otherwise stop the playback service on every cold
+     * start.
+     */
+    private var hasActivePlaybackSession = false
+
+    private var teardownRunnable: Runnable? = null
+
+    private val supportedActions = mutableSetOf<String>()
+
+    /** Number of native setPlaybackState() publishes; test hook for dedup. */
+    internal var playbackStatePublishCount = 0
+        private set
+
+    @Volatile
+    private var lastNotification: Notification? = null
+
+    init {
+        activeCore = WeakReference(this)
+
+        createLaunchPendingIntent()?.let { pendingIntent ->
+            /*
+             * Opens or returns to the app when the user taps the
+             * notification, lock-screen media card, or system media player.
+             */
+            mediaSession.setSessionActivity(pendingIntent)
+        }
+
+        mediaSession.setCallback(
+            object : MediaSession.Callback() {
+                override fun onPlay() {
+                    onCommand("play", 0.0)
+                }
+
+                override fun onPause() {
+                    onCommand("pause", 0.0)
+                }
+
+                override fun onStop() {
+                    onCommand("stop", 0.0)
+                }
+
+                override fun onSeekTo(position: Long) {
+                    onCommand(
+                        "seekto",
+                        position.toDouble() / 1000.0
+                    )
+                }
+
+                override fun onSkipToPrevious() {
+                    onCommand("previoustrack", 0.0)
+                }
+
+                override fun onSkipToNext() {
+                    onCommand("nexttrack", 0.0)
+                }
+
+                override fun onRewind() {
+                    onCommand("seekbackward", 10.0)
+                }
+
+                override fun onFastForward() {
+                    onCommand("seekforward", 10.0)
+                }
+            }
+        )
+    }
+
+    // ---- State intake (all posts land on the main thread) ----
+
+    fun updateMetadata(
+        newTitle: String?,
+        newArtist: String?,
+        newAlbum: String?,
+        newArtworkUrl: String?
+    ) {
+        mainHandler.post {
+            val incomingBlank =
+                newTitle.isNullOrBlank() &&
+                    newArtist.isNullOrBlank() &&
+                    newAlbum.isNullOrBlank() &&
+                    newArtworkUrl.isNullOrBlank()
+
+            val currentBlank =
+                title.isBlank() &&
+                    artist.isBlank() &&
+                    album.isBlank() &&
+                    artworkUrl.isBlank()
+
+            /*
+             * A frame without media metadata used to send ("", "", "", "")
+             * every second, wiping real track info and falling back to the
+             * app label. Empty payloads never replace known metadata.
+             */
+            if (incomingBlank && !currentBlank) {
+                return@post
+            }
+
+            cancelTeardown()
+
+            title = newTitle.orEmpty()
+            artist = newArtist.orEmpty()
+            album = newAlbum.orEmpty()
+
+            val normalizedArtwork = newArtworkUrl.orEmpty()
+
+            if (artworkUrl != normalizedArtwork) {
+                artworkUrl = normalizedArtwork
+                loadArtwork(normalizedArtwork)
+            }
+
+            publish()
+        }
+    }
+
+    fun updatePlaybackState(state: Int) {
+        mainHandler.post { applyPlaybackStateEvent(state) }
+    }
+
+    fun updatePosition(
+        duration: Double,
+        position: Double,
+        rate: Double
+    ) {
+        mainHandler.post {
+            val durationChanged =
+                kotlin.math.abs(durationSeconds - duration) >= 0.5
+
+            durationSeconds =
+                duration.takeIf { it.isFinite() && it > 0.0 } ?: 0.0
+
+            positionSeconds =
+                position.takeIf { it.isFinite() && it >= 0.0 } ?: 0.0
+
+            playbackRate =
+                rate.takeIf { it.isFinite() && it > 0.0 }
+                    ?.toFloat()
+                    ?: 1.0f
+
+            /*
+             * Every authoritative position report re-anchors the
+             * interpolation baseline; applyPlaybackState() then publishes the
+             * position computed from this anchor (identical to the report
+             * itself at this instant).
+             */
+            lastPositionUpdateMs = SystemClock.elapsedRealtime()
+
+            applyPlaybackState()
+
+            if (durationChanged) {
+                applyMetadata()
+            }
+        }
+    }
+
+    fun setActionSupported(
+        action: String?,
+        supported: Boolean
+    ) {
+        if (action.isNullOrBlank()) {
+            return
+        }
+
+        mainHandler.post {
+            if (supported) {
+                supportedActions.add(action)
+            } else {
+                supportedActions.remove(action)
+            }
+
+            /*
+             * Apply immediately instead of waiting for another playback event.
+             */
+            applyPlaybackState()
+            updateNotification()
+        }
+    }
+
+    /**
+     * Engine-provided artwork (GeckoView decodes its `Image` itself). URL
+     * bookkeeping is cleared so a later URL-based load is not mistaken for
+     * "already loaded".
+     */
+    fun updateArtwork(bitmap: Bitmap?) {
+        mainHandler.post {
+            artworkBitmap = bitmap
+            loadedArtworkUrl = ""
+
+            if (playbackState != PlaybackState.STATE_NONE) {
+                applyMetadata()
+                updateNotification()
+            }
+        }
+    }
+
+    // ---- State machine ----
+
+    /**
+     * Position as of [nowMs], advanced by wall time × rate while playing and
+     * clamped to a known duration. This is what every native publish uses, so
+     * a heartbeat re-publish never drags the SystemUI bar backwards (#593).
+     */
+    internal fun interpolatedPositionSeconds(
+        nowMs: Long = SystemClock.elapsedRealtime()
+    ): Double {
+        if (playbackState != PlaybackState.STATE_PLAYING ||
+            lastPositionUpdateMs <= 0L
+        ) {
+            return positionSeconds
+        }
+
+        val elapsedSeconds =
+            ((nowMs - lastPositionUpdateMs).coerceAtLeast(0L)) / 1000.0
+
+        val advanced = positionSeconds + elapsedSeconds * playbackRate
+
+        return if (durationSeconds > 0.0) {
+            kotlin.math.min(advanced, durationSeconds)
+        } else {
+            advanced
+        }
+    }
+
+    private fun applyPlaybackStateEvent(state: Int) {
+        /*
+         * Dedup: engines report state repeatedly (the WebView heartbeat sends
+         * "playing" once per second; Gecko re-fires on activity). Republishing
+         * an unchanged state would re-anchor SystemUI's interpolation to a
+         * stale position and visibly freeze the progress bar (#593).
+         */
+        if (state == playbackState) {
+            return
+        }
+
+        if (playbackState == PlaybackState.STATE_PLAYING &&
+            state != PlaybackState.STATE_PLAYING
+        ) {
+            // Leaving playback: freeze at the interpolated "now" position so
+            // the pause anchor equals where the user actually heard the track.
+            positionSeconds = interpolatedPositionSeconds()
+            lastPositionUpdateMs = SystemClock.elapsedRealtime()
+        } else if (state == PlaybackState.STATE_PLAYING) {
+            // Entering playback: keep the (possibly frozen) position but
+            // re-anchor, so interpolation does not charge the paused interval.
+            lastPositionUpdateMs = SystemClock.elapsedRealtime()
+        }
+
+        playbackState = state
+
+        publish()
+    }
+
+    private fun cancelTeardown() {
+        teardownRunnable?.let { runnable ->
+            mainHandler.removeCallbacks(runnable)
+        }
+        teardownRunnable = null
+    }
+
+    private fun scheduleTeardown() {
+        cancelTeardown()
+
+        val runnable = Runnable {
+            teardownRunnable = null
+
+            if (playbackState == PlaybackState.STATE_NONE &&
+                (
+                    hasActivePlaybackSession ||
+                        mediaSession.isActive ||
+                        lastNotification != null
+                    )
+            ) {
+                clearPlayback()
+            }
+        }
+
+        teardownRunnable = runnable
+        mainHandler.postDelayed(runnable, TEARDOWN_GRACE_MS)
+    }
+
+    private fun publish() {
+        if (playbackState == PlaybackState.STATE_NONE) {
+            /*
+             * "none" arrives from any frame whose media ended (or that never
+             * had any). Tearing down immediately let one ended ad element kill
+             * a session another frame was still playing (#566); wait out the
+             * grace period and cancel if anything reports activity again.
+             */
+            if (hasActivePlaybackSession || mediaSession.isActive || lastNotification != null) {
+                scheduleTeardown()
+            }
+            return
+        }
+
+        cancelTeardown()
+
+        hasActivePlaybackSession = true
+
+        applyMetadata()
+        applyPlaybackState()
+
+        mediaSession.isActive = true
+
+        updateNotification()
+
+        WebMediaPlaybackService.synchronize(
+            activity.applicationContext,
+            playbackState == PlaybackState.STATE_PLAYING
+        )
+    }
+
+    private fun applyMetadata() {
+        val metadata = MediaMetadata.Builder()
+            .putString(
+                MediaMetadata.METADATA_KEY_TITLE,
+                title.ifBlank { appLabel() }
+            )
+            .putString(
+                MediaMetadata.METADATA_KEY_ARTIST,
+                artist
+            )
+            .putString(
+                MediaMetadata.METADATA_KEY_ALBUM,
+                album
+            )
+            .putLong(
+                MediaMetadata.METADATA_KEY_DURATION,
+                (durationSeconds * 1000.0).toLong()
+            )
+
+        artworkBitmap?.let { bitmap ->
+            metadata.putBitmap(
+                MediaMetadata.METADATA_KEY_ART,
+                bitmap
+            )
+
+            metadata.putBitmap(
+                MediaMetadata.METADATA_KEY_ALBUM_ART,
+                bitmap
+            )
+
+            metadata.putBitmap(
+                MediaMetadata.METADATA_KEY_DISPLAY_ICON,
+                bitmap
+            )
+        }
+
+        mediaSession.setMetadata(metadata.build())
+    }
+
+    private fun applyPlaybackState() {
+        var actions =
+            PlaybackState.ACTION_PLAY or
+                PlaybackState.ACTION_PAUSE or
+                PlaybackState.ACTION_PLAY_PAUSE or
+                PlaybackState.ACTION_STOP or
+                PlaybackState.ACTION_SEEK_TO
+
+        if ("previoustrack" in supportedActions) {
+            actions = actions or PlaybackState.ACTION_SKIP_TO_PREVIOUS
+        }
+
+        if ("nexttrack" in supportedActions) {
+            actions = actions or PlaybackState.ACTION_SKIP_TO_NEXT
+        }
+
+        if ("seekbackward" in supportedActions) {
+            actions = actions or PlaybackState.ACTION_REWIND
+        }
+
+        if ("seekforward" in supportedActions) {
+            actions = actions or PlaybackState.ACTION_FAST_FORWARD
+        }
+
+        val isPlaying = playbackState == PlaybackState.STATE_PLAYING
+
+        /*
+         * Speed 0 while not playing stops SystemUI interpolation; the
+         * position carried into setState is already the interpolated "now"
+         * value, so the anchor is always continuous with what the user sees.
+         */
+        val state = PlaybackState.Builder()
+            .setActions(actions)
+            .setState(
+                playbackState,
+                (interpolatedPositionSeconds() * 1000.0).toLong(),
+                if (isPlaying) playbackRate else 0.0f
+            )
+            .build()
+
+        playbackStatePublishCount++
+
+        mediaSession.setPlaybackState(state)
+    }
+
+    // ---- Notification ----
+
+    private fun updateNotification() {
+        if (playbackState == PlaybackState.STATE_NONE) {
+            notificationManager.cancel(
+                WebMediaPlaybackService.NOTIFICATION_ID
+            )
+
+            lastNotification = null
+            return
+        }
+
+        val notification = buildNotification()
+
+        lastNotification = notification
+
+        notificationManager.notify(
+            WebMediaPlaybackService.NOTIFICATION_ID,
+            notification
+        )
+    }
+
+    private fun buildNotification(): Notification {
+        val builder = NotificationCompat.Builder(
+            activity,
+            WebMediaPlaybackService.CHANNEL_ID
+        )
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle(title.ifBlank { appLabel() })
+            .setContentText(
+                artist.ifBlank {
+                    album.ifBlank { "Media playback" }
+                }
+            )
+            .setSubText(album.takeIf { it.isNotBlank() })
+            .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setOnlyAlertOnce(true)
+            .setOngoing(
+                playbackState == PlaybackState.STATE_PLAYING
+            )
+            .setContentIntent(createLaunchPendingIntent())
+            .setDeleteIntent(
+                WebMediaPlaybackService.commandPendingIntent(
+                    activity,
+                    "stop"
+                )
+            )
+
+        artworkBitmap?.let(builder::setLargeIcon)
+
+        val compactActionIndexes = mutableListOf<Int>()
+        var actionIndex = 0
+
+        if ("previoustrack" in supportedActions) {
+            builder.addAction(
+                android.R.drawable.ic_media_previous,
+                "Previous",
+                WebMediaPlaybackService.commandPendingIntent(
+                    activity,
+                    "previoustrack"
+                )
+            )
+
+            compactActionIndexes.add(actionIndex)
+            actionIndex++
+        }
+
+        val isPlaying =
+            playbackState == PlaybackState.STATE_PLAYING
+
+        builder.addAction(
+            if (isPlaying) {
+                android.R.drawable.ic_media_pause
+            } else {
+                android.R.drawable.ic_media_play
+            },
+            if (isPlaying) "Pause" else "Play",
+            WebMediaPlaybackService.commandPendingIntent(
+                activity,
+                if (isPlaying) "pause" else "play"
+            )
+        )
+
+        compactActionIndexes.add(actionIndex)
+        actionIndex++
+
+        if ("nexttrack" in supportedActions) {
+            builder.addAction(
+                android.R.drawable.ic_media_next,
+                "Next",
+                WebMediaPlaybackService.commandPendingIntent(
+                    activity,
+                    "nexttrack"
+                )
+            )
+
+            compactActionIndexes.add(actionIndex)
+        }
+
+        val mediaStyle = MediaStyle()
+            .setMediaSession(
+                MediaSessionCompat.Token.fromToken(mediaSession.sessionToken)
+            )
+            .setShowCancelButton(true)
+            .setCancelButtonIntent(
+                WebMediaPlaybackService.commandPendingIntent(
+                    activity,
+                    "stop"
+                )
+            )
+
+        if (compactActionIndexes.isNotEmpty()) {
+            mediaStyle.setShowActionsInCompactView(
+                *compactActionIndexes
+                    .take(3)
+                    .toIntArray()
+            )
+        }
+
+        builder.setStyle(mediaStyle)
+
+        return builder.build()
+    }
+
+    private fun createLaunchPendingIntent(): PendingIntent? {
+        val launchIntent =
+            activity.packageManager.getLaunchIntentForPackage(
+                activity.packageName
+            ) ?: return null
+
+        launchIntent.addFlags(
+            Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP
+        )
+
+        return PendingIntent.getActivity(
+            activity,
+            3101,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or
+                PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    // ---- Artwork ----
+
+    private fun loadArtwork(url: String) {
+        if (url.isBlank()) {
+            artworkBitmap = null
+            loadedArtworkUrl = ""
+            publish()
+            return
+        }
+
+        if (url == loadedArtworkUrl && artworkBitmap != null) {
+            return
+        }
+
+        artworkExecutor.execute {
+            val bitmap = downloadBitmap(url)
+
+            mainHandler.post {
+                /*
+                 * Ignore an old request when the website changed tracks while
+                 * the image was still downloading.
+                 */
+                if (artworkUrl != url) {
+                    return@post
+                }
+
+                artworkBitmap = bitmap
+                loadedArtworkUrl = url
+
+                if (playbackState != PlaybackState.STATE_NONE) {
+                    applyMetadata()
+                    updateNotification()
+                }
+            }
+        }
+    }
+
+    private fun downloadBitmap(url: String): Bitmap? {
+        return try {
+            val connection = URL(url).openConnection()
+                as HttpURLConnection
+
+            connection.connectTimeout = 8_000
+            connection.readTimeout = 8_000
+            connection.instanceFollowRedirects = true
+            connection.doInput = true
+            connection.connect()
+
+            connection.inputStream.use {
+                BitmapFactory.decodeStream(it)
+            }.also {
+                connection.disconnect()
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun appLabel(): String {
+        return activity.applicationInfo
+            .loadLabel(activity.packageManager)
+            .toString()
+    }
+
+    fun clearPlayback() {
+        cancelTeardown()
+
+        hasActivePlaybackSession = false
+
+        playbackState = PlaybackState.STATE_NONE
+        positionSeconds = 0.0
+        durationSeconds = 0.0
+        lastPositionUpdateMs = 0L
+
+        mediaSession.setPlaybackState(
+            PlaybackState.Builder()
+                .setState(
+                    PlaybackState.STATE_NONE,
+                    0L,
+                    1.0f
+                )
+                .build()
+        )
+
+        mediaSession.isActive = false
+
+        notificationManager.cancel(
+            WebMediaPlaybackService.NOTIFICATION_ID
+        )
+
+        lastNotification = null
+
+        WebMediaPlaybackService.stop(
+            activity.applicationContext
+        )
+    }
+
+    fun release() {
+        clearPlayback()
+
+        artworkExecutor.shutdownNow()
+        mediaSession.release()
+
+        if (activeCore?.get() === this) {
+            activeCore = null
+        }
+    }
+
+    companion object {
+        private const val TEARDOWN_GRACE_MS = 2_500L
+
+        @Volatile
+        private var activeCore:
+            WeakReference<MediaSessionCore>? = null
+
+        internal fun dispatchFromService(
+            command: String,
+            value: Double
+        ) {
+            activeCore?.get()?.onCommand(command, value)
+        }
+
+        internal fun getForegroundNotification(
+            context: Context
+        ): Notification? {
+            return activeCore?.get()?.lastNotification
+        }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebMediaPlaybackService.kt
@@ -21,8 +21,8 @@ import com.webtoapp.util.SafeNotificationChannels
  * eligible for ongoing media playback, holds a wake lock while playing, and owns
  * the media notification lifecycle (start while playing, detach on pause, remove
  * on stop). Notification controls dispatch explicit commands back to the active
- * [MediaSessionBridge] — they do NOT depend on a generic ACTION_MEDIA_BUTTON
- * broadcast receiver.
+ * [MediaSessionCore] (WebView bridge or GeckoView adapter) — they do NOT depend
+ * on a generic ACTION_MEDIA_BUTTON broadcast receiver.
  */
 class WebMediaPlaybackService : Service() {
 
@@ -67,7 +67,7 @@ class WebMediaPlaybackService : Service() {
                 val value = intent.getDoubleExtra(EXTRA_VALUE, 0.0)
 
                 if (!command.isNullOrBlank()) {
-                    MediaSessionBridge.dispatchFromService(command, value)
+                    MediaSessionCore.dispatchFromService(command, value)
                 }
 
                 /*
@@ -94,7 +94,7 @@ class WebMediaPlaybackService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun startAsForeground() {
-        val notification = MediaSessionBridge.getForegroundNotification(this)
+        val notification = MediaSessionCore.getForegroundNotification(this)
             ?: buildFallbackNotification()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -69,6 +69,7 @@ class ShellActivity : AppCompatActivity() {
     private var pendingFloatingWindowLaunch = false
     private var notificationPolyfillEnabled = false
     private var mediaSessionBridge: com.webtoapp.core.webview.MediaSessionBridge? = null
+    private var geckoMediaAdapter: com.webtoapp.core.engine.GeckoMediaSessionAdapter? = null
 
     // Screen-awake (ALWAYS/TIMED) timer management. The timed clear is tracked so it can be
     // cancelled/re-scheduled whenever the mode is re-applied (e.g. after a forced-run change).
@@ -466,6 +467,19 @@ class ShellActivity : AppCompatActivity() {
                     if (surface.webView == null) {
                         webView = null
                         com.webtoapp.core.shell.ShellLogger.i("ShellActivity", "Browser surface created (GeckoView), ECH engine active")
+                        // GeckoView implements the web Media Session API itself;
+                        // its engine events feed the shared native core (#593).
+                        if (config.webViewConfig.enableMediaSession) {
+                            val geckoEngine = surface.engine as? com.webtoapp.core.engine.GeckoViewEngine
+                            if (geckoEngine != null) {
+                                geckoMediaAdapter?.release()
+                                geckoMediaAdapter = com.webtoapp.core.engine.GeckoMediaSessionAdapter(
+                                    this@ShellActivity,
+                                    geckoEngine
+                                )
+                                com.webtoapp.core.shell.ShellLogger.i("ShellActivity", "[MediaSession] Gecko adapter attached")
+                            }
+                        }
                     }
                 },
                 onWebViewCreated = { wv ->
@@ -881,6 +895,8 @@ class ShellActivity : AppCompatActivity() {
         webView = null
         mediaSessionBridge?.runCatching { release() }
         mediaSessionBridge = null
+        geckoMediaAdapter?.runCatching { release() }
+        geckoMediaAdapter = null
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -133,6 +133,7 @@ class WebViewActivity : AppCompatActivity() {
     private var customViewCallback: WebChromeClient.CustomViewCallback? = null
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
     private var mediaSessionBridge: com.webtoapp.core.webview.MediaSessionBridge? = null
+    internal var geckoMediaAdapter: com.webtoapp.core.engine.GeckoMediaSessionAdapter? = null
 
     private var pendingPermissionRequest: PermissionRequest? = null
     private var pendingGeolocationOrigin: String? = null
@@ -997,6 +998,8 @@ class WebViewActivity : AppCompatActivity() {
 
         mediaSessionBridge?.release()
         mediaSessionBridge = null
+        geckoMediaAdapter?.runCatching { release() }
+        geckoMediaAdapter = null
 
         android.webkit.CookieManager.getInstance().flush()
         webView?.let { wv ->
@@ -3110,6 +3113,19 @@ fun WebViewScreen(
                                 browserSurfaceRef = surface
                                 (context as? WebViewActivity)?.browserSurface = surface
                                 val createdWebView = surface.webView
+                                if (createdWebView == null &&
+                                    webApp?.webViewConfig?.enableMediaSession == true
+                                ) {
+                                    // Gecko engine preview: bridge Gecko's own media
+                                    // session events into the shared native core (#593).
+                                    val geckoEngine = surface.engine as? com.webtoapp.core.engine.GeckoViewEngine
+                                    if (geckoEngine != null) {
+                                        (context as? WebViewActivity)?.let { host ->
+                                            host.geckoMediaAdapter?.runCatching { release() }
+                                            host.geckoMediaAdapter = com.webtoapp.core.engine.GeckoMediaSessionAdapter(host, geckoEngine)
+                                        }
+                                    }
+                                }
                                 if (createdWebView != null) {
                                     createdWebView.apply {
                                     layoutParams = ViewGroup.LayoutParams(

--- a/app/src/test/java/com/webtoapp/core/webview/MediaSessionCoreTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/MediaSessionCoreTest.kt
@@ -1,0 +1,139 @@
+package com.webtoapp.core.webview
+
+import android.app.Activity
+import android.media.session.PlaybackState
+import android.os.Looper
+import android.os.SystemClock
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+/**
+ * Guards the #593 fix: SystemUI interpolates progress from the last
+ * setState anchor, so the core must (a) advance the published position by
+ * wall time × rate while playing, (b) freeze at the interpolated position on
+ * pause, and (c) never re-anchor for a repeated, unchanged state report.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@LooperMode(LooperMode.Mode.PAUSED)
+class MediaSessionCoreTest {
+
+    private lateinit var core: MediaSessionCore
+    private val commands = mutableListOf<Pair<String, Double>>()
+
+    @Before
+    fun setUp() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        core = MediaSessionCore(activity) { command, value ->
+            commands.add(command to value)
+        }
+    }
+
+    private fun idle() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun play(duration: Double = 237.0, position: Double = 216.0, rate: Double = 1.0) {
+        core.updatePosition(duration, position, rate)
+        idle()
+        core.updatePlaybackState(PlaybackState.STATE_PLAYING)
+        idle()
+    }
+
+    @Test
+    fun `playing position advances by wall time at rate 1x`() {
+        play(duration = 237.0, position = 216.0, rate = 1.0)
+
+        val now = SystemClock.elapsedRealtime()
+        val at = core.interpolatedPositionSeconds(now + 5_000)
+        assertThat(at).isWithin(0.1).of(221.0)
+    }
+
+    @Test
+    fun `playing position advances by the reported rate`() {
+        play(duration = 300.0, position = 100.0, rate = 2.0)
+
+        val now = SystemClock.elapsedRealtime()
+        val at = core.interpolatedPositionSeconds(now + 10_000)
+        assertThat(at).isWithin(0.1).of(120.0)
+    }
+
+    @Test
+    fun `interpolated position clamps to a known duration`() {
+        play(duration = 237.0, position = 236.0, rate = 1.0)
+
+        val now = SystemClock.elapsedRealtime()
+        val at = core.interpolatedPositionSeconds(now + 30_000)
+        assertThat(at).isWithin(0.1).of(237.0)
+    }
+
+    @Test
+    fun `pausing freezes the interpolated position instead of the stale anchor`() {
+        play(duration = 237.0, position = 100.0, rate = 1.0)
+
+        // 5 s of playback pass with no position report from the page.
+        Robolectric.getForegroundThreadScheduler().advanceBy(5_000)
+
+        core.updatePlaybackState(PlaybackState.STATE_PAUSED)
+        idle()
+
+        val now = SystemClock.elapsedRealtime()
+        // Frozen at ~105 s no matter how much later the system asks.
+        val at = core.interpolatedPositionSeconds(now + 120_000)
+        assertThat(at).isWithin(0.1).of(105.0)
+    }
+
+    @Test
+    fun `repeated unchanged state reports do not republish or re-anchor`() {
+        play(duration = 237.0, position = 100.0, rate = 1.0)
+
+        val publishesAfterPlay = core.playbackStatePublishCount
+
+        repeat(5) {
+            core.updatePlaybackState(PlaybackState.STATE_PLAYING)
+        }
+        idle()
+
+        // Heartbeat-style duplicates are dropped: no native re-anchor that
+        // would drag the SystemUI progress bar back to the stale position.
+        assertThat(core.playbackStatePublishCount).isEqualTo(publishesAfterPlay)
+    }
+
+    @Test
+    fun `position report while playing re-anchors and republishes`() {
+        play(duration = 237.0, position = 100.0, rate = 1.0)
+
+        val publishesBefore = core.playbackStatePublishCount
+
+        core.updatePosition(237.0, 150.0, 1.0)
+        idle()
+
+        assertThat(core.playbackStatePublishCount).isEqualTo(publishesBefore + 1)
+
+        val now = SystemClock.elapsedRealtime()
+        assertThat(core.interpolatedPositionSeconds(now + 2_000))
+            .isWithin(0.1).of(152.0)
+    }
+
+    @Test
+    fun `seek while paused publishes the new position without advancing`() {
+        play(duration = 237.0, position = 100.0, rate = 1.0)
+
+        core.updatePlaybackState(PlaybackState.STATE_PAUSED)
+        idle()
+
+        core.updatePosition(237.0, 42.0, 1.0)
+        idle()
+
+        val now = SystemClock.elapsedRealtime()
+        assertThat(core.interpolatedPositionSeconds(now + 60_000))
+            .isWithin(0.1).of(42.0)
+    }
+}


### PR DESCRIPTION
Fixes #593

## What

| #593 report | Root cause | Fix |
|---|---|---|
| Progress bar frozen while playing (WebView) | Heartbeat re-published PlaybackState every second with the **stale** position, re-anchoring SystemUI's interpolation back to the same spot; pages using `setPositionState()` only report on play/pause/seek, never per second | Position interpolation anchored on `elapsedRealtime`, published as `position + elapsed × rate` while playing; unchanged state reports dropped; pause freezes at the interpolated position |
| No media session at all on GeckoView | Bridge was `android.webkit.WebView`-only (`addJavascriptInterface` + document-start injection) | `GeckoMediaSessionAdapter` translates GeckoView 142's native Web Media Session delegate into the same core; commands route back via the `MediaSession` controller |

## How

**`MediaSessionCore`** (new, engine-agnostic): the native `MediaSession` state machine extracted from the bridge — metadata/artwork, position anchoring + interpolation (clamped to duration), playback-state dedup, teardown grace, notification, `WebMediaPlaybackService` sync. Leaving playback freezes the position at the interpolated "now"; entering playback re-anchors so paused time is not charged; non-playing publishes carry speed 0.

**`MediaSessionBridge`** (WebView adapter, slimmed): keeps the JS polyfill, frame arbitration (#566), and command dispatch; all state flows into the core.

**`GeckoMediaSessionAdapter`** (new): GeckoView implements the web Media Session API itself, so this is a pure translation — `onPlay/onPause/onStop` → playback states, `Metadata`/`PositionState` → core metadata/position, `Feature` bit flags → optional actions, `Image.getBitmap(512)` for artwork. No JS polyfill, no frame arbitration. `GeckoViewEngine.setMediaSessionDelegate` re-attaches on every session rebuild; `ShellActivity` (exported APKs) and `WebViewActivity` (host preview) wire it behind the same `enableMediaSession` flag, both released on destroy.

**`WebMediaPlaybackService`** dispatches through the shared core — both engines ride one notification/foreground-service pipeline.

## Validation

- New `MediaSessionCoreTest` (7): 1×/2× rate advance, duration clamp, pause freezes at interpolated position (5 s playback → frozen at ~105 s regardless of later wall time), repeated unchanged states publish **nothing**, position report re-anchors, paused seek does not advance
- Existing `MediaSessionBridgeScriptTest` 10/10 (injection-script contract intact); full webview+engine suites **119/119 green**
- Shell sync verified for all runtime-synced files; `:shell:assembleRelease` + `:app:syncShellTemplateApk` green