### PR TITLE
fix(activation): align preview and exported APK activation behavior

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -4,10 +4,13 @@ import android.content.Intent
 import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.lifecycleScope
 import com.webtoapp.WebToAppApplication
 import com.webtoapp.core.activation.ActivationResult
+import com.webtoapp.core.activation.ActivationStatus
 import com.webtoapp.core.shell.ShellConfig
 import com.webtoapp.data.model.Announcement
 import com.webtoapp.ui.components.announcement.toUiTemplate
@@ -20,6 +23,14 @@ fun ShellActivationDialog(
     onActivated: (String?) -> Unit
 ) {
     val activation = WebToAppApplication.activation
+
+    val activationStatus by produceState<ActivationStatus?>(initialValue = null) {
+        value = try {
+            activation.getActivationStatus(-1L)
+        } catch (e: Exception) {
+            null
+        }
+    }
 
     com.webtoapp.ui.components.EnhancedActivationDialog(
         onDismiss = onDismiss,
@@ -49,6 +60,7 @@ fun ShellActivationDialog(
             }
             result
         },
+        activationStatus = activationStatus,
         customTitle = config.activationDialogTitle,
         customSubtitle = config.activationDialogSubtitle,
         customInputLabel = config.activationDialogInputLabel,

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -24,6 +24,7 @@ import com.webtoapp.data.model.Announcement
 import com.webtoapp.util.TvUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 @SuppressLint("SetJavaScriptEnabled")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -442,7 +443,9 @@ fun ShellScreen(
                         linkUrl = config.announcementLink.ifEmpty { null },
                         showOnce = config.announcementShowOnce
                     )
-                    showAnnouncementDialog = kotlinx.coroutines.runBlocking { announcement.shouldShowAnnouncement(-1L, ann) }
+                    scope.launch {
+                        showAnnouncementDialog = announcement.shouldShowAnnouncement(-1L, ann)
+                    }
                 }
             }
         )

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -135,7 +135,10 @@ fun SplashLauncherScreen(
                 val remoteRequest = activation.buildRemoteRequest(
                     verifyUrl = remoteConfig.verifyUrl,
                     publicKeyBase64 = remoteConfig.publicKeyBase64,
-                    offlinePolicy = remoteConfig.offlinePolicy
+                    offlinePolicy = remoteConfig.offlinePolicy,
+                    deliverUrl = remoteConfig.deliverUrl,
+                    encryptUrl = remoteConfig.encryptUrl,
+                    aesKeyBase64 = remoteConfig.aesKeyBase64
                 )
                 if (activationRequireEveryTime) {
                     val result = activation.reverifyRemoteWithCachedCode(activationAppId, remoteRequest)
@@ -268,7 +271,10 @@ fun SplashLauncherScreen(
                         activation.buildRemoteRequest(
                             verifyUrl = remoteConfig.verifyUrl,
                             publicKeyBase64 = remoteConfig.publicKeyBase64,
-                            offlinePolicy = remoteConfig.offlinePolicy
+                            offlinePolicy = remoteConfig.offlinePolicy,
+                            deliverUrl = remoteConfig.deliverUrl,
+                            encryptUrl = remoteConfig.encryptUrl,
+                            aesKeyBase64 = remoteConfig.aesKeyBase64
                         )
                     )
                 } else {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -1060,6 +1060,10 @@ fun WebViewScreen(
     var showActivationDialog by remember { mutableStateOf(false) }
     var showAnnouncementDialog by remember { mutableStateOf(false) }
 
+    // URL delivered by the remote activation server (dynamic URL mode). Takes precedence over
+    // the configured app URL for plain WEB apps, mirroring ShellScreen.dynamicUrl.
+    var remoteDeliveredUrl by remember { mutableStateOf<String?>(null) }
+
     var isActivated by remember { mutableStateOf(false) }
 
     var isActivationChecked by remember { mutableStateOf(false) }
@@ -1322,13 +1326,28 @@ fun WebViewScreen(
                         isActivationChecked = true
                         showActivationDialog = true
                     } else {
-                        val activated = if (app.activationRemoteConfig?.enabled == true) {
-                            activation.isActivated(appId).first()
+                        val remote = app.activationRemoteConfig?.takeIf { it.enabled }
+                        val activated = if (remote != null) {
+                            activation.isActivated(appId).first() &&
+                                activation.isRemoteStartupAllowed(
+                                    appId,
+                                    activation.buildRemoteRequest(
+                                        verifyUrl = remote.verifyUrl,
+                                        publicKeyBase64 = remote.publicKeyBase64,
+                                        offlinePolicy = remote.offlinePolicy,
+                                        deliverUrl = remote.deliverUrl,
+                                        encryptUrl = remote.encryptUrl,
+                                        aesKeyBase64 = remote.aesKeyBase64
+                                    )
+                                )
                         } else {
                             activation.resolveStartupActivation(appId)
                         }
                         isActivated = activated
                         isActivationChecked = true
+                        if (activated && remote != null && remote.deliverUrl) {
+                            remoteDeliveredUrl = activation.getCachedRemoteUrl(appId)
+                        }
                         if (!activated) {
                             showActivationDialog = true
                         }
@@ -2584,7 +2603,7 @@ fun WebViewScreen(
 
     val localHttpServer = remember { LocalHttpServer.getInstance(context) }
 
-    val targetResolution = remember(directUrl, webApp, testUrl) {
+    val targetResolution = remember(directUrl, webApp, testUrl, remoteDeliveredUrl) {
         val app = webApp
         when {
 
@@ -2693,7 +2712,7 @@ fun WebViewScreen(
                     "" to null
                 }
             }
-            else -> normalizeWebUrlForSecurity(app?.url) to null
+            else -> normalizeWebUrlForSecurity(remoteDeliveredUrl ?: app?.url) to null
         }
     }
     val targetUrl = targetResolution.first
@@ -3462,17 +3481,24 @@ fun WebViewScreen(
         com.webtoapp.ui.components.EnhancedActivationDialog(
             onDismiss = { showActivationDialog = false },
             onActivate = { code ->
-                val remote = webApp?.activationRemoteConfig
-                if (remote?.enabled == true) {
-                    return@EnhancedActivationDialog activation.verifyRemoteActivation(
+                val remote = webApp?.activationRemoteConfig?.takeIf { it.enabled }
+                if (remote != null) {
+                    val result = activation.verifyRemoteActivation(
                         appId,
                         code,
                         activation.buildRemoteRequest(
                             verifyUrl = remote.verifyUrl,
                             publicKeyBase64 = remote.publicKeyBase64,
-                            offlinePolicy = remote.offlinePolicy
+                            offlinePolicy = remote.offlinePolicy,
+                            deliverUrl = remote.deliverUrl,
+                            encryptUrl = remote.encryptUrl,
+                            aesKeyBase64 = remote.aesKeyBase64
                         )
                     )
+                    if (result is com.webtoapp.core.activation.ActivationResult.Success && remote.deliverUrl) {
+                        remoteDeliveredUrl = result.url
+                    }
+                    return@EnhancedActivationDialog result
                 }
                 val allCodes = webApp?.activationCodeList ?: emptyList()
                 return@EnhancedActivationDialog activation.verifyActivationCodeWithObjects(appId, code, allCodes)


### PR DESCRIPTION
## Summary

The activation-code feature behaved differently in the editor preview (`WebViewActivity`) than in a built APK (`ShellScreen` / `ShellDialogs`). Both sides shared the same `EnhancedActivationDialog`, but the call sites passed different arguments, so each side shipped half the feature. This PR aligns them in both directions without touching any config model or shell JSON schema.

### Exported APK now matches preview

- `ShellActivationDialog` passes `activationStatus` (via `produceState`) so an existing activation record renders its status card — expiry time, remaining usage, device binding — exactly like preview.
- The announcement check after successful activation runs in a coroutine instead of `runBlocking` inside composition (main-thread stall risk).

### Preview now matches exported APK

- Remote verify requests now carry the full `RemoteRequest`: `deliverUrl`, `encryptUrl`, `aesKeyBase64`. This is the load-bearing fix: `deliverUrl` is part of the RSA-signed payload checked by `RemoteActivationVerifier.verifySignature`, so the previous 3-argument request **failed signature validation** against any server configured for URL delivery — remote activation was effectively broken in preview.
- Startup re-checks `isActivated && isRemoteStartupAllowed(…)` per the configured offline policy, instead of trusting local `isActivated` alone.
- A remotely delivered URL is applied at startup (cached) and after successful activation for plain WEB apps, mirroring `ShellScreen.dynamicUrl`; test URLs, direct intents, HTML/FRONTEND, MULTI_WEB, and server-runtime apps are untouched.

### Also

- `SplashLauncherActivity`'s two `buildRemoteRequest` call sites get the same parameter parity.

Fixes #621

## Test plan

- [x] `:app:compileStandardDebugKotlin` green
- [x] `:app:testStandardDebugUnitTest` full suite green locally
- [x] `:app:checkConfigFieldDrift` green (no config field changes)
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` template rebuilt; synced sources verified to contain the changes
- [x] Audited all 6 `buildRemoteRequest` call sites — every site now passes `deliverUrl` / `encryptUrl` / `aesKeyBase64`
- [ ] CI (`Android CI Build / check`) green on this PR