### PR TITLE
fix(export): stop compositing the user image twice in launcher icons

### DIFF
--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkBuilder.kt
@@ -57,6 +57,9 @@ class ApkBuilder(private val context: Context) {
         private val PACKAGE_NAME_REGEX = AppConstants.PACKAGE_NAME_REGEX
         private val CHARSET_REGEX = AppConstants.CHARSET_REGEX
         private const val FLOATING_WINDOW_MINIMIZED_ICON_ASSET = "floating_window_minimized_icon.png"
+
+        /** Adaptive icon canvas size (108dp @ xxxhdpi) used for foreground/background layers. */
+        private const val ADAPTIVE_ICON_PX = 432
         private val GECKOVIEW_RUNTIME_COMPONENTS = (0..39)
             .map { "org.mozilla.gecko.process.GeckoChildProcessServices\$tab$it" }
             .toSet() + setOf(
@@ -1061,7 +1064,7 @@ class ApkBuilder(private val context: Context) {
         }
     }
 
-    private suspend fun modifyApk(
+    internal suspend fun modifyApk(
         sourceApk: File,
         outputApk: File,
         config: ApkConfig,
@@ -1100,6 +1103,7 @@ class ApkBuilder(private val context: Context) {
         var strippedNativeLibSize = 0L
         val replacedIconPaths = mutableSetOf<String>()
         var discoveredOldIconPaths = emptySet<String>()
+        var discoveredIconSpecs = emptyList<ArscRebuilder.DiscoveredIconPath>()
 
         // Native libs the per-app-type injection step writes for the device ABI (16KB-aligned).
         // The template also ships them; skip the template's device-ABI copy in the loop below so
@@ -1199,6 +1203,7 @@ class ApkBuilder(private val context: Context) {
                             )
 
                             discoveredOldIconPaths = arscRebuilder.getLastDiscoveredIconPaths()
+                            discoveredIconSpecs = arscRebuilder.getLastDiscoveredIconSpecs()
                             logger.log("Discovered old icon paths from ARSC: $discoveredOldIconPaths")
                             writeEntryStored(zipOut, entry.name, modifiedData)
                         }
@@ -1210,10 +1215,22 @@ class ApkBuilder(private val context: Context) {
 
                         iconBitmap != null && (isIconEntry(entry.name) || discoveredOldIconPaths.contains(entry.name)) -> {
 
-                            val iconBytes = template.createAdaptiveForegroundIcon(iconBitmap, 432)
+                            // Template icon entries carry obfuscated names, so the ARSC scan is
+                            // what tells a legacy mipmap from the adaptive foreground — write
+                            // layer-appropriate, density-appropriate bitmaps per entry.
+                            val spec = discoveredIconSpecs.firstOrNull { it.path == entry.name }
+                            val iconBytes = when (spec?.kind) {
+                                ArscRebuilder.LauncherIconKind.FOREGROUND ->
+                                    template.createAdaptiveForegroundIcon(iconBitmap, ADAPTIVE_ICON_PX)
+                                ArscRebuilder.LauncherIconKind.ROUND ->
+                                    template.createRoundIcon(iconBitmap, iconPixelSizeForDensity(spec.densityDpi))
+                                ArscRebuilder.LauncherIconKind.LAUNCHER ->
+                                    template.scaleBitmapToPng(iconBitmap, iconPixelSizeForDensity(spec.densityDpi))
+                                null -> template.createAdaptiveForegroundIcon(iconBitmap, ADAPTIVE_ICON_PX)
+                            }
                             writeEntryDeflated(zipOut, entry.name, iconBytes)
                             replacedIconPaths.add(entry.name)
-                            AppLogger.d("ApkBuilder", "Replaced icon entry: ${entry.name} (${iconBytes.size} bytes)")
+                            AppLogger.d("ApkBuilder", "Replaced icon entry: ${entry.name} (kind=${spec?.kind}, ${iconBytes.size} bytes)")
                         }
 
                         entry.name in geckoRuntimeEntries -> {
@@ -1338,9 +1355,11 @@ class ApkBuilder(private val context: Context) {
                     if (iconBitmap != null) {
                         addAdaptiveIconPngs(zipOut, iconBitmap, entryNames)
 
-                        val bgBytes = template.createFullBleedBackgroundIcon(iconBitmap, 432)
+                        // Solid backing color — never the user image itself, or launchers
+                        // composite the picture twice (background + safe-zone foreground).
+                        val bgBytes = ApkTemplate.createSolidBackgroundIcon(iconBitmap, ADAPTIVE_ICON_PX)
                         writeEntryDeflated(zipOut, ArscRebuilder.LAUNCHER_BACKGROUND_DRAWABLE_PATH, bgBytes)
-                        logger.log("Added full-bleed launcher background drawable (${bgBytes.size} bytes)")
+                        logger.log("Added solid launcher background drawable (${bgBytes.size} bytes)")
                     }
                 }
 
@@ -3027,7 +3046,7 @@ builtins.__import__ = _w2a_import
             "res/drawable-anydpi-v24/ic_launcher_foreground_new"
         )
 
-        val iconBytes = template.createAdaptiveForegroundIcon(bitmap, 432)
+        val iconBytes = template.createAdaptiveForegroundIcon(bitmap, ADAPTIVE_ICON_PX)
 
         bases.forEach { base ->
             val pngPath = "${base}.png"
@@ -3038,17 +3057,13 @@ builtins.__import__ = _w2a_import
         }
     }
 
-    private fun addAdaptiveIconReplacementPngs(zipOut: ZipOutputStream, bitmap: Bitmap) {
-
-        val iconPng = template.scaleBitmapToPng(bitmap, 512)
-        writeEntryDeflated(zipOut, "res/mipmap-anydpi-v26/ic_launcher.png", iconPng)
-        AppLogger.d("ApkBuilder", "Added replacement icon: res/mipmap-anydpi-v26/ic_launcher.png (512px, ${iconPng.size} bytes)")
-
-        val roundPng = template.createRoundIcon(bitmap, 512)
-        writeEntryDeflated(zipOut, "res/mipmap-anydpi-v26/ic_launcher_round.png", roundPng)
-        AppLogger.d("ApkBuilder", "Added replacement icon: res/mipmap-anydpi-v26/ic_launcher_round.png (512px, ${roundPng.size} bytes)")
-
-        logger.log("Added PNG icons at mipmap-anydpi-v26 paths (512px, replacing adaptive icon XMLs)")
+    private fun iconPixelSizeForDensity(densityDpi: Int): Int = when (densityDpi) {
+        120 -> 36
+        160 -> 48
+        240 -> 72
+        320 -> 96
+        480 -> 144
+        else -> 192
     }
 
     private fun writeEntryDeflated(zipOut: ZipOutputStream, name: String, data: ByteArray) {
@@ -3181,41 +3196,6 @@ builtins.__import__ = _w2a_import
         return entryName.startsWith("res/mipmap-anydpi") &&
             (entryName.contains("ic_launcher") || entryName.contains("ic_launcher_round")) &&
             entryName.endsWith(".xml")
-    }
-
-    private fun replaceIconEntry(zipOut: ZipOutputStream, entryName: String, bitmap: Bitmap) {
-
-        var size = ApkTemplate.ICON_PATHS.find { it.first == entryName }?.second
-            ?: ApkTemplate.ROUND_ICON_PATHS.find { it.first == entryName }?.second
-
-        if (size == null) {
-            size = when {
-                entryName.contains("xxxhdpi") -> 192
-                entryName.contains("xxhdpi") -> 144
-                entryName.contains("xhdpi") -> 96
-                entryName.contains("hdpi") -> 72
-                entryName.contains("mdpi") -> 48
-                entryName.contains("ldpi") -> 36
-                else -> 96
-            }
-        }
-
-        val iconBytes = when {
-
-            entryName.contains("round") -> {
-                template.createRoundIcon(bitmap, size)
-            }
-
-            entryName.contains("foreground") -> {
-                template.createAdaptiveForegroundIcon(bitmap, size)
-            }
-
-            else -> {
-                template.scaleBitmapToPng(bitmap, size)
-            }
-        }
-
-        writeEntryDeflated(zipOut, entryName, iconBytes)
     }
 
     private fun copyEntry(zipIn: ZipFile, zipOut: ZipOutputStream, entry: ZipEntry) {

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ApkTemplate.kt
@@ -31,6 +31,83 @@ class ApkTemplate(private val context: Context) {
             "res/mipmap-xxhdpi-v4/ic_launcher_round.png" to 144,
             "res/mipmap-xxxhdpi-v4/ic_launcher_round.png" to 192
         )
+
+        /**
+         * Picks a solid color to back an adaptive-icon foreground layer.
+         *
+         * The user image must never be reused as the background layer: launchers composite
+         * background + foreground, so an image-backed background shows the whole picture
+         * behind the safe-zone subject (issue: "transparent background icon duplicates it
+         * behind the subject"). Opaque images keep their dominant border color so the icon
+         * still reads as a full tile; transparent logos fall back to white/black by
+         * luminance contrast against the subject.
+         */
+        fun deriveLauncherBackgroundColor(bitmap: Bitmap): Int {
+            // Sample a coarse grid straight from the source pixels; downscaling through
+            // createScaledBitmap is neither needed nor reliable across renderers.
+            val cols = minOf(32, bitmap.width)
+            val rows = minOf(32, bitmap.height)
+            val band = maxOf(1, minOf(cols, rows) / 8)
+
+            val borderCounts = HashMap<Int, Int>()
+            val allCounts = HashMap<Int, Int>()
+            var borderOpaque = 0
+            var borderCells = 0
+
+            for (gy in 0 until rows) {
+                val y = ((gy + 0.5f) * bitmap.height / rows).toInt().coerceIn(0, bitmap.height - 1)
+                for (gx in 0 until cols) {
+                    val x = ((gx + 0.5f) * bitmap.width / cols).toInt().coerceIn(0, bitmap.width - 1)
+
+                    val isBorder = gx < band || gy < band || gx >= cols - band || gy >= rows - band
+                    if (isBorder) {
+                        borderCells++
+                    }
+
+                    val pixel = bitmap.getPixel(x, y)
+                    if ((pixel ushr 24) < 128) continue
+
+                    val quantized = quantizeColor(pixel)
+                    allCounts[quantized] = (allCounts[quantized] ?: 0) + 1
+                    if (isBorder) {
+                        borderCounts[quantized] = (borderCounts[quantized] ?: 0) + 1
+                        borderOpaque++
+                    }
+                }
+            }
+
+            if (borderOpaque * 2 >= borderCells) {
+                borderCounts.maxByOrNull { it.value }?.let { return it.key }
+            }
+
+            val dominant = allCounts.maxByOrNull { it.value }?.key
+                ?: return 0xFFFFFFFF.toInt()
+            return if (luminance(dominant) >= 0.5f) 0xFF000000.toInt() else 0xFFFFFFFF.toInt()
+        }
+
+        fun createSolidBackgroundIcon(bitmap: Bitmap, size: Int): ByteArray {
+            val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+            output.eraseColor(deriveLauncherBackgroundColor(bitmap))
+
+            val baos = ByteArrayOutputStream()
+            output.compress(Bitmap.CompressFormat.PNG, 100, baos)
+            output.recycle()
+            return baos.toByteArray()
+        }
+
+        private fun quantizeColor(color: Int): Int {
+            val r = (color shr 16) and 0xF8
+            val g = (color shr 8) and 0xF8
+            val b = color and 0xF8
+            return 0xFF000000.toInt() or (r shl 16) or (g shl 8) or b
+        }
+
+        private fun luminance(color: Int): Float {
+            val r = (color shr 16) and 0xFF
+            val g = (color shr 8) and 0xFF
+            val b = color and 0xFF
+            return (0.299f * r + 0.587f * g + 0.114f * b) / 255f
+        }
     }
 
     private val templateDir = File(context.cacheDir, "apk_templates")
@@ -75,24 +152,12 @@ class ApkTemplate(private val context: Context) {
         ApkConfigJsonFactory.createEncryptedStub(config)
 
     fun scaleBitmapToPng(bitmap: Bitmap, size: Int): ByteArray {
-        val scaled = Bitmap.createScaledBitmap(bitmap, size, size, true)
-        val baos = ByteArrayOutputStream()
-        scaled.compress(Bitmap.CompressFormat.PNG, 100, baos)
-        if (scaled != bitmap) {
-            scaled.recycle()
-        }
-        return baos.toByteArray()
-    }
-
-    fun createFullBleedBackgroundIcon(bitmap: Bitmap, size: Int): ByteArray {
         val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
         val canvas = android.graphics.Canvas(output)
 
-        val scale = size.toFloat() / maxOf(bitmap.width, bitmap.height)
+        val scale = minOf(size.toFloat() / bitmap.width, size.toFloat() / bitmap.height)
         val scaledW = (bitmap.width * scale).toInt().coerceAtLeast(1)
         val scaledH = (bitmap.height * scale).toInt().coerceAtLeast(1)
-        val scaled = Bitmap.createScaledBitmap(bitmap, scaledW, scaledH, true)
-
         val left = (size - scaledW) / 2f
         val top = (size - scaledH) / 2f
 
@@ -100,12 +165,10 @@ class ApkTemplate(private val context: Context) {
             isAntiAlias = true
             isFilterBitmap = true
         }
-        canvas.drawBitmap(scaled, left, top, paint)
+        canvas.drawBitmap(bitmap, null, android.graphics.RectF(left, top, left + scaledW, top + scaledH), paint)
 
         val baos = ByteArrayOutputStream()
         output.compress(Bitmap.CompressFormat.PNG, 100, baos)
-
-        if (scaled != bitmap) scaled.recycle()
         output.recycle()
 
         return baos.toByteArray()
@@ -133,45 +196,56 @@ class ApkTemplate(private val context: Context) {
         val canvas = android.graphics.Canvas(output)
 
         val safeZoneSize = (size * 72f / 108f).toInt()
-        val padding = (size - safeZoneSize) / 2
+        val padding = (size - safeZoneSize) / 2f
 
-        val scaled = Bitmap.createScaledBitmap(bitmap, safeZoneSize, safeZoneSize, true)
+        val scale = minOf(safeZoneSize.toFloat() / bitmap.width, safeZoneSize.toFloat() / bitmap.height)
+        val scaledW = (bitmap.width * scale).toInt().coerceAtLeast(1)
+        val scaledH = (bitmap.height * scale).toInt().coerceAtLeast(1)
+        val left = padding + (safeZoneSize - scaledW) / 2f
+        val top = padding + (safeZoneSize - scaledH) / 2f
 
         val paint = android.graphics.Paint().apply {
             isAntiAlias = true
             isFilterBitmap = true
         }
-        canvas.drawBitmap(scaled, padding.toFloat(), padding.toFloat(), paint)
+        canvas.drawBitmap(bitmap, null, android.graphics.RectF(left, top, left + scaledW, top + scaledH), paint)
 
         val baos = ByteArrayOutputStream()
         output.compress(Bitmap.CompressFormat.PNG, 100, baos)
 
-        if (scaled != bitmap) scaled.recycle()
         output.recycle()
 
         return baos.toByteArray()
     }
 
     fun createRoundIcon(bitmap: Bitmap, size: Int): ByteArray {
-        val scaled = Bitmap.createScaledBitmap(bitmap, size, size, true)
         val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
 
         val canvas = android.graphics.Canvas(output)
+
+        val scale = minOf(size.toFloat() / bitmap.width, size.toFloat() / bitmap.height)
+        val scaledW = (bitmap.width * scale).toInt().coerceAtLeast(1)
+        val scaledH = (bitmap.height * scale).toInt().coerceAtLeast(1)
+        val left = (size - scaledW) / 2f
+        val top = (size - scaledH) / 2f
+
         val paint = android.graphics.Paint().apply {
             isAntiAlias = true
             isFilterBitmap = true
         }
+        canvas.drawBitmap(bitmap, null, android.graphics.RectF(left, top, left + scaledW, top + scaledH), paint)
 
-        val rect = android.graphics.RectF(0f, 0f, size.toFloat(), size.toFloat())
-        canvas.drawOval(rect, paint)
-
-        paint.xfermode = android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.SRC_IN)
-        canvas.drawBitmap(scaled, 0f, 0f, paint)
+        // Mask with DST_IN over the full canvas: an SRC_IN composite against a pre-drawn
+        // circle would leave the circle visible wherever the letterboxed content didn't cover.
+        val maskPaint = android.graphics.Paint().apply {
+            isAntiAlias = true
+            xfermode = android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.DST_IN)
+        }
+        canvas.drawOval(android.graphics.RectF(0f, 0f, size.toFloat(), size.toFloat()), maskPaint)
 
         val baos = ByteArrayOutputStream()
         output.compress(Bitmap.CompressFormat.PNG, 100, baos)
 
-        if (scaled != bitmap) scaled.recycle()
         output.recycle()
 
         return baos.toByteArray()

--- a/app/src/main/java/com/webtoapp/core/apkbuilder/ArscRebuilder.kt
+++ b/app/src/main/java/com/webtoapp/core/apkbuilder/ArscRebuilder.kt
@@ -18,6 +18,10 @@ class ArscRebuilder {
         const val LAUNCHER_BACKGROUND_DRAWABLE_PATH = "res/ic_launcher_bg.png"
     }
 
+    enum class LauncherIconKind { FOREGROUND, LAUNCHER, ROUND }
+
+    data class DiscoveredIconPath(val path: String, val kind: LauncherIconKind, val densityDpi: Int)
+
     fun rebuildWithNewAppName(arscData: ByteArray, targetAppName: String): ByteArray {
         return rebuildWithNewAppNameAndIcons(arscData, targetAppName, replaceIcons = false)
     }
@@ -84,7 +88,8 @@ class ArscRebuilder {
 
             if (replaceIcons) {
                 val iconPaths = findIconPathIndices(remainingData, strings)
-                _lastDiscoveredIconPaths = iconPaths.map { (idx, _) -> strings[idx] }.toSet()
+                _lastDiscoveredIconSpecs = iconPaths
+                _lastDiscoveredIconPaths = iconPaths.map { it.path }.toSet()
                 AppLogger.d(TAG, "Discovered old icon paths (for ZIP replacement): $_lastDiscoveredIconPaths")
 
                 convertLauncherBackgroundToDrawable(remainingData, strings)
@@ -159,6 +164,9 @@ class ArscRebuilder {
 
     private var _lastDiscoveredIconPaths = emptySet<String>()
     fun getLastDiscoveredIconPaths(): Set<String> = _lastDiscoveredIconPaths
+
+    private var _lastDiscoveredIconSpecs: List<DiscoveredIconPath> = emptyList()
+    fun getLastDiscoveredIconSpecs(): List<DiscoveredIconPath> = _lastDiscoveredIconSpecs
 
     private fun convertLauncherBackgroundToDrawable(
         packageData: ByteArray,
@@ -266,8 +274,8 @@ class ArscRebuilder {
     private fun findIconPathIndices(
         packageData: ByteArray,
         globalStrings: List<String>
-    ): List<Pair<Int, String>> {
-        val result = mutableListOf<Pair<Int, String>>()
+    ): List<DiscoveredIconPath> {
+        val result = mutableListOf<DiscoveredIconPath>()
 
         try {
             val buf = ByteBuffer.wrap(packageData).order(ByteOrder.LITTLE_ENDIAN)
@@ -337,11 +345,15 @@ class ArscRebuilder {
                     val entryCount = buf.int
                     val entriesStart = buf.int
 
+                    // ResTable_config density sits at config offset 14; the config itself
+                    // starts right after the fixed 20-byte type chunk header.
+                    val densityDpi = readU16(packageData, pos + 34)
+
                     val isInteresting = typeId == mipmapTypeId || typeId == drawableTypeId
                     if (isInteresting) {
                         if (typeId == mipmapTypeId) mipmapTypeChunkCount++
                         if (typeId == drawableTypeId) drawableTypeChunkCount++
-                        AppLogger.d(TAG, "Type chunk #$typeChunkCount: typeId=$typeId, entryCount=$entryCount, entriesStart=$entriesStart, chunkHeaderSize=$chunkHeaderSize, pos=$pos")
+                        AppLogger.d(TAG, "Type chunk #$typeChunkCount: typeId=$typeId, density=$densityDpi, entryCount=$entryCount, entriesStart=$entriesStart, chunkHeaderSize=$chunkHeaderSize, pos=$pos")
                     }
 
                     buf.position(pos + chunkHeaderSize)
@@ -396,21 +408,24 @@ class ArscRebuilder {
                         val globalStrIdx = valueData
                         if (globalStrIdx < 0 || globalStrIdx >= globalStrings.size) continue
 
-                        if (typeId == mipmapTypeId) {
-                            if (entryKeyIndex == icLauncherKeyIdx || entryKeyIndex == icLauncherRoundKeyIdx) {
-                                val oldPath = globalStrings[globalStrIdx]
-                                val keyName = if (entryKeyIndex >= 0 && entryKeyIndex < keyStrings.size) keyStrings[entryKeyIndex] else "?"
-                                AppLogger.d(TAG, "Found mipmap/$keyName → '$oldPath' (adaptive icon XML, KEEPING)")
-                            }
+                        val oldPath = globalStrings[globalStrIdx]
+                        val kind = when {
+                            typeId == drawableTypeId && entryKeyIndex == icLauncherFgKeyIdx -> LauncherIconKind.FOREGROUND
+                            typeId == mipmapTypeId && entryKeyIndex == icLauncherKeyIdx -> LauncherIconKind.LAUNCHER
+                            typeId == mipmapTypeId && entryKeyIndex == icLauncherRoundKeyIdx -> LauncherIconKind.ROUND
+                            else -> null
                         }
 
-                        if (typeId == drawableTypeId) {
-                            if (entryKeyIndex == icLauncherFgKeyIdx) {
-                                val oldPath = globalStrings[globalStrIdx]
-                                AppLogger.d(TAG, "Found drawable/ic_launcher_foreground → '$oldPath' (foreground image, REPLACING)")
-                                result.add(globalStrIdx to oldPath)
-                            }
+                        if (kind == null) continue
+
+                        // Adaptive-icon XML definitions must stay; only bitmap files are replaced.
+                        if (!oldPath.endsWith(".png")) {
+                            AppLogger.d(TAG, "Found icon path '$oldPath' (kind=$kind, non-bitmap, KEEPING)")
+                            continue
                         }
+
+                        AppLogger.d(TAG, "Found icon path '$oldPath' (kind=$kind, density=$densityDpi, REPLACING)")
+                        result.add(DiscoveredIconPath(oldPath, kind, densityDpi))
                     }
                 }
 
@@ -422,7 +437,7 @@ class ArscRebuilder {
             AppLogger.e(TAG, "Failed to find icon path indices", e)
         }
 
-        return result.distinctBy { it.first }
+        return result.distinctBy { it.path }
     }
 
     private fun readStringPool(buf: ByteBuffer, fullData: ByteArray): List<String> {

--- a/app/src/main/java/com/webtoapp/core/appmodifier/AppCloner.kt
+++ b/app/src/main/java/com/webtoapp/core/appmodifier/AppCloner.kt
@@ -15,6 +15,7 @@ import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import com.webtoapp.core.apkbuilder.ArscEditor
+import com.webtoapp.core.apkbuilder.ApkTemplate
 import com.webtoapp.core.apkbuilder.AxmlEditor
 import com.webtoapp.core.apkbuilder.AxmlRebuilder
 import com.webtoapp.core.apkbuilder.JarSigner
@@ -590,6 +591,12 @@ class AppCloner(private val context: Context) {
                 createAdaptiveForegroundIcon(bitmap, size)
             }
 
+            entryName.contains("background") -> {
+                // Adaptive background layer: solid backing color, never the user image
+                // itself (launchers would composite the picture twice).
+                ApkTemplate.createSolidBackgroundIcon(bitmap, size)
+            }
+
             else -> {
                 scaleBitmapToPng(bitmap, size)
             }
@@ -654,15 +661,6 @@ class AppCloner(private val context: Context) {
     private fun createRoundIcon(bitmap: Bitmap, size: Int): ByteArray {
         val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(output)
-        val paint = android.graphics.Paint().apply {
-            isAntiAlias = true
-            isFilterBitmap = true
-        }
-
-        val rect = android.graphics.RectF(0f, 0f, size.toFloat(), size.toFloat())
-        canvas.drawOval(rect, paint)
-
-        paint.xfermode = android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.SRC_IN)
 
         val scale = Math.min(size.toFloat() / bitmap.width, size.toFloat() / bitmap.height)
         val scaledWidth = (bitmap.width * scale).toInt()
@@ -671,8 +669,19 @@ class AppCloner(private val context: Context) {
         val left = (size - scaledWidth) / 2f
         val top = (size - scaledHeight) / 2f
 
-        val destRect = android.graphics.RectF(left, top, left + scaledWidth, top + scaledHeight)
-        canvas.drawBitmap(bitmap, null, destRect, paint)
+        val paint = android.graphics.Paint().apply {
+            isAntiAlias = true
+            isFilterBitmap = true
+        }
+        canvas.drawBitmap(bitmap, null, android.graphics.RectF(left, top, left + scaledWidth, top + scaledHeight), paint)
+
+        // Mask with DST_IN over the full canvas: an SRC_IN composite against a pre-drawn
+        // circle would leave the circle visible wherever the letterboxed content didn't cover.
+        val maskPaint = android.graphics.Paint().apply {
+            isAntiAlias = true
+            xfermode = android.graphics.PorterDuffXfermode(android.graphics.PorterDuff.Mode.DST_IN)
+        }
+        canvas.drawOval(android.graphics.RectF(0f, 0f, size.toFloat(), size.toFloat()), maskPaint)
 
         val baos = ByteArrayOutputStream()
         output.compress(Bitmap.CompressFormat.PNG, 100, baos)

--- a/app/src/test/java/com/webtoapp/core/apkbuilder/LauncherIconGenerationTest.kt
+++ b/app/src/test/java/com/webtoapp/core/apkbuilder/LauncherIconGenerationTest.kt
@@ -1,0 +1,290 @@
+package com.webtoapp.core.apkbuilder
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.util.zip.ZipFile
+import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Regression tests for the launcher icon pipeline (issue #529: a transparent-background
+ * icon image was composited twice — full-bleed background layer plus safe-zone foreground).
+ *
+ * The generated APK must back the adaptive icon with a solid derived color, keep the
+ * foreground aspect-correct inside the safe zone, and give legacy mipmap entries
+ * density-appropriate sizes instead of stretched 432px foreground padding.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class LauncherIconGenerationTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val template = ApkTemplate(context)
+
+    // --- background color derivation ---
+
+    @Test
+    fun `transparent logo with dark subject derives a white background`() {
+        val logo = transparentLogo(subjectColor = Color.BLACK)
+
+        assertThat(ApkTemplate.deriveLauncherBackgroundColor(logo)).isEqualTo(0xFFFFFFFF.toInt())
+    }
+
+    @Test
+    fun `transparent logo with light subject derives a black background`() {
+        val logo = transparentLogo(subjectColor = Color.WHITE)
+
+        assertThat(ApkTemplate.deriveLauncherBackgroundColor(logo)).isEqualTo(0xFF000000.toInt())
+    }
+
+    @Test
+    fun `fully transparent image falls back to white`() {
+        val bitmap = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888)
+
+        assertThat(ApkTemplate.deriveLauncherBackgroundColor(bitmap)).isEqualTo(0xFFFFFFFF.toInt())
+    }
+
+    @Test
+    fun `opaque image keeps its dominant border color as background`() {
+        val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(0xFF3366CC.toInt())
+
+        val derived = ApkTemplate.deriveLauncherBackgroundColor(bitmap)
+
+        assertThat(Color.alpha(derived)).isEqualTo(255)
+        assertThat(Math.abs(((derived shr 16) and 0xFF) - 0x33)).isAtMost(8)
+        assertThat(Math.abs(((derived shr 8) and 0xFF) - 0x66)).isAtMost(8)
+        assertThat(Math.abs((derived and 0xFF) - 0xCC)).isAtMost(8)
+    }
+
+    @Test
+    fun `solid background png is uniform and fully opaque`() {
+        val logo = transparentLogo(subjectColor = Color.BLACK)
+
+        val png = ApkTemplate.createSolidBackgroundIcon(logo, 432)
+        val decoded = BitmapFactory.decodeByteArray(png, 0, png.size)
+
+        assertThat(decoded.width).isEqualTo(432)
+        assertThat(decoded.height).isEqualTo(432)
+
+        val pixels = IntArray(432 * 432)
+        decoded.getPixels(pixels, 0, 432, 0, 0, 432, 432)
+        assertThat(pixels.distinct()).containsExactly(0xFFFFFFFF.toInt())
+    }
+
+    // --- foreground / legacy geometry ---
+
+    @Test
+    fun `adaptive foreground preserves aspect ratio inside the safe zone`() {
+        val logo = transparentLogo(subjectColor = Color.BLACK)
+
+        val png = template.createAdaptiveForegroundIcon(logo, 432)
+        val decoded = BitmapFactory.decodeByteArray(png, 0, png.size)
+
+        assertThat(decoded.width).isEqualTo(432)
+        assertThat(decoded.height).isEqualTo(432)
+
+        val bounds = opaqueBounds(decoded)
+        val width = bounds.width().toFloat()
+        val height = bounds.height().toFloat()
+
+        assertThat(width / height).isWithin(0.2f).of(2f)
+        // Safe zone is the central 72% (288px of 432); the content must not spill out.
+        assertThat(bounds.left).isAtLeast(72 - 8)
+        assertThat(bounds.top).isAtLeast(72 - 8)
+        assertThat(bounds.right).isAtMost(360 + 8)
+        assertThat(bounds.bottom).isAtMost(360 + 8)
+    }
+
+    @Test
+    fun `square foreground fills the safe zone`() {
+        val logo = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        logo.eraseColor(Color.BLACK)
+
+        val png = template.createAdaptiveForegroundIcon(logo, 432)
+        val bounds = opaqueBounds(BitmapFactory.decodeByteArray(png, 0, png.size))
+
+        assertThat(bounds.width().toFloat()).isWithin(8f).of(288f)
+        assertThat(bounds.height().toFloat()).isWithin(8f).of(288f)
+    }
+
+    @Test
+    fun `legacy launcher png letterboxes instead of stretching`() {
+        val logo = transparentLogo(subjectColor = Color.BLACK)
+
+        val png = template.scaleBitmapToPng(logo, 48)
+        val decoded = BitmapFactory.decodeByteArray(png, 0, png.size)
+
+        assertThat(decoded.width).isEqualTo(48)
+        assertThat(decoded.height).isEqualTo(48)
+
+        val bounds = opaqueBounds(decoded)
+        assertThat(bounds.width().toFloat() / bounds.height()).isWithin(0.25f).of(2f)
+    }
+
+    @Test
+    fun `round icon letterboxes inside the circle mask`() {
+        val logo = transparentLogo(subjectColor = Color.BLACK)
+
+        val png = template.createRoundIcon(logo, 96)
+        val decoded = BitmapFactory.decodeByteArray(png, 0, png.size)
+
+        assertThat(decoded.width).isEqualTo(96)
+        assertThat(decoded.height).isEqualTo(96)
+
+        // A 2:1 wide logo inside a circle stays wider than tall, and the circle corners stay clear.
+        val bounds = opaqueBounds(decoded)
+        assertThat(bounds.width()).isGreaterThan(bounds.height())
+        assertThat(decoded.getPixel(2, 2) ushr 24).isEqualTo(0)
+    }
+
+    // --- full pipeline against the real shell template ---
+
+    @Test
+    fun `modifyApk writes a solid background and layer-correct icon entries`() {
+        val templateApk = resolveFile(
+            "src/main/assets/template/webview_shell.apk",
+            "app/src/main/assets/template/webview_shell.apk"
+        )
+        assumeTrue("shell template not built — run ':app:syncShellTemplateApk' first", templateApk.exists())
+
+        val logoFile = temp.newFile("icon.png")
+        transparentLogo(subjectColor = Color.BLACK)
+            .compress(Bitmap.CompressFormat.PNG, 100, logoFile.outputStream())
+
+        val outputApk = temp.newFile("generated.apk")
+        val config = ApkConfig(
+            meta = MetaBlock(
+                appName = "IconFix",
+                packageName = "com.example.iconfix",
+                targetUrl = "https://example.com",
+                appType = "WEB"
+            )
+        )
+
+        runBlocking {
+            ApkBuilder(context).modifyApk(
+                sourceApk = templateApk,
+                outputApk = outputApk,
+                config = config,
+                iconPath = logoFile.absolutePath,
+                splashMediaPath = null
+            ) { _, _ -> }
+        }
+
+        assertThat(outputApk.exists()).isTrue()
+        assertThat(outputApk.length()).isGreaterThan(0)
+
+        val specs = ArscRebuilder().let { rebuilder ->
+            val arsc = ZipFile(templateApk).use {
+                it.getInputStream(it.getEntry("resources.arsc")).readBytes()
+            }
+            rebuilder.rebuildWithNewAppNameAndIcons(arsc, "IconFix", replaceIcons = true)
+            rebuilder.getLastDiscoveredIconSpecs()
+        }
+
+        assertThat(specs.filter { it.kind == ArscRebuilder.LauncherIconKind.FOREGROUND }).isNotEmpty()
+        assertThat(specs.filter { it.kind == ArscRebuilder.LauncherIconKind.LAUNCHER }).isNotEmpty()
+        assertThat(specs.filter { it.kind == ArscRebuilder.LauncherIconKind.ROUND }).isNotEmpty()
+
+        ZipFile(outputApk).use { zip ->
+            // The background layer must be a uniform opaque color, not the user image.
+            val bgEntry = zip.getEntry(ArscRebuilder.LAUNCHER_BACKGROUND_DRAWABLE_PATH)
+            assertThat(bgEntry).isNotNull()
+            val bgBytes = zip.getInputStream(bgEntry).readBytes()
+            val bg = BitmapFactory.decodeByteArray(bgBytes, 0, bgBytes.size)
+            val bgPixels = IntArray(bg.width * bg.height)
+            bg.getPixels(bgPixels, 0, bg.width, 0, 0, bg.width, bg.height)
+            assertThat(bgPixels.distinct()).hasSize(1)
+            assertThat(bgPixels.first() ushr 24).isEqualTo(255)
+            // Dark subject on a transparent logo must get a light backing.
+            assertThat(bgPixels.first()).isEqualTo(0xFFFFFFFF.toInt())
+
+            specs.forEach { spec ->
+                val entry = zip.getEntry(spec.path)
+                assertThat(entry).isNotNull()
+                val entryBytes = zip.getInputStream(entry).readBytes()
+                val bitmap = BitmapFactory.decodeByteArray(entryBytes, 0, entryBytes.size)
+
+                when (spec.kind) {
+                    ArscRebuilder.LauncherIconKind.FOREGROUND -> {
+                        assertThat(bitmap.width).isEqualTo(432)
+                        assertThat(bitmap.height).isEqualTo(432)
+                        val bounds = opaqueBounds(bitmap)
+                        assertThat(bounds.width().toFloat() / bounds.height()).isWithin(0.25f).of(2f)
+                    }
+                    ArscRebuilder.LauncherIconKind.LAUNCHER,
+                    ArscRebuilder.LauncherIconKind.ROUND -> {
+                        assertThat(bitmap.width).isEqualTo(bitmap.height)
+                        assertThat(bitmap.width).isIn(expectedLegacySizes())
+                        val bounds = opaqueBounds(bitmap)
+                        assertThat(bounds.width().toFloat() / bounds.height()).isWithin(0.3f).of(2f)
+                    }
+                }
+            }
+        }
+    }
+
+    // --- helpers ---
+
+    /** 2:1 wide logo with a transparent background — the shape from issue #529. */
+    private fun transparentLogo(subjectColor: Int): Bitmap {
+        val bitmap = Bitmap.createBitmap(200, 100, Bitmap.Config.ARGB_8888)
+        val pixels = IntArray(200 * 100) { Color.TRANSPARENT }
+        for (y in 25 until 75) {
+            for (x in 50 until 150) {
+                pixels[y * 200 + x] = subjectColor
+            }
+        }
+        bitmap.setPixels(pixels, 0, 200, 0, 0, 200, 100)
+        return bitmap
+    }
+
+    private fun opaqueBounds(bitmap: Bitmap): android.graphics.Rect {
+        var left = bitmap.width
+        var top = bitmap.height
+        var right = -1
+        var bottom = -1
+        for (y in 0 until bitmap.height) {
+            for (x in 0 until bitmap.width) {
+                if ((bitmap.getPixel(x, y) ushr 24) >= 128) {
+                    if (x < left) left = x
+                    if (x > right) right = x
+                    if (y < top) top = y
+                    if (y > bottom) bottom = y
+                }
+            }
+        }
+        assertThat(right).isGreaterThan(left)
+        assertThat(bottom).isGreaterThan(top)
+        return android.graphics.Rect(left, top, right + 1, bottom + 1)
+    }
+
+    private fun expectedLegacySizes() = setOf(36, 48, 72, 96, 144, 192)
+
+    private fun resolveFile(vararg candidates: String): File {
+        for (c in candidates) {
+            val f = File(c)
+            if (f.exists()) return f
+            val f2 = File(System.getProperty("user.dir"), c)
+            if (f2.exists()) return f2
+        }
+        return File(candidates.first())
+    }
+}


### PR DESCRIPTION
## Problem

#529: when the user picks an icon image with a transparent background, the generated app's launcher icon shows the image **duplicated behind the subject**.

## Root cause

`ApkBuilder.modifyApk` used the user's image as **both** adaptive-icon layers:

- the ARSC patch repointed `color/ic_launcher_background` to `res/ic_launcher_bg.png`, and the builder wrote a full-bleed copy of the user image there (`createFullBleedBackgroundIcon`);
- the foreground layer drew the whole image squeezed into the central safe zone.

Launchers composite background + foreground, so the visible icon was "zoomed center of the image behind + the entire image floating in front". Transparent PNGs made this unmistakable (the reported duplication); opaque images were subtly broken too (a shrunken copy of the picture pasted over itself).

Two adjacent defects surfaced while fixing this:

1. `createAdaptiveForegroundIcon` stretched non-square images to a square (distortion); legacy mipmaps and round icons stretched as well.
2. The ARSC scan only collected `drawable/ic_launcher_foreground` paths. Legacy `mipmap/ic_launcher` / `ic_launcher_round` PNG entries carry R8-obfuscated names in the template, matched nothing, and were copied through unchanged — so pre-Android-8 devices kept the template's default icon instead of the user's.

## Fix

- **Solid derived background.** New `ApkTemplate.createSolidBackgroundIcon` / `deriveLauncherBackgroundColor`: dominant border color for mostly-opaque images (keeps the full-tile look), white/black by luminance contrast against the dominant color for transparent logos, white if fully transparent. The ARSC patch machinery is unchanged — only the bytes written to `res/ic_launcher_bg.png` differ.
- **Aspect-fit everywhere.** Foreground now letterboxes inside the 72/108 safe zone; legacy mipmaps and round icons letterbox instead of stretching.
- **Correct round masking.** Round icons are masked with `DST_IN` over the full canvas. The previous draw-oval-then-`SRC_IN` composite leaves the pre-drawn circle visible wherever letterboxed content doesn't cover — latent before (stretch hid it), exposed by aspect-fit.
- **Complete icon discovery.** `ArscRebuilder.findIconPathIndices` now returns kind (`FOREGROUND` / `LAUNCHER` / `ROUND`) + density for every bitmap path (XML adaptive definitions still kept). `ApkBuilder` writes layer-appropriate, density-appropriate bitmaps per obfuscated entry (36/48/72/96/144/192 px), instead of padding every entry with a 432px safe-zone foreground.
- **AppCloner parity.** Cloned APKs get the same solid-background treatment for `ic_launcher_background*` entries instead of the user image.
- Removed dead code: uncalled `replaceIconEntry` / `addAdaptiveIconReplacementPngs`.

Host-only packages (`core/apkbuilder`, `core/appmodifier`) — not in `syncShellRuntimeSources`; template bytes unchanged, no template rebuild needed.

## Verification

New `LauncherIconGenerationTest` (Robolectric, native graphics):

- pixel-level unit tests: background derivation rules (dark/light/transparent/opaque), uniform+opaque solid background PNG, foreground aspect ratio inside the safe zone, legacy letterboxing, round-icon corner transparency;
- integration test runs a real `modifyApk` against the committed shell template with a transparent 2:1 logo and asserts, on the generated APK: uniform opaque background, every discovered icon entry present, foreground 432px aspect-correct, legacy entries square at density sizes with preserved aspect ratio.

Full `:app:testStandardDebugUnitTest` suite passes locally; rendered composites (launcher circle/squircle) verified visually — single subject on clean backing, no duplication.

Fixes #529