### PR TITLE
fix(webview): keep OAuth sign-in inside the app WebView and let it complete

### DIFF
--- a/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/BrowserEngineCallback.kt
@@ -46,7 +46,11 @@ interface BrowserEngineCallback {
 
     fun onConsoleMessage(level: Int, message: String, sourceId: String, lineNumber: Int) {}
 
-    fun onNewWindow(resultMsg: android.os.Message?) {}
+    /**
+     * A popup window was requested. Return true when the host renders the popup transport;
+     * false lets the WebViewManager fall back to loading the popup URL in the same window.
+     */
+    fun onNewWindow(resultMsg: android.os.Message?): Boolean = false
 
     /**
      * Request Android runtime permissions on behalf of the engine. GeckoView surfaces these via

--- a/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/EngineViewFactory.kt
@@ -201,8 +201,8 @@ fun WebViewCallbacks.toBrowserEngineCallback(): BrowserEngineCallback {
             source.onConsoleMessage(level, message, sourceId, lineNumber)
         }
 
-        override fun onNewWindow(resultMsg: android.os.Message?) {
-            source.onNewWindow(resultMsg)
+        override fun onNewWindow(resultMsg: android.os.Message?): Boolean {
+            return source.onNewWindow(resultMsg)
         }
 
         override fun onAndroidPermissionsRequest(permissions: Array<String>, onResult: (Boolean) -> Unit) {

--- a/app/src/main/java/com/webtoapp/core/engine/SystemWebViewEngine.kt
+++ b/app/src/main/java/com/webtoapp/core/engine/SystemWebViewEngine.kt
@@ -71,8 +71,8 @@ class SystemWebViewEngine(
                 callback.onConsoleMessage(level, message, sourceId, lineNumber)
             }
 
-            override fun onNewWindow(resultMsg: android.os.Message?) {
-                callback.onNewWindow(resultMsg)
+            override fun onNewWindow(resultMsg: android.os.Message?): Boolean {
+                return callback.onNewWindow(resultMsg)
             }
         }
 

--- a/app/src/main/java/com/webtoapp/core/webview/OAuthProviderHosts.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/OAuthProviderHosts.kt
@@ -1,0 +1,49 @@
+package com.webtoapp.core.webview
+
+/**
+ * Hosts that carry cross-site authentication / challenge flows.
+ *
+ * Sign-in must complete inside the app's own WebView: the site session lives in this
+ * WebView's cookie jar, so routing an OAuth navigation to an external browser can never
+ * hand the session back (#601 — "sign-in never completes"). Embedded provider frames
+ * additionally need third-party cookies, which Android WebView disables by default.
+ *
+ * Kept free of Android dependencies so it is unit-testable on the plain JVM.
+ */
+object OAuthProviderHosts {
+
+    val HOST_SUFFIXES = setOf(
+        "accounts.google.com",
+        "accounts.youtube.com",
+        "myaccount.google.com",
+
+        "www.facebook.com",
+        "m.facebook.com",
+
+        "appleid.apple.com",
+
+        "login.microsoftonline.com",
+        "login.live.com",
+
+        "github.com",
+
+        "api.twitter.com",
+        "api.x.com"
+    )
+
+    fun isOAuthHost(url: String): Boolean {
+        val host = extractHost(url) ?: return false
+        return HOST_SUFFIXES.any { suffix ->
+            host == suffix || host.endsWith(".$suffix")
+        }
+    }
+
+    fun extractHost(url: String): String? {
+        val schemeEnd = url.indexOf("://")
+        if (schemeEnd <= 0) return null
+        var rest = url.substring(schemeEnd + 3)
+        rest = rest.substringBefore('/').substringBefore('?').substringBefore('#')
+        rest = rest.substringAfterLast('@')
+        return rest.substringBefore(':').lowercase().ifEmpty { null }
+    }
+}

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewCallbacks.kt
@@ -37,7 +37,12 @@ interface WebViewCallbacks {
 
     fun onUrlChanged(webView: WebView?, url: String?) {}
 
-    fun onNewWindow(resultMsg: android.os.Message?) {}
+    /**
+     * A popup window was requested (newWindowBehavior = POPUP_WINDOW). Return true when the
+     * host actually renders the popup transport; false makes WebViewManager fall back to
+     * loading the popup URL in the same window so the navigation is never silently dropped.
+     */
+    fun onNewWindow(resultMsg: android.os.Message?): Boolean = false
 
     fun onRenderProcessGone(didCrash: Boolean) {}
 

--- a/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
+++ b/app/src/main/java/com/webtoapp/core/webview/WebViewManager.kt
@@ -134,25 +134,7 @@ class WebViewManager(
             "funcaptcha.com"
         )
 
-        private val OAUTH_HOST_SUFFIXES = setOf(
-
-            "accounts.google.com",
-            "accounts.youtube.com",
-            "myaccount.google.com",
-
-            "www.facebook.com",
-            "m.facebook.com",
-
-            "appleid.apple.com",
-
-            "login.microsoftonline.com",
-            "login.live.com",
-
-            "github.com",
-
-            "api.twitter.com",
-            "api.x.com"
-        )
+        private val OAUTH_HOST_SUFFIXES get() = OAuthProviderHosts.HOST_SUFFIXES
 
         private val MAP_TILE_HOST_SUFFIXES = setOf(
             "tile.openstreetmap.org",
@@ -1146,6 +1128,10 @@ class WebViewManager(
     private var lastDownloadInterceptedAtMs = 0L
     private val DOWNLOAD_INTERCEPT_RETRY_SUPPRESS_MS = 10_000L
 
+    // Set once an auth/challenge provider is visited; third-party cookies stay on for
+    // this WebView session so embedded sign-in frames can complete (#601).
+    private var thirdPartyCookiesForceEnabled = false
+
     private fun noteDownloadInterceptedUrl(url: String) {
         lastDownloadInterceptedUrl = url
         lastDownloadInterceptedAtMs = android.os.SystemClock.elapsedRealtime()
@@ -2014,6 +2000,14 @@ class WebViewManager(
                     }
                 }
 
+                // OAuth sign-in must complete inside this WebView: the site session lives
+                // in this WebView's cookie jar, so handing the login navigation to an
+                // external browser (openExternalLinks) can never sign the app in (#601).
+                if (request.isForMainFrame && isOAuthServiceRequest(url)) {
+                    AppLogger.d("WebViewManager", "Keeping OAuth navigation in-app: $url")
+                    return false
+                }
+
                 if (config.openExternalLinks && isExternalUrl(url, view?.url)) {
                     // For local-file apps, only open externally on a genuine user gesture.
                     // Otherwise an automatic entry/redirect navigation gets hijacked and the
@@ -2055,6 +2049,19 @@ class WebViewManager(
                     userscriptInjectionState.remove(it)
                     pagePhaseExecutionState.remove(it)
                     cancelDeferredExtensionModuleInjection(it)
+                }
+
+                // Embedded sign-in frames ("Sign in with Google" buttons, captcha
+                // challenges) are cross-origin iframes that need third-party cookies,
+                // which WebView disables by default. Once the user reaches a login or
+                // challenge provider, enable them for this WebView's session so the
+                // flow can complete even under the default privacy config (#601).
+                if (view != null && url != null && !thirdPartyCookiesForceEnabled &&
+                    (isOAuthServiceRequest(url) || isCaptchaServiceRequest(url))
+                ) {
+                    thirdPartyCookiesForceEnabled = true
+                    CookieManager.getInstance().setAcceptThirdPartyCookies(view, true)
+                    AppLogger.d("WebViewManager", "Third-party cookies enabled for auth/challenge flow: $url")
                 }
 
                 view?.let { wv ->
@@ -3040,10 +3047,7 @@ class WebViewManager(
     }
 
     private fun isOAuthServiceRequest(url: String): Boolean {
-        val host = extractHostFromUrl(url) ?: return false
-        return OAUTH_HOST_SUFFIXES.any { suffix ->
-            host == suffix || host.endsWith(".$suffix")
-        }
+        return OAuthProviderHosts.isOAuthHost(url)
     }
 
     private fun shouldUseConservativeScriptMode(pageUrl: String?): Boolean {
@@ -3460,29 +3464,38 @@ class WebViewManager(
 
                 val originalWebView = view
 
-                return when (config.newWindowBehavior) {
-                    NewWindowBehavior.SAME_WINDOW -> {
+                // Load the popup URL into the main WebView through a transport.
+                fun openInSameWindow(): Boolean {
+                    val transport = resultMsg?.obj as? WebView.WebViewTransport
+                    if (transport != null) {
 
-                        val transport = resultMsg?.obj as? WebView.WebViewTransport
-                        if (transport != null) {
-
-                            val tempWebView = WebView(context)
-                            tempWebView.webViewClient = object : WebViewClient() {
-                                override fun shouldOverrideUrlLoading(tempView: WebView?, request: WebResourceRequest?): Boolean {
-                                    val url = request?.url?.toString()
-                                    if (url != null) {
-                                        val safeUrl = normalizeHttpUrlForSecurity(url)
-                                        originalWebView.loadUrl(safeUrl)
-                                        tempView?.destroy()
-                                    }
-                                    return true
+                        val tempWebView = WebView(context)
+                        tempWebView.webViewClient = object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(tempView: WebView?, request: WebResourceRequest?): Boolean {
+                                val url = request?.url?.toString()
+                                if (url != null) {
+                                    val safeUrl = normalizeHttpUrlForSecurity(url)
+                                    originalWebView.loadUrl(safeUrl)
+                                    tempView?.destroy()
                                 }
+                                return true
                             }
-                            transport.webView = tempWebView
-                            resultMsg.sendToTarget()
                         }
-                        true
+                        transport.webView = tempWebView
+                        resultMsg.sendToTarget()
                     }
+                    return true
+                }
+
+                // A sign-in popup must stay attached to this WebView's session: opening it
+                // in an external browser or dropping it breaks the OAuth round-trip (#601).
+                if (href != null && isOAuthServiceRequest(href)) {
+                    AppLogger.d("WebViewManager", "OAuth popup kept in-app: $href")
+                    return openInSameWindow()
+                }
+
+                return when (config.newWindowBehavior) {
+                    NewWindowBehavior.SAME_WINDOW -> openInSameWindow()
                     NewWindowBehavior.EXTERNAL_BROWSER -> {
 
                         val transport = resultMsg?.obj as? WebView.WebViewTransport
@@ -3511,9 +3524,13 @@ class WebViewManager(
                         true
                     }
                     NewWindowBehavior.POPUP_WINDOW -> {
-
-                        callbacks.onNewWindow(resultMsg)
-                        true
+                        // No host currently renders a real popup window; fall back to the
+                        // same-window transport instead of silently swallowing the popup.
+                        if (callbacks.onNewWindow(resultMsg)) {
+                            true
+                        } else {
+                            openInSameWindow()
+                        }
                     }
                     NewWindowBehavior.BLOCK -> {
 

--- a/app/src/test/java/com/webtoapp/core/webview/OAuthProviderHostsTest.kt
+++ b/app/src/test/java/com/webtoapp/core/webview/OAuthProviderHostsTest.kt
@@ -1,0 +1,38 @@
+package com.webtoapp.core.webview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class OAuthProviderHostsTest {
+
+    @Test
+    fun `oauth provider hosts are detected`() {
+        assertThat(OAuthProviderHosts.isOAuthHost("https://accounts.google.com/o/oauth2/auth?client_id=x")).isTrue()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://accounts.google.com/")).isTrue()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://github.com/login")).isTrue()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://appleid.apple.com/auth")).isTrue()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://login.microsoftonline.com/common/oauth2")).isTrue()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://api.x.com/oauth")).isTrue()
+    }
+
+    @Test
+    fun `provider subdomains are detected`() {
+        assertThat(OAuthProviderHosts.isOAuthHost("https://www.accounts.google.com/")).isTrue()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://sub.github.com/")).isTrue()
+    }
+
+    @Test
+    fun `lookalike hosts are not detected`() {
+        assertThat(OAuthProviderHosts.isOAuthHost("https://evil-github.com/login")).isFalse()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://github.com.evil.io/x")).isFalse()
+        assertThat(OAuthProviderHosts.isOAuthHost("https://example.com/?next=https://accounts.google.com/")).isFalse()
+    }
+
+    @Test
+    fun `non http urls and garbage are not detected`() {
+        assertThat(OAuthProviderHosts.isOAuthHost("file:///x")).isFalse()
+        assertThat(OAuthProviderHosts.isOAuthHost("about:blank")).isFalse()
+        assertThat(OAuthProviderHosts.isOAuthHost("not a url")).isFalse()
+        assertThat(OAuthProviderHosts.isOAuthHost("")).isFalse()
+    }
+}


### PR DESCRIPTION
## Problem

Part 2 of #601: in a generated WebView app, Google sign-in opened in the external browser and never completed, while the same site signed in fine on the GeckoView engine.

## Root cause

A website session lives in the WebView's cookie jar. Routing the login navigation to an external browser can therefore never sign the *app* in — after auth, the browser holds the session and the app's WebView is still logged out. On top of that, two default-config settings made in-app sign-in impossible:

1. **`openExternalLinks`** routed `accounts.google.com` navigations out of the app before they could complete.
2. **Third-party cookies off by default** (`acceptThirdPartyCookies = false`): modern "Sign in with Google" buttons embed a cross-origin `accounts.google.com` iframe, which cannot authenticate without third-party cookies.

GeckoView worked because its engine presents a Firefox-style UA and keeps one shared session for everything.

## Fix

- **New `OAuthProviderHosts`** (Android-free, pure-JVM tested): classifies auth provider hosts (Google accounts, GitHub, Apple, Microsoft, Facebook, X).
- **OAuth stays in-app**: main-frame navigations to provider hosts take priority over `openExternalLinks`, so login flows always run where the session lives.
- **Third-party cookies auto-enable per session** once the user reaches an auth or captcha provider (same precedent as `enableCloudflareCompat`). Default privacy config is untouched until a login flow actually needs it.
- **Sign-in popups stay in-app**: `onCreateWindow` forces the same-window transport for OAuth popup URLs regardless of the configured popup behavior (EXTERNAL_BROWSER/BLOCK would break the round-trip). `POPUP_WINDOW` mode now falls back to the same-window transport when no host renders real popups — `WebViewCallbacks.onNewWindow` returns whether it handled the transport (nothing overrides it today; previously the popup was silently swallowed).

## Known limitation

Chromium WebViews send an `X-Requested-With: <package>` header on every request. Google primarily gates OAuth on the User-Agent (the `; wv)` marker is already stripped by default), but the header remains a secondary fingerprint that cannot be removed without fully proxying WebView traffic — out of scope here.

## Verification

- New `OAuthProviderHostsTest`: provider hosts, subdomains, lookalike-host rejection, non-http schemes.
- Full `:app:testStandardDebugUnitTest` green; `:shell:compileReleaseKotlin` green (WebViewManager/WebViewCallbacks are shell-synced).
- Shell-synced runtime change: template rebuilt via `:shell:assembleRelease` + `:app:syncShellTemplateApk` (template asset is gitignored; release workflow rebuilds from source).

Fixes part 2 of #601. Part 3 ("preview functionality is crashing") needs crash logs to investigate — asked on the issue.

Part of #601