### PR TITLE
fix(shell): align preview/export behavior for announcements, multiweb assets, runtimes

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellDialogs.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import com.webtoapp.WebToAppApplication
 import com.webtoapp.core.activation.ActivationResult
 import com.webtoapp.core.activation.ActivationStatus
+import com.webtoapp.core.i18n.Strings
 import com.webtoapp.core.shell.ShellConfig
 import com.webtoapp.data.model.Announcement
 import com.webtoapp.ui.components.announcement.toUiTemplate
@@ -119,12 +120,22 @@ fun ShellAnnouncementDialog(
             onDismiss()
             val scope = (context as? AppCompatActivity)?.lifecycleScope
             scope?.launch {
-                announcement.markAnnouncementShown(-1L, 1)
+                announcement.markAnnouncementShown(-1L, config.announcementVersion)
             }
         },
         onLinkClick = { url ->
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(normalizeExternalUrlForIntent(url)))
-            context.startActivity(intent)
+            // Guarded like the preview's announcement dialog: normalize, reject blank targets,
+            // and survive a missing browser app instead of crashing inside composition.
+            try {
+                val safeUrl = normalizeExternalUrlForIntent(url)
+                if (safeUrl.isBlank()) {
+                    android.widget.Toast.makeText(context, Strings.cannotOpenLink, android.widget.Toast.LENGTH_SHORT).show()
+                } else {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(safeUrl)))
+                }
+            } catch (e: Exception) {
+                android.widget.Toast.makeText(context, Strings.cannotOpenLink, android.widget.Toast.LENGTH_SHORT).show()
+            }
         },
         onNeverShowChecked = { checked ->
             if (checked) {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.webtoapp.WebToAppApplication
 import com.webtoapp.core.logging.AppLogger
 import com.webtoapp.core.shell.ShellConfig
@@ -25,6 +26,22 @@ import com.webtoapp.util.TvUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+
+/**
+ * Model-level Announcement built from the shell payload for gating decisions. Rendering uses
+ * ShellAnnouncementDialog's own construction (template/custom-icon mapping); this one carries
+ * the trigger and version fields the show/hide gate must honor.
+ */
+internal fun buildShellAnnouncement(config: ShellConfig): Announcement = Announcement(
+    title = config.announcementTitle,
+    content = config.announcementContent,
+    linkUrl = config.announcementLink.ifEmpty { null },
+    showOnce = config.announcementShowOnce,
+    version = config.announcementVersion,
+    triggerOnLaunch = config.announcementTriggerOnLaunch,
+    triggerOnNoNetwork = config.announcementTriggerOnNoNetwork,
+    triggerIntervalMinutes = config.announcementTriggerIntervalMinutes
+)
 
 @SuppressLint("SetJavaScriptEnabled")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -183,14 +200,16 @@ fun ShellScreen(
             }
         }
 
-        if (config.announcementEnabled && isActivated && config.announcementTitle.isNotEmpty()) {
-            val ann = Announcement(
-                title = config.announcementTitle,
-                content = config.announcementContent,
-                linkUrl = config.announcementLink.ifEmpty { null },
-                showOnce = config.announcementShowOnce
+        if (config.announcementEnabled && isActivated &&
+            (config.announcementTitle.isNotEmpty() || config.announcementContent.isNotEmpty())
+        ) {
+            // Trigger-aware gate: honors triggerOnLaunch=false, version-pinned showOnce, and the
+            // no-network / interval modes driven by the effects below.
+            showAnnouncementDialog = announcement.shouldShowAnnouncementForTrigger(
+                -1L,
+                buildShellAnnouncement(config),
+                isLaunch = true
             )
-            showAnnouncementDialog = announcement.shouldShowAnnouncement(-1L, ann)
         }
 
         val validOrientationModes = setOf("PORTRAIT", "LANDSCAPE", "REVERSE_PORTRAIT", "REVERSE_LANDSCAPE", "SENSOR_PORTRAIT", "SENSOR_LANDSCAPE", "AUTO")
@@ -242,6 +261,58 @@ fun ShellScreen(
 
         AppLogger.d("ShellActivity", "LaunchedEffect: showSplash=$showSplash, splashCountdown=$splashCountdown")
 
+    }
+
+    // Announcement no-network trigger: monitor connectivity while the shell is up (preview parity
+    // with WebViewActivity's monitoring for triggerOnNoNetwork announcements).
+    DisposableEffect(Unit) {
+        if (config.announcementEnabled && config.announcementTriggerOnNoNetwork) {
+            announcement.startNetworkMonitoring()
+        }
+        onDispose { announcement.stopNetworkMonitoring() }
+    }
+
+    val networkAvailable by announcement.isNetworkAvailable.collectAsStateWithLifecycle()
+    var lastNetworkState by remember { mutableStateOf(true) }
+
+    LaunchedEffect(networkAvailable, isActivated) {
+        if (lastNetworkState && !networkAvailable && isActivated &&
+            config.announcementEnabled && config.announcementTriggerOnNoNetwork
+        ) {
+            val shouldShow = announcement.shouldShowAnnouncementForTrigger(
+                -1L,
+                buildShellAnnouncement(config),
+                isNoNetwork = true
+            )
+            if (shouldShow && !showAnnouncementDialog) {
+                showAnnouncementDialog = true
+            }
+        }
+        lastNetworkState = networkAvailable
+    }
+
+    // Announcement interval trigger: re-show periodically while the app stays open.
+    LaunchedEffect(isActivated) {
+        val intervalMinutes = config.announcementTriggerIntervalMinutes
+        if (!isActivated || !config.announcementEnabled || intervalMinutes <= 0) return@LaunchedEffect
+
+        if (config.announcementTriggerIntervalIncludeLaunch) {
+            announcement.resetIntervalTrigger(-1L)
+        }
+
+        val ann = buildShellAnnouncement(config)
+        while (true) {
+            val nextDelay = announcement.getMillisUntilNextIntervalAnnouncement(-1L, ann)
+            delay(nextDelay.coerceIn(1_000L, intervalMinutes * 60_000L))
+
+            if (announcement.shouldTriggerIntervalAnnouncement(-1L, ann)) {
+                val shouldShow = announcement.shouldShowAnnouncementForTrigger(-1L, ann, isInterval = true)
+                if (shouldShow && !showAnnouncementDialog) {
+                    showAnnouncementDialog = true
+                    announcement.markIntervalTrigger(-1L)
+                }
+            }
+        }
     }
 
     fun usesPageTopStatusBarColor(): Boolean {
@@ -436,15 +507,11 @@ fun ShellScreen(
                     dynamicUrl = url
                 }
 
-                if (config.announcementEnabled && config.announcementTitle.isNotEmpty()) {
-                    val ann = Announcement(
-                        title = config.announcementTitle,
-                        content = config.announcementContent,
-                        linkUrl = config.announcementLink.ifEmpty { null },
-                        showOnce = config.announcementShowOnce
-                    )
+                if (config.announcementEnabled &&
+                    (config.announcementTitle.isNotEmpty() || config.announcementContent.isNotEmpty())
+                ) {
                     scope.launch {
-                        showAnnouncementDialog = announcement.shouldShowAnnouncement(-1L, ann)
+                        showAnnouncementDialog = announcement.shouldShowAnnouncement(-1L, buildShellAnnouncement(config))
                     }
                 }
             }

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellServerModes.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellServerModes.kt
@@ -83,7 +83,11 @@ fun WordPressShellMode(
 
                 phase = "starting"
                 val requestPort = config.wordpressConfig.phpPort
-                val port = phpRuntime.startServer(wpDir.absolutePath, requestPort)
+                val port = phpRuntime.startServer(
+                    wpDir.absolutePath,
+                    requestPort,
+                    resolveShellPortConflictMode(config.wordpressConfig.portConflictMode)
+                )
 
                 if (port > 0) {
                     serverUrl = "http://127.0.0.1:$port"
@@ -240,11 +244,15 @@ fun HtmlFrontendShellMode(
                 )
 
                 val assetBase = config.siteAssetBase.ifBlank { "html" }
-                val hasBundledAssets = try { context.assets.list(assetBase)?.isNotEmpty() == true } catch (_: Exception) { false }
+                // Multi-web per-site projects are embedded under assets/multiweb_sites/<siteId>/<assetBase>
+                // (AppContentEmbedder.MultiWebContentEmbedder); plain HTML/FRONTEND shells embed at
+                // the top-level assets/<assetBase>.
+                val embeddedAssetRoot = if (config.siteId.isNotBlank()) "multiweb_sites/${config.siteId}/$assetBase" else assetBase
+                val hasBundledAssets = try { context.assets.list(embeddedAssetRoot)?.isNotEmpty() == true } catch (_: Exception) { false }
                 if (hasBundledAssets && shouldReextractAssets(marker, extractionToken)) {
                     AppLogger.i("HtmlShell", "Extracting HTML assets to ${siteDir.absolutePath}")
                     siteDir.deleteRecursively()
-                    extractAssetsRecursive(context, assetBase, siteDir)
+                    extractAssetsRecursive(context, embeddedAssetRoot, siteDir)
                     writeExtractionMarker(marker, extractionToken)
                 }
 
@@ -579,6 +587,7 @@ fun NodeJsShellMode(
                     projectDir = projectDir.absolutePath,
                     entryFile = entryFile,
                     port = requestPort ?: 0,
+                    portConflictMode = resolveShellPortConflictMode(config.nodejsConfig.portConflictMode),
                     envVars = envVars
                 )
 
@@ -717,7 +726,9 @@ fun PhpAppShellMode(
                     documentRoot = docRoot,
                     entryFile = entryFile,
                     port = config.phpAppConfig.port,
-                    envVars = config.phpAppConfig.envVars
+                    portConflictMode = resolveShellPortConflictMode(config.phpAppConfig.portConflictMode),
+                    envVars = config.phpAppConfig.envVars,
+                    phpExtensions = config.phpAppConfig.phpExtensions
                 )
 
                 if (port > 0) {
@@ -887,6 +898,7 @@ fun PythonAppShellMode(
                     entryFile = entryFile,
                     framework = framework,
                     port = pyConfig.port,
+                    portConflictMode = resolveShellPortConflictMode(pyConfig.portConflictMode),
                     envVars = pyConfig.envVars,
                     installDeps = true
                 )
@@ -1039,6 +1051,7 @@ fun GoAppShellMode(
                     projectDir = projectDir.absolutePath,
                     binaryName = binaryName,
                     port = goConfig.port,
+                    portConflictMode = resolveShellPortConflictMode(goConfig.portConflictMode),
                     envVars = goConfig.envVars
                 )
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellUtils.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellUtils.kt
@@ -141,6 +141,15 @@ internal fun normalizeExternalUrlForIntent(rawUrl: String): String {
     return normalizeShellTargetUrlForSecurity(safeUrl)
 }
 
+/** Safely parse a stored port-conflict-mode string (from ShellConfig JSON) into the enum. */
+internal fun resolveShellPortConflictMode(name: String?): com.webtoapp.data.model.PortConflictMode {
+    return try {
+        com.webtoapp.data.model.PortConflictMode.valueOf(name ?: "AUTO_KILL")
+    } catch (_: Exception) {
+        com.webtoapp.data.model.PortConflictMode.AUTO_KILL
+    }
+}
+
 internal fun shouldReextractAssets(marker: File, expectedToken: String): Boolean {
     if (!marker.exists()) return true
     return try {

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewCallbacks.kt
@@ -126,7 +126,7 @@ fun createShellWebViewCallbacks(
         }
 
         override fun onSslError(error: String) {
-            updateError("SSL安全错误")
+            updateError(Strings.sslError)
             com.webtoapp.core.shell.ShellLogger.logWebView("SSL错误", currentUrlProvider(), error)
         }
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellWebViewConfig.kt
@@ -90,7 +90,10 @@ fun buildWebViewConfig(config: ShellConfig): WebViewConfig {
         decodeBase64Mode = try {
             com.webtoapp.data.model.Base64DeepLinkMode.valueOf(config.webViewConfig.decodeBase64Mode)
         } catch (e: Exception) { com.webtoapp.data.model.Base64DeepLinkMode.GESTURE_ONLY },
-        mediaAutoplayEnabled = config.webViewConfig.mediaAutoplayEnabled,
+        // Local HTML/FRONTEND projects always allow gesture-free playback in the host preview
+        // (WebViewActivity forces mediaPlaybackRequiresUserGesture=false); mirror that here so
+        // exported shells behave identically.
+        mediaAutoplayEnabled = config.webViewConfig.mediaAutoplayEnabled || isLocalFileApp,
         mediaAutoplayScope = try {
             com.webtoapp.data.model.MediaAutoplayScope.valueOf(config.webViewConfig.mediaAutoplayScope)
         } catch (e: Exception) { com.webtoapp.data.model.MediaAutoplayScope.VIDEO_ONLY },

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -2000,16 +2000,22 @@ fun WebViewScreen(
         }
 
         try {
-            val candidates = listOf("dist", "build", "public", "static", "www", "")
+            // Honor the configured build mode the way the exported shell does
+            // (ShellContentRouter branches on nodejsConfig.mode): only STATIC projects get the
+            // doc-root sniff; API_BACKEND always goes to the Node runtime.
+            val staticMode = config.buildMode == com.webtoapp.data.model.NodeJsBuildMode.STATIC
             var foundDocRoot: File? = null
-            for (dir in candidates) {
-                val candidate = if (dir.isEmpty()) projectDir else File(projectDir, dir)
-                val hasIndex = File(candidate, "index.html").exists()
-                AppLogger.d("NodeJsAppPreview", "Checking candidate: '$dir' -> ${candidate.absolutePath}, isDir=${candidate.isDirectory}, hasIndex=$hasIndex")
-                if (candidate.isDirectory && hasIndex) {
-                    foundDocRoot = candidate
-                    AppLogger.i("NodeJsAppPreview", "Found docRoot: ${candidate.absolutePath}")
-                    break
+            if (staticMode) {
+                val candidates = listOf("dist", "build", "public", "static", "www", "")
+                for (dir in candidates) {
+                    val candidate = if (dir.isEmpty()) projectDir else File(projectDir, dir)
+                    val hasIndex = File(candidate, "index.html").exists()
+                    AppLogger.d("NodeJsAppPreview", "Checking candidate: '$dir' -> ${candidate.absolutePath}, isDir=${candidate.isDirectory}, hasIndex=$hasIndex")
+                    if (candidate.isDirectory && hasIndex) {
+                        foundDocRoot = candidate
+                        AppLogger.i("NodeJsAppPreview", "Found docRoot: ${candidate.absolutePath}")
+                        break
+                    }
                 }
             }
 
@@ -2020,7 +2026,7 @@ fun WebViewScreen(
                 nodeJsAppPreviewState = NodeJsAppPreviewState.Ready(url)
                 delay(200)
                 loadInBrowser(url)
-            } else if (nodeRuntime.isNodeAvailable()) {
+            } else if (!staticMode && nodeRuntime.isNodeAvailable()) {
 
                 AppLogger.i("NodeJsAppPreview", "Node.js runtime available, starting backend server")
                 nodeJsAppPreviewState = NodeJsAppPreviewState.StartingServer


### PR DESCRIPTION
## Summary

Second batch of preview-vs-export parity fixes (follow-up to #622), from a systematic audit of the same drift pattern: shared runtime code fed different arguments by the host preview (`WebViewActivity`) and the exported APK (`ui/shell`). No config model or shell JSON schema changes — all fixes are call-site/mapper level.

### Exported APK now matches preview

- **Multi-web HTML sites render again.** `MultiWebContentEmbedder` embeds per-site projects at `assets/multiweb_sites/<siteId>/<assetBase>`, but the shell extraction looked only at top-level `assets/<assetBase>` — a path that never exists in MULTI_WEB APKs, so exported HTML sites rendered blank. Extraction now resolves the embedded per-site root when `siteId` is set.
- **Announcement triggers work.** `ShellScreen` now gates on a fully-populated `Announcement` (`buildShellAnnouncement`): `triggerOnLaunch=false` announcements no longer pop at launch; no-network monitoring and the interval re-show loop are wired up mirroring `WebViewActivity`; dismissal records the configured version so version bumps re-show after app updates (was hardcoded 1).
- **Port-conflict policy honored.** All five runtime launches (Node/PHP/Python/Go/WordPress) pass the configured `portConflictMode` through a safe parser in `ShellUtils` (`resolveShellPortConflictMode`); PHP also passes its extension toggles. Previously user-configured ALERT silently degraded to AUTO_KILL (port-killing) on every export-path start.
- **HTML/FRONTEND autoplay.** `buildWebViewConfig` enables gesture-free playback for local-file apps (`mediaAutoplayEnabled || isLocalFileApp`), matching WebViewActivity's unconditional override.
- **Link click crash guard** in the announcement dialog (blank/blocked URL toast + try/catch around startActivity).
- **SSL error banner localized** via `Strings.sslError` (was hardcoded Chinese).
- **Title-less announcements** with content are no longer suppressed (gate is title-or-content, matching `AnnouncementManager`).

### Preview now matches exported APK

- Node.js preview honors `nodejsConfig.buildMode`: doc-root sniffing only runs in STATIC mode; API_BACKEND always starts the backend server even if a bundled frontend exists.

Fixes #625

## Test plan

- [x] `:app:compileStandardDebugKotlin` green
- [x] `:app:testStandardDebugUnitTest` full suite green locally
- [x] `:app:checkConfigFieldDrift` green
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` template rebuilt; synced sources verified to contain all changes
- [ ] CI (`Android CI Build / check`) green on this PR