### PR TITLE
fix(webview): download documents instead of black-screening; steady loopback downloads

### DIFF
--- a/app/src/main/java/com/webtoapp/core/webview/DocumentDownloadPolicy.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/DocumentDownloadPolicy.kt
@@ -1,0 +1,76 @@
+package com.webtoapp.core.webview
+
+/**
+ * Classifies navigations and download URLs that need special handling around
+ * Chromium's inability to render documents inline (issue #601: tapping a PDF
+ * served by the embedded webserver navigated the main frame to an unrenderable
+ * response — a black page — and never reached the download listener).
+ *
+ * Kept free of Android dependencies so it is unit-testable on the plain JVM.
+ */
+object DocumentDownloadPolicy {
+
+    /** Document types Chromium cannot display inline; served without a
+     *  Content-Disposition they navigate to a blank frame instead of downloading. */
+    private val UNRENDERABLE_EXTENSIONS = setOf(
+        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
+        "zip", "rar", "7z", "epub", "apk"
+    )
+
+    private val MIME_BY_EXTENSION = mapOf(
+        "pdf" to "application/pdf",
+        "doc" to "application/msword",
+        "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xls" to "application/vnd.ms-excel",
+        "xlsx" to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ppt" to "application/vnd.ms-powerpoint",
+        "pptx" to "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "zip" to "application/zip",
+        "rar" to "application/vnd.rar",
+        "7z" to "application/x-7z-compressed",
+        "epub" to "application/epub+zip",
+        "apk" to "application/vnd.android.package-archive"
+    )
+
+    /**
+     * True for http(s) main-frame targets the WebView would render as a blank or
+     * garbled frame; those navigations should be handed to the download pipeline.
+     */
+    fun isUnrenderableDocumentUrl(url: String): Boolean {
+        if (!url.startsWith("http://") && !url.startsWith("https://")) return false
+        val ext = urlExtension(url) ?: return false
+        return ext in UNRENDERABLE_EXTENSIONS
+    }
+
+    fun mimeTypeFor(url: String): String =
+        urlExtension(url)?.let { MIME_BY_EXTENSION[it] } ?: "application/octet-stream"
+
+    /** The app's own embedded runtimes bind these hosts; downloads from them are best
+     *  fetched in-process instead of through the out-of-process system DownloadManager. */
+    fun isLoopbackUrl(url: String): Boolean {
+        val host = uriHost(url) ?: return false
+        return host == "127.0.0.1" || host == "localhost" || host == "::1"
+    }
+
+    private fun urlExtension(url: String): String? {
+        var segment = url.substringBefore('#').substringBefore('?')
+        val slash = segment.lastIndexOf('/')
+        if (slash >= 0) segment = segment.substring(slash + 1)
+        val dot = segment.lastIndexOf('.')
+        if (dot <= 0 || dot == segment.length - 1) return null
+        val ext = segment.substring(dot + 1).lowercase()
+        return ext.ifBlank { null }?.takeIf { it.length <= 5 }
+    }
+
+    private fun uriHost(url: String): String? {
+        val schemeEnd = url.indexOf("://")
+        if (schemeEnd < 0) return null
+        var rest = url.substring(schemeEnd + 3)
+        rest = rest.substringBefore('/').substringBefore('?').substringBefore('#')
+        rest = rest.substringAfterLast('@')
+        if (rest.startsWith("[")) {
+            return rest.substringBefore(']').removePrefix("[").lowercase()
+        }
+        return rest.substringBefore(':').lowercase()
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -1140,6 +1140,24 @@ class WebViewManager(
     private val LOOPBACK_MAIN_FRAME_MAX_RETRIES = 3
     private val LOOPBACK_MAIN_FRAME_RETRY_DELAY_MS = 150L
 
+    // A download-intercepted navigation surfaces as an aborted main-frame load; remember
+    // the URL so the loopback auto-retry does not re-navigate into the same download.
+    private var lastDownloadInterceptedUrl: String? = null
+    private var lastDownloadInterceptedAtMs = 0L
+    private val DOWNLOAD_INTERCEPT_RETRY_SUPPRESS_MS = 10_000L
+
+    private fun noteDownloadInterceptedUrl(url: String) {
+        lastDownloadInterceptedUrl = url
+        lastDownloadInterceptedAtMs = android.os.SystemClock.elapsedRealtime()
+    }
+
+    private fun wasRecentlyInterceptedForDownload(url: String): Boolean {
+        val intercepted = lastDownloadInterceptedUrl ?: return false
+        return url == intercepted &&
+            android.os.SystemClock.elapsedRealtime() - lastDownloadInterceptedAtMs <
+                DOWNLOAD_INTERCEPT_RETRY_SUPPRESS_MS
+    }
+
     private fun cancelLoopbackMainFrameRetry() {
         val pending = loopbackMainFrameRetryRunnable
         val view = loopbackMainFrameRetryView
@@ -1587,6 +1605,7 @@ class WebViewManager(
 
             if (config.downloadEnabled) {
                 setDownloadListener { url, userAgent, contentDisposition, mimeType, contentLength ->
+                    noteDownloadInterceptedUrl(url)
                     callbacks.onDownloadStart(url, userAgent, contentDisposition, mimeType, contentLength)
                 }
 
@@ -2003,6 +2022,25 @@ class WebViewManager(
                         return false
                     }
                     callbacks.onExternalLink(url)
+                    return true
+                }
+
+                // Chromium cannot render documents like PDF inline; letting the main frame
+                // navigate there yields a black page and never fires the download listener.
+                // Hand the navigation straight to the download pipeline instead (#601).
+                if (request.isForMainFrame &&
+                    config.downloadEnabled &&
+                    DocumentDownloadPolicy.isUnrenderableDocumentUrl(url)
+                ) {
+                    AppLogger.d("WebViewManager", "Intercepting unrenderable document as download: $url")
+                    noteDownloadInterceptedUrl(url)
+                    callbacks.onDownloadStart(
+                        url,
+                        view?.settings?.userAgentString ?: "",
+                        "",
+                        DocumentDownloadPolicy.mimeTypeFor(url),
+                        -1L
+                    )
                     return true
                 }
 
@@ -2945,6 +2983,10 @@ class WebViewManager(
     ): Boolean {
         if (!isLocalRuntimeUrl(failedUrl)) return false
         if (isCleartextBlockedError(errorCode, rawDescription, normalizedDescription)) return false
+        // An aborted load of a document URL (or of a URL the download pipeline just took)
+        // is a download interception, not a server that failed to come up — never re-navigate.
+        if (wasRecentlyInterceptedForDownload(failedUrl)) return false
+        if (DocumentDownloadPolicy.isUnrenderableDocumentUrl(failedUrl)) return false
 
         val merged = "$rawDescription $normalizedDescription".uppercase()
         return errorCode == WebViewClient.ERROR_UNKNOWN ||

--- a/app/src/main/java/com/webtoapp/util/DownloadHelper.kt
+++ b/app/src/main/java/com/webtoapp/util/DownloadHelper.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.core.i18n.Strings
+import com.webtoapp.core.webview.DocumentDownloadPolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -284,6 +285,17 @@ object DownloadHelper {
             return
         }
 
+        // Downloads from the app's own loopback webserver skip the system DownloadManager:
+        // it runs out-of-process and adds OEM failure modes (disabled/throttled provider),
+        // while the in-app client reaches the embedded server directly with cookies and
+        // headers attached. Generated shells keep targetSdk 28 (legacy storage), so the
+        // in-app writer can still place files in the public Downloads directory.
+        if (DocumentDownloadPolicy.isLoopbackUrl(safeUrl) && runsAsGeneratedApp(context)) {
+            AppLogger.d(TAG, "Loopback URL routed to in-app downloader: $safeUrl")
+            downloadInApp(context, safeUrl, userAgent, fileName, mimeType, scope, downloadLocationMode, customDownloadDirUri)
+            return
+        }
+
         val downloadId = try {
             val request = buildDownloadManagerRequest(
                 context = context,
@@ -398,6 +410,10 @@ object DownloadHelper {
             "android.permission.DOWNLOAD_WITHOUT_NOTIFICATION"
         ) == PackageManager.PERMISSION_GRANTED
     }
+
+    /** Generated shells always target SDK 28 (fork+exec runtimes); the host app targets 35+. */
+    private fun runsAsGeneratedApp(context: Context): Boolean =
+        context.applicationInfo.targetSdkVersion <= 28
 
     private fun downloadInApp(
         context: Context,

--- a/app/src/test/java/com/webtoapp/core/webview/DocumentDownloadPolicyTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/DocumentDownloadPolicyTest.kt
@@ -1,0 +1,54 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DocumentDownloadPolicyTest {
+
+    @Test
+    fun `document urls are flagged as unrenderable`() {
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("http://127.0.0.1:8080/report.pdf")).isTrue()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/files/合同.DOCX")).isTrue()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/app.apk?token=1")).isTrue()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/a/b/archive.zip#frag")).isTrue()
+    }
+
+    @Test
+    fun `renderable urls are not flagged`() {
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("http://127.0.0.1:8080/")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/index.html")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/api/data.json")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/docs/page.php?id=report.pdf")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://example.com/img.photo.jpg")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("https://cdn.example.com/v1.2/app")).isFalse()
+    }
+
+    @Test
+    fun `non http schemes are never flagged`() {
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("file:///docs/report.pdf")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("content://media/file.pdf")).isFalse()
+        assertThat(DocumentDownloadPolicy.isUnrenderableDocumentUrl("blob:https://example.com/abc")).isFalse()
+    }
+
+    @Test
+    fun `mime types map to the detected extension`() {
+        assertThat(DocumentDownloadPolicy.mimeTypeFor("https://example.com/a.pdf"))
+            .isEqualTo("application/pdf")
+        assertThat(DocumentDownloadPolicy.mimeTypeFor("https://example.com/a.PDF"))
+            .isEqualTo("application/pdf")
+        assertThat(DocumentDownloadPolicy.mimeTypeFor("https://example.com/a.apk"))
+            .isEqualTo("application/vnd.android.package-archive")
+        assertThat(DocumentDownloadPolicy.mimeTypeFor("https://example.com/a.weird"))
+            .isEqualTo("application/octet-stream")
+    }
+
+    @Test
+    fun `loopback hosts are detected`() {
+        assertThat(DocumentDownloadPolicy.isLoopbackUrl("http://127.0.0.1:8080/file.pdf")).isTrue()
+        assertThat(DocumentDownloadPolicy.isLoopbackUrl("http://localhost:3000/")).isTrue()
+        assertThat(DocumentDownloadPolicy.isLoopbackUrl("http://[::1]:9000/x")).isTrue()
+        assertThat(DocumentDownloadPolicy.isLoopbackUrl("https://example.com/file")).isFalse()
+        assertThat(DocumentDownloadPolicy.isLoopbackUrl("http://127.0.0.1.example.com/")).isFalse()
+        assertThat(DocumentDownloadPolicy.isLoopbackUrl("file:///localhost/x")).isFalse()
+    }
+}


### PR DESCRIPTION
## Problem

Part 1 of #601: in a generated WebView app, tapping a link to a PDF (or similar document) served by the app's own webserver black-screened the app, felt stuck, and eventually reported "download failed".

## Root cause

Three interacting defects:

1. **Inline document navigation.** Chromium WebView cannot render PDFs. A PDF served *inline* (no `Content-Disposition: attachment`) never fires `setDownloadListener`; instead the main frame navigates to the PDF URL and renders nothing — the black screen.
2. **Loopback auto-retry fights downloads.** `shouldRetryLoopbackMainFrameRequest` includes `ERR_ABORTED`. A download-intercepted navigation surfaces as an aborted main-frame load, so the retry logic re-navigated to the file URL up to 3 times, re-triggering the download each pass while the WebView sat on a black page.
3. **System DownloadManager for loopback URLs.** Downloads from `127.0.0.1:<port>` were enqueued into the out-of-process system DownloadManager, which adds OEM failure modes (disabled/throttled provider) the in-app client doesn't have.

## Fix

- **`DocumentDownloadPolicy`** (new, Android-free, pure-JVM unit-tested): classifies http(s) URLs whose extension Chromium cannot render inline (`pdf`, office docs, `zip/rar/7z`, `epub`, `apk`) and detects loopback hosts.
- **`WebViewManager.shouldOverrideUrlLoading`**: main-frame navigations to unrenderable documents go straight to `onDownloadStart` (download instead of black frame). The explicit *open external links in browser* configuration still wins for external URLs, so configured behavior is unchanged there.
- **Retry suppression**: `setDownloadListener` records the intercepted URL (10 s window) and `shouldRetryLoopbackMainFrameRequest` skips URLs that were just handed to the download pipeline or look like document URLs — an intercepted download is no longer re-navigated in a loop. Genuine server-startup retries (connection refused/reset/timeout) are unaffected.
- **`DownloadHelper.downloadWithManager`**: on generated apps (targetSdk 28 — legacy storage, per the shell invariant) loopback downloads use the in-app downloader, which reaches the embedded server directly with cookies/UA/Origin attached and shows progress/complete notifications. The host app (targetSdk 35) keeps the system DownloadManager, which handles scoped storage correctly.

## Verification

- New `DocumentDownloadPolicyTest` (plain JUnit): extension/scheme/host classification including query strings, uppercase extensions, `file://`/`blob:` rejection, loopback vs. lookalike hosts.
- Full `:app:testStandardDebugUnitTest` suite green; `:shell:compileReleaseKotlin` green (both consumers are shell-synced).
- Shell-synced runtime change: template rebuilt locally via `:shell:assembleRelease` + `:app:syncShellTemplateApk` (the template asset is gitignored; the release workflow rebuilds it from source).

Remaining parts of #601 (Google sign-in flow, preview crash) are separate and not addressed here.

Fixes part 1 of #601