### PR TITLE
Fix FilterChip row overflow in dialogs and config cards

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/ActivationCodeCard.kt
@@ -1390,37 +1390,12 @@ private fun BatchGenerateDialog(
                 )
 
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
                     horizontalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
-                    ActivationCodeType.values().take(3).forEach { type ->
-                        val theme = getCodeTypeTheme(type)
-                        val isSelected = codeType == type
-                        FilterChip(
-                            selected = isSelected,
-                            onClick = { codeType = type },
-                            label = {
-                                Text(
-                                    getActivationTypeName(type),
-                                    style = MaterialTheme.typography.labelSmall
-                                )
-                            },
-                            leadingIcon = {
-                                Icon(theme.icon, null, modifier = Modifier.size(14.dp))
-                            },
-                            colors = FilterChipDefaults.filterChipColors(
-                                selectedContainerColor = theme.labelBg,
-                                selectedLabelColor = theme.color,
-                                selectedLeadingIconColor = theme.color
-                            )
-                        )
-                    }
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    ActivationCodeType.values().drop(3).forEach { type ->
+                    ActivationCodeType.values().forEach { type ->
                         val theme = getCodeTypeTheme(type)
                         val isSelected = codeType == type
                         FilterChip(

--- a/app/src/main/java/com/webtoapp/ui/components/WtaCodeEditorDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/components/WtaCodeEditorDialog.kt
@@ -367,6 +367,7 @@ fun WtaCodeEditorDialog(
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
+                                    .horizontalScroll(rememberScrollState())
                                     .padding(top = 4.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
@@ -383,7 +384,7 @@ fun WtaCodeEditorDialog(
                                         )
                                     }
                                 )
-                                Spacer(Modifier.weight(1f))
+                                Spacer(Modifier.width(8.dp))
                                 if (searchQuery.isNotBlank() && matches.isEmpty()) {
                                     Text(
                                         Strings.codeEditorNoMatches,

--- a/app/src/main/java/com/webtoapp/ui/screens/BatchImportDialog.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/BatchImportDialog.kt
@@ -3,6 +3,7 @@ package com.webtoapp.ui.screens
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,6 +38,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -119,7 +121,12 @@ fun BatchImportDialog(
                     .heightIn(max = 520.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     FilterChip(
                         selected = tab == 0,
                         onClick = {

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -9,12 +9,14 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -1112,6 +1114,7 @@ fun BrowserAdvancedConfigCard(
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
+                                    .horizontalScroll(rememberScrollState())
                                     .padding(
                                         horizontal = WtaSpacing.RowHorizontal,
                                         vertical = WtaSpacing.ContentGap
@@ -1161,6 +1164,7 @@ fun BrowserAdvancedConfigCard(
                                     Row(
                                         modifier = Modifier
                                             .fillMaxWidth()
+                                            .horizontalScroll(rememberScrollState())
                                             .padding(horizontal = WtaSpacing.RowHorizontal),
                                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                                     ) {
@@ -2440,7 +2444,9 @@ fun FullscreenModeCard(
 
                             var statusBarModeTab by remember { mutableStateOf(0) }
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .horizontalScroll(rememberScrollState()),
                                 horizontalArrangement = Arrangement.Center
                             ) {
                                 FilterChip(
@@ -2818,7 +2824,9 @@ fun KeepScreenOnCard(
                             )
 
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .horizontalScroll(rememberScrollState()),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
                                 listOf(10, 30, 60, 120).forEach { minutes ->
@@ -2831,8 +2839,7 @@ fun KeepScreenOnCard(
                                                 text = Strings.screenAwakeTimeoutValue(minutes),
                                                 style = MaterialTheme.typography.labelSmall
                                             )
-                                        },
-                                        modifier = Modifier.weight(1f)
+                                        }
                                     )
                                 }
                             }
@@ -2854,7 +2861,9 @@ fun KeepScreenOnCard(
                     }
 
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState()),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         val isAuto = screenBrightness < 0
@@ -2870,8 +2879,7 @@ fun KeepScreenOnCard(
                                         modifier = Modifier.size(16.dp)
                                     )
                                 }
-                            } else null,
-                            modifier = Modifier.weight(1f)
+                            } else null
                         )
                         FilterChip(
                             selected = !isAuto,
@@ -2885,8 +2893,7 @@ fun KeepScreenOnCard(
                                         modifier = Modifier.size(16.dp)
                                     )
                                 }
-                            } else null,
-                            modifier = Modifier.weight(1f)
+                            } else null
                         )
                     }
 


### PR DESCRIPTION
## Summary

Several `FilterChip` rows render more chips than fit the available width — they either squeeze their labels (`weight(1f)`) or hard-clip at the container edge, leaving options unreachable. This PR puts every affected row on `horizontalScroll(rememberScrollState())` so chips keep intrinsic width and scroll instead (issue #610):

- **ActivationCodeCard** batch-generate dialog: the six code-type chips were hardcoded into two rows via `take(3)`/`drop(3)`; now one scrollable row (also survives future type-count changes).
- **BatchImportDialog**: import-source tab row wrapped in horizontal scroll.
- **WtaCodeEditorDialog**: find/replace toolbar scrolls; trailing `weight(1f)` spacer becomes a fixed 8dp gap.
- **CreateAppWebViewCards**: back-button behavior chips, auto-refresh interval presets, status-bar style tabs (light/dark), and keep-screen-on timeout/brightness rows all become scrollable with `weight(1f)` removed from the chips.

Host-only Compose UI change: no shell sync, export packaging, or config-field impact.

Closes #610

## Test plan

- [x] `:app:compileStandardDebugKotlin`, `:app:testStandardDebugUnitTest`, `:app:checkConfigFieldDrift` green locally
- [x] Emulator (Pixel 6, standardDebug), verified by screenshot + uiautomator element bounds:
  - Batch-generate dialog: single type-chip row, third chip clipped at edge as designed, swiping reveals remaining types
  - Batch-import dialog tabs fit side by side
  - FullscreenModeCard status-bar style tabs render centered, unsqueezed
  - KeepScreenOnCard timeout presets (10/30/60/120 min) and brightness chips keep intrinsic width inside a scroll lane
  - BrowserAdvancedConfigCard back-button + auto-refresh preset chips unsqueezed
- [ ] WtaCodeEditorDialog toolbar: same one-line `horizontalScroll` pattern as above, compile-checked only (dialog not exercised on emulator this round)