### PR TITLE
Polish Agent home screen and composer visuals

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/AgentScreen.kt
@@ -9,13 +9,13 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -30,18 +30,23 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Apps
 import androidx.compose.material.icons.outlined.ArrowDownward
-import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material.icons.outlined.Checklist
+import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Logout
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.RocketLaunch
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Smartphone
+import androidx.compose.material.icons.outlined.Web
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -63,6 +68,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -90,6 +96,7 @@ import com.webtoapp.ui.design.WtaAlpha
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
 import com.webtoapp.ui.design.WtaIconButton
+import com.webtoapp.ui.design.WtaRadius
 import com.webtoapp.ui.design.WtaScreen
 import com.webtoapp.ui.design.WtaSize
 import com.webtoapp.ui.design.WtaSpacing
@@ -99,11 +106,13 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextOverflow
 import com.webtoapp.ui.design.WtaButton
 import com.webtoapp.ui.design.WtaButtonSize
 import com.webtoapp.ui.design.WtaButtonVariant
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
 fun AgentScreen(
@@ -656,9 +665,10 @@ private fun JumpToLatestPill(onClick: () -> Unit) {
     WtaCard(
         onClick = onClick,
         tone = WtaCardTone.Highlighted,
+        shape = RoundedCornerShape(WtaRadius.Pill),
         contentPadding = PaddingValues(
-            horizontal = WtaSpacing.Medium,
-            vertical = WtaSpacing.Small
+            horizontal = WtaSpacing.Medium + 2.dp,
+            vertical = WtaSpacing.Small + 2.dp
         )
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -695,10 +705,10 @@ private fun EmptyConversationHint(
     }
     val starterPrompts = remember {
         listOf(
-            Strings.agentStarterPrompt1,
-            Strings.agentStarterPrompt2,
-            Strings.agentStarterPrompt3,
-            Strings.agentStarterPrompt4
+            Strings.agentStarterPrompt1 to Icons.Outlined.Checklist,
+            Strings.agentStarterPrompt2 to Icons.Outlined.Web,
+            Strings.agentStarterPrompt3 to Icons.Outlined.Code,
+            Strings.agentStarterPrompt4 to Icons.Outlined.Smartphone
         )
     }
 
@@ -712,13 +722,21 @@ private fun EmptyConversationHint(
     ) {
         item("hero") {
             Column {
-                Icon(
-                    imageVector = Icons.Outlined.AutoAwesome,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(WtaSize.IconLarge)
-                )
-                Spacer(Modifier.height(WtaSpacing.Small + 2.dp))
+                Box(
+                    modifier = Modifier
+                        .size(52.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.primaryContainer),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.RocketLaunch,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(26.dp)
+                    )
+                }
+                Spacer(Modifier.height(WtaSpacing.Medium + 2.dp))
                 Text(
                     text = Strings.agentHomeTitle,
                     style = MaterialTheme.typography.headlineSmall,
@@ -742,7 +760,23 @@ private fun EmptyConversationHint(
             )
         }
         item("starters-grid") {
-            StarterPromptsRow(prompts = starterPrompts, onPick = onFillComposer)
+            Column(verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                starterPrompts.chunked(2).forEachIndexed { rowIndex, rowPrompts ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small)) {
+                        rowPrompts.forEach { (prompt, icon) ->
+                            StarterCard(
+                                prompt = prompt,
+                                icon = icon,
+                                onPick = onFillComposer,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        if (rowPrompts.size == 1) {
+                            Spacer(Modifier.weight(1f))
+                        }
+                    }
+                }
+            }
         }
 
         if (recentSessions.isNotEmpty()) {
@@ -756,6 +790,48 @@ private fun EmptyConversationHint(
             items(recentSessions, key = { "session-${it.id}" }) { session ->
                 RecentSessionRow(session = session, onClick = { onPickSession(session.id) })
             }
+        }
+    }
+}
+
+@Composable
+private fun StarterCard(
+    prompt: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    onPick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    WtaCard(
+        onClick = { onPick(prompt) },
+        tone = WtaCardTone.Elevated,
+        contentPadding = PaddingValues(
+            horizontal = WtaSpacing.Medium - 2.dp,
+            vertical = WtaSpacing.Small + 4.dp
+        ),
+        modifier = modifier
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(RoundedCornerShape(WtaRadius.Chip))
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = WtaAlpha.MutedContainer)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(17.dp)
+                )
+            }
+            Spacer(Modifier.height(WtaSpacing.Small))
+            Text(
+                text = prompt,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2
+            )
         }
     }
 }
@@ -783,33 +859,6 @@ private fun SectionHeader(title: String, actionLabel: String?, onAction: (() -> 
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun StarterPromptsRow(prompts: List<String>, onPick: (String) -> Unit) {
-    androidx.compose.foundation.layout.FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(WtaSpacing.Small),
-        verticalArrangement = Arrangement.spacedBy(WtaSpacing.Small)
-    ) {
-        prompts.forEach { prompt ->
-            WtaCard(
-                onClick = { onPick(prompt) },
-                tone = WtaCardTone.Elevated,
-                contentPadding = PaddingValues(
-                    horizontal = WtaSpacing.Medium,
-                    vertical = WtaSpacing.Small + 2.dp
-                )
-            ) {
-                Text(
-                    text = prompt,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2
-                )
-            }
-        }
-    }
-}
-
 @Composable
 private fun RecentSessionRow(
     session: com.webtoapp.core.agent.session.AgentSession,
@@ -833,11 +882,14 @@ private fun RecentSessionRow(
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1
                 )
-                val parts = buildList {
-                    add(Strings.agentSessionMessagesShort.format(session.messages.size))
+                val timeText = remember(session.updatedAt) {
+                    SESSION_TIME_FORMAT.format(Date(session.updatedAt))
                 }
                 Text(
-                    text = parts.joinToString(" · "),
+                    text = listOf(
+                        Strings.agentSessionMessagesShort.format(session.messages.size),
+                        timeText
+                    ).joinToString(" · "),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -851,3 +903,5 @@ private fun RecentSessionRow(
         }
     }
 }
+
+private val SESSION_TIME_FORMAT = SimpleDateFormat("MM-dd HH:mm", Locale.getDefault())

--- a/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
@@ -16,11 +16,11 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.AttachFile
-import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.Cancel
@@ -31,8 +31,9 @@ import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.InsertDriveFile
 import androidx.compose.material.icons.outlined.Lock
-import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material.icons.outlined.SmartToy
+import androidx.compose.material.icons.outlined.Stop
+import androidx.compose.material.icons.outlined.Terminal
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -41,6 +42,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -61,10 +63,10 @@ import com.webtoapp.ui.design.WtaButtonVariant
 import com.webtoapp.ui.design.WtaCard
 import com.webtoapp.ui.design.WtaCardTone
 import com.webtoapp.ui.design.WtaIconButton
+import com.webtoapp.ui.design.WtaRadius
 import com.webtoapp.ui.design.WtaSettingRow
 import com.webtoapp.ui.design.WtaSize
 import com.webtoapp.ui.design.WtaSpacing
-import com.webtoapp.ui.design.WtaTextField
 
 @Composable
 fun Composer(
@@ -130,15 +132,13 @@ fun Composer(
                 onAttachFolder = onAttachFolder
             )
             Spacer(Modifier.width(WtaSpacing.Small))
-            WtaTextField(
+            ComposerPillField(
                 value = state.composerText,
                 onValueChange = onTextChange,
+                placeholder = composerPlaceholder(state),
                 modifier = Modifier
                     .weight(1f)
-                    .heightIn(min = WtaSize.TextFieldHeight, max = 220.dp),
-                placeholder = composerPlaceholder(state),
-                singleLine = false,
-                maxLines = 6
+                    .heightIn(max = 220.dp)
             )
             Spacer(Modifier.width(WtaSpacing.Small))
             SendButton(
@@ -162,6 +162,47 @@ fun Composer(
             onCompactContext = onCompactContext,
             selectedContextCount = state.contextAppIds.size + state.contextModuleIds.size,
             onOpenContextPicker = onOpenContextPicker
+        )
+    }
+}
+
+/**
+ * Capsule-shaped composer input. Rendered as a pill Surface with a borderless
+ * M3 TextField inside (all chrome transparent) so the focused state never
+ * draws its underline across the rounded capsule.
+ */
+@Composable
+private fun ComposerPillField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier
+) {
+    val pillShape = RoundedCornerShape(WtaRadius.Pill)
+    Surface(
+        shape = pillShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = modifier
+    ) {
+        TextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text(placeholder) },
+            singleLine = false,
+            maxLines = 6,
+            shape = pillShape,
+            colors = androidx.compose.material3.TextFieldDefaults.colors(
+                focusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                unfocusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                disabledContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                errorContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                focusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                disabledIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                errorIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                cursorColor = MaterialTheme.colorScheme.primary
+            )
         )
     }
 }
@@ -469,7 +510,7 @@ private fun ModeChipRow(
 
         ModeChip(
             label = Strings.agentSlashChipLabel,
-            icon = Icons.Outlined.AutoAwesome,
+            icon = Icons.Outlined.Terminal,
             primary = false,
             onClick = onTriggerSlash
         )
@@ -526,6 +567,12 @@ private fun formatTokenUsage(used: Int, capacity: Int): String {
     return "$usedK / $capK"
 }
 
+/**
+ * Current-model chip at the trailing edge of the composer mode row. The model
+ * name lives in an inner horizontally scrollable lane (capped, never
+ * ellipsized), so long provider/model ids stay fully readable by swiping the
+ * chip itself instead of truncating the label.
+ */
 @Composable
 private fun ModelChip(
     label: String,
@@ -547,15 +594,20 @@ private fun ModelChip(
                 modifier = Modifier.size(WtaSize.IconSmall - 2.dp)
             )
             Spacer(Modifier.width(WtaSpacing.Tiny + 2.dp))
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                maxLines = 1,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                modifier = Modifier.widthIn(max = 140.dp)
-            )
+            Box(
+                modifier = Modifier
+                    .widthIn(max = 200.dp)
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    maxLines = 1,
+                    softWrap = false
+                )
+            }
         }
     }
 }
@@ -571,7 +623,7 @@ private fun ContextChip(
         onClick = onClick,
         tone = com.webtoapp.ui.design.WtaCardTone.Surface,
         contentPadding = androidx.compose.foundation.layout.PaddingValues(
-            horizontal = WtaSpacing.Small,
+            horizontal = WtaSpacing.Small + 2.dp,
             vertical = WtaSpacing.Tiny + 2.dp
         )
     ) {

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MaterialIconRef.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MaterialIconRef.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.FactCheck
-import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Construction
 import androidx.compose.material.icons.outlined.DataObject
@@ -134,5 +133,5 @@ private fun resolveIcon(name: String?): ImageVector = when (name) {
     "compress" -> Icons.Outlined.Construction
     "logout" -> Icons.Outlined.PlayArrow
     "help" -> Icons.Outlined.QuestionMark
-    else -> Icons.Outlined.AutoAwesome
+    else -> Icons.Outlined.Extension
 }

--- a/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/MessageBubbles.kt
@@ -414,13 +414,16 @@ fun StreamingBubble(
                 )
             }
             if (text.isBlank() && pendingTools.isEmpty() && thinkingSegments.isEmpty()) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier.padding(vertical = WtaSpacing.Tiny),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     CircularProgressIndicator(
-                        modifier = Modifier.size(12.dp),
-                        strokeWidth = 1.5.dp,
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 1.6.dp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Spacer(Modifier.width(WtaSpacing.Small))
+                    Spacer(Modifier.width(WtaSpacing.Small + 2.dp))
                     Text(
                         text = activity ?: Strings.agentPhaseThinking,
                         style = MaterialTheme.typography.labelMedium,


### PR DESCRIPTION
## Summary

Visual and usability polish for the Agent screen's empty state and composer (issue #608):

- **Starter prompts**: plain FlowRow text chips become a 2x2 grid of `StarterCard`s, each with an icon badge (Checklist / Web / Code / Smartphone); the hero gets a rocket icon in a rounded `primaryContainer` tile.
- **Composer input**: new `ComposerPillField` — a pill `Surface` wrapping a borderless M3 `TextField` with fully transparent container/indicator colors, so the focus underline never draws across the rounded capsule.
- **Model chip**: the model name now lives in an inner horizontally scrollable lane (capped at 200dp, no ellipsis), so long provider/model ids stay readable by swiping.
- **Recent sessions**: rows now show last-updated time (`MM-dd HH:mm`) alongside the message count.
- Small icon/sizing swaps: slash chip → Terminal, tool icon fallback → Extension, streaming spinner 12→14dp with more breathing room.

Closes #608

## Test plan

- [x] `:app:compileStandardDebugKotlin` green
- [x] `:app:testStandardDebugUnitTest` + `:app:checkConfigFieldDrift` green locally
- [x] Emulator (Pixel 6, standardDebug): agent home renders the hero + 2-column starter grid; element bounds confirm aligned column edges (42/529 vs 550/1038) and row-top alignment
- [x] Tapping a starter card fills the composer and enables send
- [x] Composer pill renders correctly; model chip exposes an inner horizontal scroll lane (uiautomator dump)