### PR TITLE
fix(python): diagnose seccomp kills in pip installs; stop pointless retries

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -3626,6 +3626,8 @@ object Strings {
     val pyDepsInstallFailedCode: String get() = StringsD.pyDepsInstallFailedCode
     val pyDepsNoWheelHint: String get() = StringsD.pyDepsNoWheelHint
     val pyDepsSourceBuildHint: String get() = StringsD.pyDepsSourceBuildHint
+    val pyDepsKilledBySignal: String get() = StringsD.pyDepsKilledBySignal
+    val pyDepsSeccompHint: String get() = StringsD.pyDepsSeccompHint
     val pyDownloadSourceLabel: String get() = StringsD.pyDownloadSourceLabel
     val pyExtractNoBinary: String get() = StringsD.pyExtractNoBinary
     val pyExtractFailed: String get() = StringsD.pyExtractFailed
@@ -50275,6 +50277,30 @@ object StringsD {
         AppLanguage.RUSSIAN -> "Нет готового wheel для Python %s на этом устройстве, а сборка из исходного кода требует компилятор, который недоступен на устройстве. Попробуйте обновить пакет или убрать фиксацию версии."
         AppLanguage.JAPANESE -> "このデバイスの Python %s 向けにプリビルド wheel がなく、ソースビルドにはデバイス上にないコンパイラが必要です。パッケージをアップグレードするか、バージョン固定を解除してみてください。"
         AppLanguage.KOREAN -> "이 기기의 Python %s용 사전 빌드 wheel이 없으며, 소스 빌드에는 기기에 없는 컴파일러가 필요합니다. 패키지를 업그레이드하거나 버전 고정을 제거해 보세요."
+    }
+    val pyDepsKilledBySignal: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "依赖安装进程被系统终止(信号 %d / %s)"
+        AppLanguage.ENGLISH -> "The dependency install process was killed by the system (signal %d / %s)"
+        AppLanguage.ARABIC -> "تم إنهاء عملية تثبيت التبعيات بواسطة النظام (الإشارة %d / %s)"
+        AppLanguage.PORTUGUESE -> "O processo de instalação de dependências foi encerrado pelo sistema (sinal %d / %s)"
+        AppLanguage.SPANISH -> "El proceso de instalación de dependencias fue terminado por el sistema (señal %d / %s)"
+        AppLanguage.FRENCH -> "Le processus d'installation des dépendances a été tué par le système (signal %d / %s)"
+        AppLanguage.GERMAN -> "Der Abhängigkeitsinstallationsprozess wurde vom System beendet (Signal %d / %s)"
+        AppLanguage.RUSSIAN -> "Процесс установки зависимостей был завершён системой (сигнал %d / %s)"
+        AppLanguage.JAPANESE -> "依存関係のインストールプロセスがシステムによって強制終了されました (シグナル %d / %s)"
+        AppLanguage.KOREAN -> "의존성 설치 프로세스가 시스템에 의해 종료되었습니다 (시그널 %d / %s)"
+    }
+    val pyDepsSeccompHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "内置 Python %s 运行时被本 Android 版本的系统调用过滤器(SIGSYS)终止，这是系统层面的不兼容：Python 功能需要 Android 9.0 或更高版本。"
+        AppLanguage.ENGLISH -> "The bundled Python %s runtime was killed by this Android version's system-call filter (SIGSYS). This is an OS-level incompatibility: Python features require Android 9.0 or newer."
+        AppLanguage.ARABIC -> "تم إنهاء بيئة Python %s المدمجة بواسطة مرشح استدعاءات النظام في إصدار Android هذا (SIGSYS). هذا تعارض على مستوى النظام: تتطلب ميزات Python نظام Android 9.0 أو أحدث."
+        AppLanguage.PORTUGUESE -> "O runtime Python %s integrado foi encerrado pelo filtro de chamadas de sistema desta versão do Android (SIGSYS). Esta é uma incompatibilidade no nível do sistema: os recursos de Python exigem o Android 9.0 ou mais recente."
+        AppLanguage.SPANISH -> "El runtime de Python %s incluido fue terminado por el filtro de llamadas al sistema de esta versión de Android (SIGSYS). Es una incompatibilidad a nivel del sistema operativo: las funciones de Python requieren Android 9.0 o superior."
+        AppLanguage.FRENCH -> "L'environnement Python %s intégré a été tué par le filtre d'appels système de cette version d'Android (SIGSYS). Il s'agit d'une incompatibilité au niveau du système : les fonctionnalités Python nécessitent Android 9.0 ou plus récent."
+        AppLanguage.GERMAN -> "Die integrierte Python-%s-Laufzeit wurde vom Systemaufruf-Filter dieser Android-Version beendet (SIGSYS). Dies ist eine Inkompatibilität auf Betriebssystemebene: Python-Funktionen erfordern Android 9.0 oder neuer."
+        AppLanguage.RUSSIAN -> "Встроенная среда Python %s была завершена фильтром системных вызовов этой версии Android (SIGSYS). Это несовместимость на уровне ОС: функции Python требуют Android 9.0 или новее."
+        AppLanguage.JAPANESE -> "内蔵の Python %s ランタイムが、この Android バージョンのシステムコールフィルター (SIGSYS) によって強制終了されました。これは OS レベルの非互換性であり、Python 機能には Android 9.0 以降が必要です。"
+        AppLanguage.KOREAN -> "내장된 Python %s 런타임이 이 Android 버전의 시스템 콜 필터(SIGSYS)에 의해 종료되었습니다. 이는 OS 수준의 비호환성이며, Python 기능에는 Android 9.0 이상이 필요합니다."
     }
     val pyDownloadSourceLabel: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "%s [源%d/%d]"

--- a/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
+++ b/app/src/main/java/com/webtoapp/core/linux/LocalBuildEnvironment.kt
@@ -326,7 +326,7 @@ object LocalBuildEnvironment {
             return@withContext ExecutionResult(0, "no requirements.txt", "", 0)
         }
         if (!isPythonReady(context)) {
-            return@withContext ExecutionResult(-1, "", "Python 运行时未就绪", 0)
+            return@withContext ExecutionResult(-1, "", Strings.pythonRuntimeNotReady, 0)
         }
         val start = System.currentTimeMillis()
         val ok = com.webtoapp.core.python.PythonDependencyManager.installRequirements(
@@ -339,7 +339,7 @@ object LocalBuildEnvironment {
         ExecutionResult(
             exitCode = if (ok) 0 else -1,
             stdout = "",
-            stderr = if (ok) "" else "pip install 失败",
+            stderr = if (ok) "" else Strings.pyDepsInstallFailed,
             duration = duration,
         )
     }

--- a/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonDependencyManager.kt
@@ -767,6 +767,17 @@ sys.exit(main())
 
         if (firstResult.exitCode == 0) return true
 
+        // A seccomp kill (SIGSYS, wrapper-reported as exitCode 159) is a deterministic
+        // OS-level incompatibility: an identical retry only repeats the failure (#600).
+        if (PythonProcessDiagnostics.isDeterministicEnvironmentFailure(firstResult.exitCode)) {
+            AppLogger.w(
+                TAG,
+                "pip install killed by the OS (exitCode=${firstResult.exitCode}); skipping retry — environment incompatibility"
+            )
+            sitePackages.deleteRecursively()
+            return false
+        }
+
         val noWheelPackage = findNoWheelPackage(firstResult.output)
         if (noWheelPackage != null && shouldSkipSourceBuildRetry(firstResult.output)) {
             // A source build needs a compiler, which does not exist on-device.
@@ -928,6 +939,23 @@ sys.exit(main())
             val lastOutput = capturedOutput.lines().takeLast(5).joinToString("\n")
             AppLogger.e(TAG, "pip install failed, exitCode=$exitCode, output=$lastOutput")
             onOutput?.invoke(String.format(com.webtoapp.core.i18n.Strings.pyDepsInstallFailedCode, exitCode))
+
+            val signal = PythonProcessDiagnostics.signalForExitCode(exitCode)
+            if (signal != null) {
+                onOutput?.invoke(
+                    String.format(
+                        com.webtoapp.core.i18n.Strings.pyDepsKilledBySignal,
+                        signal,
+                        PythonProcessDiagnostics.signalName(signal)
+                    )
+                )
+                if (signal == PythonProcessDiagnostics.SIGSYS) {
+                    // Seccomp kill: the bundled musl Python issued a system call this
+                    // Android version's filter forbids — deterministic, not transient (#600).
+                    AppLogger.e(TAG, "pip install died from SIGSYS (seccomp); Python $PYTHON_VERSION is incompatible with this OS level")
+                    onOutput?.invoke(String.format(com.webtoapp.core.i18n.Strings.pyDepsSeccompHint, PYTHON_VERSION))
+                }
+            }
         }
         return CommandResult(exitCode, capturedOutput)
     }

--- a/app/src/main/java/com/webtoapp/core/python/PythonProcessDiagnostics.kt
+++ b/app/src/main/java/com/webtoapp/core/python/PythonProcessDiagnostics.kt
@@ -1,0 +1,59 @@
+package com.webtoapp.core.python
+
+/**
+ * Interprets abnormal pip / runtime process exit codes.
+ *
+ * A shell wrapper reports a signal death as 128+signal; the issue log's
+ * `exitCode=159` is 128+31 = SIGSYS — the kernel's seccomp filter killed the
+ * bundled musl Python because it issued a system call outside this Android
+ * version's allowlist (Android 8.0 introduced seccomp with an old-kernel
+ * policy). That is a deterministic environment incompatibility: retrying an
+ * identical command only repeats the failure.
+ *
+ * Kept free of Android dependencies so it is unit-testable on the plain JVM.
+ */
+object PythonProcessDiagnostics {
+
+    const val SIGHUP = 1
+    const val SIGINT = 2
+    const val SIGQUIT = 3
+    const val SIGILL = 4
+    const val SIGTRAP = 5
+    const val SIGABRT = 6
+    const val SIGBUS = 7
+    const val SIGFPE = 8
+    const val SIGKILL = 9
+    const val SIGSEGV = 11
+    const val SIGPIPE = 13
+    const val SIGTERM = 15
+    const val SIGSYS = 31
+
+    /** Signal number behind a wrapper-reported exit code (128+signal), or null. */
+    fun signalForExitCode(exitCode: Int): Int? =
+        if (exitCode >= 128) exitCode - 128 else null
+
+    fun signalName(signal: Int): String = when (signal) {
+        SIGHUP -> "SIGHUP"
+        SIGINT -> "SIGINT"
+        SIGQUIT -> "SIGQUIT"
+        SIGILL -> "SIGILL"
+        SIGTRAP -> "SIGTRAP"
+        SIGABRT -> "SIGABRT"
+        SIGBUS -> "SIGBUS"
+        SIGFPE -> "SIGFPE"
+        SIGKILL -> "SIGKILL"
+        SIGSEGV -> "SIGSEGV"
+        SIGPIPE -> "SIGPIPE"
+        SIGTERM -> "SIGTERM"
+        SIGSYS -> "SIGSYS"
+        else -> "SIGNAL_$signal"
+    }
+
+    /**
+     * True when the process died from a signal that indicates a deterministic
+     * environment problem (not a transient network hiccup), so an identical
+     * retry cannot succeed. SIGSYS is the seccomp kill described above.
+     */
+    fun isDeterministicEnvironmentFailure(exitCode: Int): Boolean =
+        signalForExitCode(exitCode) == SIGSYS
+}

--- a/app/src/test/java/com/webtoapp/core/python/PythonProcessDiagnosticsTest.kt
+++ b/app/src/test/java/com/webtoapp/core/python/PythonProcessDiagnosticsTest.kt
@@ -1,0 +1,40 @@
+package com.webtoapp.core.python
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PythonProcessDiagnosticsTest {
+
+    @Test
+    fun `wrapper-reported signal deaths decode to their signal`() {
+        assertThat(PythonProcessDiagnostics.signalForExitCode(159)).isEqualTo(PythonProcessDiagnostics.SIGSYS)
+        assertThat(PythonProcessDiagnostics.signalForExitCode(137)).isEqualTo(PythonProcessDiagnostics.SIGKILL)
+        assertThat(PythonProcessDiagnostics.signalForExitCode(139)).isEqualTo(PythonProcessDiagnostics.SIGSEGV)
+        assertThat(PythonProcessDiagnostics.signalForExitCode(134)).isEqualTo(PythonProcessDiagnostics.SIGABRT)
+    }
+
+    @Test
+    fun `normal and negative exit codes carry no signal`() {
+        assertThat(PythonProcessDiagnostics.signalForExitCode(0)).isNull()
+        assertThat(PythonProcessDiagnostics.signalForExitCode(1)).isNull()
+        assertThat(PythonProcessDiagnostics.signalForExitCode(127)).isNull()
+        assertThat(PythonProcessDiagnostics.signalForExitCode(-1)).isNull()
+    }
+
+    @Test
+    fun `signal names resolve for the common signals`() {
+        assertThat(PythonProcessDiagnostics.signalName(31)).isEqualTo("SIGSYS")
+        assertThat(PythonProcessDiagnostics.signalName(9)).isEqualTo("SIGKILL")
+        assertThat(PythonProcessDiagnostics.signalName(11)).isEqualTo("SIGSEGV")
+        assertThat(PythonProcessDiagnostics.signalName(99)).isEqualTo("SIGNAL_99")
+    }
+
+    @Test
+    fun `seccomp kill is a deterministic environment failure`() {
+        assertThat(PythonProcessDiagnostics.isDeterministicEnvironmentFailure(159)).isTrue()
+        // Other signal deaths and ordinary failures are not classified as deterministic.
+        assertThat(PythonProcessDiagnostics.isDeterministicEnvironmentFailure(137)).isFalse()
+        assertThat(PythonProcessDiagnostics.isDeterministicEnvironmentFailure(1)).isFalse()
+        assertThat(PythonProcessDiagnostics.isDeterministicEnvironmentFailure(-1)).isFalse()
+    }
+}


### PR DESCRIPTION
## Problem

#600: on Android 8.0, `pip install -r requirements.txt` downloaded every wheel successfully, then died at "Installing collected packages" with `exitCode=159` — twice (the manager retried identically), surfacing only a bare exit code.

## Root cause

`exitCode=159` is `128 + 31` = **SIGSYS** (the shell wrapper reports signal deaths as 128+signal). Android 8.0 introduced seccomp-bpf with an allowlist based on the kernels of its era; the bundled musl-built Python 3.14 issues a system call outside that allowlist during wheel installation, and the kernel kills the process. Downloads succeed because networking syscalls are all old; the failure is deterministic — an identical retry can never succeed.

## Changes

- **New `PythonProcessDiagnostics`** (Android-free, pure-JVM unit-tested): decodes wrapper-reported signal deaths (`128+signal`) and classifies SIGSYS as a deterministic environment failure.
- **`executeCommand`** now reports which signal killed the process, and for SIGSYS explains in plain language that the bundled Python runtime is incompatible with this Android version (9.0+ required) — localized in all ten UI languages (new `pyDepsKilledBySignal` / `pyDepsSeccompHint` strings).
- **`runPipWithWrapper` skips the identical retry** when the first attempt was seccomp-killed — no more double failure with a guaranteed outcome.
- **`LocalBuildEnvironment`**: replaced two hardcoded Chinese stderr strings ("pip install 失败", "Python 运行时未就绪") with the existing localized `Strings.pyDepsInstallFailed` / `Strings.pythonRuntimeNotReady`.

## Scope note

A true fix for Android 8 would require bundling an older Python runtime for pre-9 devices — a runtime-packaging decision, not a code-level one. This change makes the failure explicit and actionable instead of mysterious, and stops wasting the retry. Users on Android 9+ are unaffected (their installs already work).

## Verification

- New `PythonProcessDiagnosticsTest`: 159/137/139/134 decode to SIGSYS/SIGKILL/SIGSEGV/SIGABRT; normal and negative codes carry no signal; only SIGSYS classifies as deterministic.
- Full `:app:testStandardDebugUnitTest` green; app + shell (debug/release) compile verified with a forced clean recompile; `checkConfigFieldDrift` unaffected (no config changes).
- Shell-synced runtime change: template rebuilt via `:shell:assembleRelease` + `:app:syncShellTemplateApk` (template asset is gitignored; release workflow rebuilds from source).

Relates to #600