### PR TITLE
feat(agent): align composer field with send button geometry; capsule button

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
+++ b/app/src/main/java/com/webtoapp/ui/agent/components/Composer.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material.icons.outlined.Add
@@ -42,7 +43,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.webtoapp.core.agent.session.UserAttachment
@@ -167,9 +168,11 @@ fun Composer(
 }
 
 /**
- * Capsule-shaped composer input. Rendered as a pill Surface with a borderless
- * M3 TextField inside (all chrome transparent) so the focused state never
- * draws its underline across the rounded capsule.
+ * Composer input matching the trailing send button: same 10dp corner radius
+ * ([WtaRadius.Button]) and the same resting height ([WtaSize.ButtonHeightMedium]).
+ * Built on foundation [BasicTextField] inside a Surface — an M3 TextField would
+ * enforce its own 56dp minimum, so height parity with the button is impossible
+ * there; BasicTextField also keeps focus chrome invisible by construction.
  */
 @Composable
 private fun ComposerPillField(
@@ -178,31 +181,37 @@ private fun ComposerPillField(
     placeholder: String,
     modifier: Modifier = Modifier
 ) {
-    val pillShape = RoundedCornerShape(WtaRadius.Pill)
     Surface(
-        shape = pillShape,
+        shape = RoundedCornerShape(WtaRadius.Button),
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         modifier = modifier
     ) {
-        TextField(
+        BasicTextField(
             value = value,
             onValueChange = onValueChange,
-            modifier = Modifier.fillMaxWidth(),
-            placeholder = { Text(placeholder) },
-            singleLine = false,
-            maxLines = 6,
-            shape = pillShape,
-            colors = androidx.compose.material3.TextFieldDefaults.colors(
-                focusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
-                unfocusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
-                disabledContainerColor = androidx.compose.ui.graphics.Color.Transparent,
-                errorContainerColor = androidx.compose.ui.graphics.Color.Transparent,
-                focusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
-                unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
-                disabledIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
-                errorIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
-                cursorColor = MaterialTheme.colorScheme.primary
-            )
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = WtaSize.ButtonHeightMedium),
+            textStyle = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface
+            ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            decorationBox = { innerField ->
+                Box(
+                    modifier = Modifier.padding(horizontal = 14.dp),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1
+                        )
+                    }
+                    innerField()
+                }
+            }
         )
     }
 }
@@ -308,7 +317,8 @@ private fun SendButton(
         WtaButton(
             onClick = onCancel,
             variant = WtaButtonVariant.Destructive,
-            size = WtaButtonSize.Medium
+            size = WtaButtonSize.Medium,
+            shape = RoundedCornerShape(WtaRadius.Pill)
         ) {
             Icon(
                 Icons.Outlined.Stop,
@@ -321,7 +331,8 @@ private fun SendButton(
             onClick = onSend,
             variant = WtaButtonVariant.Primary,
             size = WtaButtonSize.Medium,
-            enabled = enabled
+            enabled = enabled,
+            shape = RoundedCornerShape(WtaRadius.Pill)
         ) {
             Icon(
                 Icons.AutoMirrored.Outlined.Send,

--- a/app/src/main/java/com/webtoapp/ui/design/WtaButton.kt
+++ b/app/src/main/java/com/webtoapp/ui/design/WtaButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
@@ -33,7 +34,8 @@ fun WtaButton(
     enabled: Boolean = true,
     leadingIcon: ImageVector? = null,
     trailingIcon: ImageVector? = null,
-    contentPadding: PaddingValues? = null
+    contentPadding: PaddingValues? = null,
+    shape: Shape = RoundedCornerShape(WtaRadius.Button)
 ) {
     WtaButton(
         onClick = onClick,
@@ -41,7 +43,8 @@ fun WtaButton(
         variant = variant,
         size = size,
         enabled = enabled,
-        contentPadding = contentPadding
+        contentPadding = contentPadding,
+        shape = shape
     ) {
         if (leadingIcon != null) {
             Icon(leadingIcon, contentDescription = null, modifier = Modifier.size(WtaSize.IconSmall))
@@ -63,6 +66,7 @@ fun WtaButton(
     size: WtaButtonSize = WtaButtonSize.Medium,
     enabled: Boolean = true,
     contentPadding: PaddingValues? = null,
+    shape: Shape = RoundedCornerShape(WtaRadius.Button),
     content: @Composable RowScope.() -> Unit
 ) {
     val hapticClick = rememberHapticClick(onClick)
@@ -76,7 +80,6 @@ fun WtaButton(
         WtaButtonSize.Medium -> PaddingValues(horizontal = 24.dp, vertical = 10.dp)
         WtaButtonSize.Large -> PaddingValues(horizontal = 24.dp, vertical = 14.dp)
     }
-    val shape = RoundedCornerShape(WtaRadius.Button)
     val btnModifier = modifier.heightIn(min = heightMin)
     val colors = MaterialTheme.colorScheme
 


### PR DESCRIPTION
## Problem / Goal

#618: two shape tweaks to the Agent composer row, continuing the 2.5.x composer polish (#608/#609):

1. The capsule input field should match the send button's geometry — same resting height (44dp) and the same 10dp corner radius — while keeping multiline growth (max 220dp).
2. The send button itself becomes a capsule; the working-state stop button follows.

## Fix

- `ComposerPillField`: rebuilt on `BasicTextField` inside the Surface. An M3 `TextField` enforces its own 56dp minimum, so exact height parity with the 44dp button is impossible there; `BasicTextField` gives exact control and makes the focus chrome invisible by construction (the transparent-color hacks go away). Resting height `heightIn(min = WtaSize.ButtonHeightMedium)`, shape `RoundedCornerShape(WtaRadius.Button)`, placeholder + cursor styled to match the old field.
- `WtaButton`: new optional `shape: Shape = RoundedCornerShape(WtaRadius.Button)` parameter on both overloads — every existing call site keeps its current appearance; the composer passes `RoundedCornerShape(WtaRadius.Pill)` for send and stop.

## Verification

- `:app:compileStandardDebugKotlin` green.
- On emulator (Pixel 6 AVD, standard debug): composer field and send button both measure 116px (44dp) tall — exact parity; button renders as a full capsule; long-text growth up to the 220dp cap intact; no other button in the app changed.

Fixes #618
