### PR TITLE
fix(shell): render slim toolbar when only console/zoom buttons are enabled

### DIFF
--- a/app/src/main/java/com/webtoapp/data/model/ToolbarVisibility.kt
+++ b/app/src/main/java/com/webtoapp/data/model/ToolbarVisibility.kt
@@ -22,6 +22,24 @@ data class ToolbarButtonVisibility(
 )
 
 /**
+ * Whether the customized slim toolbar has at least one item to render. Console and
+ * zoom are toolbar items in their own right: a toolbar customized down to only
+ * those two buttons must still render. Both the host preview and the exported
+ * shell gate the slim toolbar on this predicate — keep them on the shared
+ * function so the two paths cannot drift apart again.
+ */
+fun hasAnySlimToolbarItem(
+    toolbarShowTitle: Boolean,
+    toolbarShowUrl: Boolean,
+    toolbarShowBack: Boolean,
+    toolbarShowForward: Boolean,
+    toolbarShowRefresh: Boolean,
+    toolbarShowConsole: Boolean,
+    toolbarShowZoom: Boolean
+): Boolean = toolbarShowTitle || toolbarShowUrl || toolbarShowBack || toolbarShowForward ||
+    toolbarShowRefresh || toolbarShowConsole || toolbarShowZoom
+
+/**
  * Resolves which toolbar buttons are visible given the hide-toggle state and the
  * customized toolbar content flags. See [ToolbarButtonVisibility] for the contract.
  */

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScaffoldLayout.kt
@@ -28,6 +28,7 @@ import com.webtoapp.core.shell.ShellConfig
 import com.webtoapp.core.webview.PageZoomStore
 import com.webtoapp.core.webview.WebViewCallbacks
 import com.webtoapp.data.model.WebViewConfig
+import com.webtoapp.data.model.hasAnySlimToolbarItem
 import com.webtoapp.data.model.resolveToolbarButtons
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -100,9 +101,15 @@ fun BoxScope.ShellScaffoldLayout(
     }
 
     val toolbarCfg = config.webViewConfig
-    val hasAnyToolbarItem = toolbarCfg.toolbarShowTitle || toolbarCfg.toolbarShowUrl ||
-        toolbarCfg.toolbarShowBack || toolbarCfg.toolbarShowForward || toolbarCfg.toolbarShowRefresh
-    val showSlimToolbar = hideBrowserToolbar && toolbarCfg.browserToolbarCustomized && hasAnyToolbarItem
+    val showSlimToolbar = hideBrowserToolbar && toolbarCfg.browserToolbarCustomized && hasAnySlimToolbarItem(
+        toolbarShowTitle = toolbarCfg.toolbarShowTitle,
+        toolbarShowUrl = toolbarCfg.toolbarShowUrl,
+        toolbarShowBack = toolbarCfg.toolbarShowBack,
+        toolbarShowForward = toolbarCfg.toolbarShowForward,
+        toolbarShowRefresh = toolbarCfg.toolbarShowRefresh,
+        toolbarShowConsole = toolbarCfg.toolbarShowConsole,
+        toolbarShowZoom = toolbarCfg.toolbarShowZoom
+    )
     val showToolbar = (!hideToolbar || config.webViewConfig.showToolbarInFullscreen) &&
         (!hideBrowserToolbar || showSlimToolbar)
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -67,6 +67,7 @@ import com.webtoapp.data.model.HtmlLoadMode
 import com.webtoapp.data.model.SplashOrientation
 import com.webtoapp.data.model.SplashType
 import com.webtoapp.data.model.WebApp
+import com.webtoapp.data.model.hasAnySlimToolbarItem
 import com.webtoapp.data.model.resolveToolbarButtons
 import com.webtoapp.core.webview.PageZoomStore
 import android.content.pm.ActivityInfo
@@ -2713,8 +2714,17 @@ fun WebViewScreen(
     val showToolbarInPreview = !hideToolbar || webApp?.webViewConfig?.showToolbarInFullscreen == true
 
     val toolbarCfg = webApp?.webViewConfig
-    val hasAnyToolbarItem = toolbarCfg?.toolbarShowTitle == true || toolbarCfg?.toolbarShowUrl == true ||
-        toolbarCfg?.toolbarShowBack == true || toolbarCfg?.toolbarShowForward == true || toolbarCfg?.toolbarShowRefresh == true
+    val hasAnyToolbarItem = toolbarCfg?.let {
+        hasAnySlimToolbarItem(
+            toolbarShowTitle = it.toolbarShowTitle,
+            toolbarShowUrl = it.toolbarShowUrl,
+            toolbarShowBack = it.toolbarShowBack,
+            toolbarShowForward = it.toolbarShowForward,
+            toolbarShowRefresh = it.toolbarShowRefresh,
+            toolbarShowConsole = it.toolbarShowConsole,
+            toolbarShowZoom = it.toolbarShowZoom
+        )
+    } == true
     val showSlimToolbar = hideBrowserToolbar && toolbarCfg?.browserToolbarCustomized == true && hasAnyToolbarItem
     val shouldShowTopBar = showToolbarInPreview && (!hideBrowserToolbar || showSlimToolbar)
 

--- a/app/src/test/java/com/webtoapp/data/model/ToolbarVisibilityTest.kt
+++ b/app/src/test/java/com/webtoapp/data/model/ToolbarVisibilityTest.kt
@@ -130,4 +130,37 @@ class ToolbarVisibilityTest {
         assertThat(visibility.showConsoleButton).isTrue()
         assertThat(visibility.showZoom).isTrue()
     }
+
+    @Test
+    fun `slim toolbar with only console and zoom enabled still has content`() {
+        // Regression: the slim-toolbar gate in both the preview and the exported shell
+        // used to count only the five navigation items, so a toolbar customized down
+        // to just the console and zoom buttons rendered as a completely hidden top bar.
+        val hasContent = hasAnySlimToolbarItem(
+            toolbarShowTitle = false,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false,
+            toolbarShowConsole = true,
+            toolbarShowZoom = true
+        )
+
+        assertThat(hasContent).isTrue()
+    }
+
+    @Test
+    fun `slim toolbar with every item off is empty`() {
+        val hasContent = hasAnySlimToolbarItem(
+            toolbarShowTitle = false,
+            toolbarShowUrl = false,
+            toolbarShowBack = false,
+            toolbarShowForward = false,
+            toolbarShowRefresh = false,
+            toolbarShowConsole = false,
+            toolbarShowZoom = false
+        )
+
+        assertThat(hasContent).isFalse()
+    }
 }


### PR DESCRIPTION
## Problem

#617: with "Hide browser toolbar" on and the toolbar content customized down to only **Show Console Button** + **Show Page Zoom Button** (both default on), the app renders no toolbar at all instead of the slim bar with those two buttons.

## Root cause

Both renderers gate the slim toolbar on a hand-copied `hasAnyToolbarItem` that only counts the five navigation toggles (title / URL / back / forward / refresh) — `toolbarShowConsole` and `toolbarShowZoom` are missing from both copies:

- `WebViewActivity.kt` (host preview)
- `ShellScaffoldLayout.kt` (exported shell)

So "console + zoom only" counts as an empty toolbar and the whole top bar is dropped. Two free-floating copies of one predicate is also exactly how the paths drifted.

## Fix

- New shared `hasAnySlimToolbarItem(...)` in `data/model/ToolbarVisibility.kt` counting all seven items, next to `resolveToolbarButtons` (both shell-synced).
- `ShellScaffoldLayout.kt` and `WebViewActivity.kt` now call the shared function — preview and export can no longer disagree.
- `ToolbarVisibilityTest`: two regression cases (console+zoom-only has content; all-off is empty).

## Verification

- `:app:compileStandardDebugKotlin` + `:shell:compileReleaseKotlin` green.
- `ToolbarVisibilityTest` — 8/8 green (6 existing + 2 new).
- Shell template rebuilt via `:shell:assembleRelease :app:syncShellTemplateApk` (template asset is gitignored; release workflow rebuilds it from source).

Fixes #617
