### PR TITLE
fix(shell): restore even tab distribution for few multi-web sites

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/MultiWebShellMode.kt
@@ -169,48 +169,58 @@ private fun TabsMode(
                     color = MaterialTheme.colorScheme.surface,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    LazyRow(
-                        state = tabsListState,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(48.dp),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        contentPadding = PaddingValues(horizontal = 8.dp)
-                    ) {
-                        itemsIndexed(sites) { index, site ->
-                            val isSelected = selectedTab == index
-                            Column(
-                                modifier = Modifier
-                                    .widthIn(min = 72.dp)
-                                    .fillMaxHeight()
-                                    .clickable { selectedTab = index },
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.Center
-                            ) {
-                                if (site.iconEmoji.isNotBlank()) {
+                    // 站点少时每个 tab 平分整条底栏（对称布局，回归 #597 报告的行为）；
+                    // 平分后不足 72dp（站点多）则保持 #283 的最小宽度 + 横向滚动。
+                    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                        val evenWidth =
+                            (maxWidth - 16.dp - 4.dp * (sites.size - 1)) / sites.size
+                        val tabModifier = if (evenWidth >= 72.dp) {
+                            Modifier.width(evenWidth)
+                        } else {
+                            Modifier.widthIn(min = 72.dp)
+                        }
+                        LazyRow(
+                            state = tabsListState,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(48.dp),
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            contentPadding = PaddingValues(horizontal = 8.dp)
+                        ) {
+                            itemsIndexed(sites) { index, site ->
+                                val isSelected = selectedTab == index
+                                Column(
+                                    modifier = tabModifier
+                                        .fillMaxHeight()
+                                        .clickable { selectedTab = index },
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    if (site.iconEmoji.isNotBlank()) {
+                                        Text(
+                                            site.iconEmoji,
+                                            fontSize = if (isSelected) 18.sp else 16.sp
+                                        )
+                                    } else {
+                                        Icon(
+                                            Icons.Outlined.Language,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(if (isSelected) 20.dp else 18.dp),
+                                            tint = if (isSelected) MaterialTheme.colorScheme.primary
+                                                   else MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
                                     Text(
-                                        site.iconEmoji,
-                                        fontSize = if (isSelected) 18.sp else 16.sp
-                                    )
-                                } else {
-                                    Icon(
-                                        Icons.Outlined.Language,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(if (isSelected) 20.dp else 18.dp),
-                                        tint = if (isSelected) MaterialTheme.colorScheme.primary
-                                               else MaterialTheme.colorScheme.onSurfaceVariant
+                                        site.name.ifBlank { extractDomain(site.url) },
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        fontSize = 10.sp,
+                                        color = if (isSelected) MaterialTheme.colorScheme.primary
+                                               else MaterialTheme.colorScheme.onSurfaceVariant,
+                                        lineHeight = 12.sp
                                     )
                                 }
-                                Text(
-                                    site.name.ifBlank { extractDomain(site.url) },
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    fontSize = 10.sp,
-                                    color = if (isSelected) MaterialTheme.colorScheme.primary
-                                           else MaterialTheme.colorScheme.onSurfaceVariant,
-                                    lineHeight = 12.sp
-                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Problem

In multi-site apps (TABS display mode), site titles in the bottom bar used to distribute evenly across the full bar width. After #283's scrollable-tabs rework (b0cca272, shipped in #289), the bar became a `LazyRow` where every tab only has `widthIn(min = 72.dp)` — `LazyRow` items have no `weight`, so with few sites each tab keeps its minimum width and stacks in the left corner, leaving the rest of the bar empty (reported in #597).

## Fix

Wrap the bar in `BoxWithConstraints` and compute the even share per tab:

- `evenWidth = (barWidth − 16dp padding − 4dp × (n−1) spacing) / n`
- If `evenWidth ≥ 72.dp` → each tab gets `width(evenWidth)`: the tabs fill the bar symmetrically (the pre-#283 behavior).
- Otherwise → keep `widthIn(min = 72.dp)`: the bar stays horizontally scrollable with usable tab sizes (the #283 behavior).

Both regimes switch naturally by width — no site-count threshold, single code path. `animateScrollToItem` selection scrolling is unaffected (an exactly-filled row has nothing to scroll).

`MultiWebShellMode.kt` is shell-synced, so the fix applies to host preview and generated APKs alike; the shell template has been rebuilt.

Fixes #597