### PR TITLE
fix(shell): activation-gate splash/BGM; align appId-preview sourcing and misc parity

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellBgmPlayer.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellBgmPlayer.kt
@@ -59,7 +59,8 @@ internal fun parseLrcText(text: String): LrcData? {
 @Composable
 fun rememberBgmPlayerState(
     context: Context,
-    config: ShellConfig
+    config: ShellConfig,
+    enabled: Boolean = true
 ): BgmPlayerState {
 
     val bgmPlayerState = remember { mutableStateOf<MediaPlayer?>(null) }
@@ -126,7 +127,10 @@ fun rememberBgmPlayerState(
         }
     }
 
-    LaunchedEffect(config.bgmEnabled) {
+    LaunchedEffect(config.bgmEnabled, enabled) {
+        // Gated on activation resolution by the caller: an activation-gated app must not
+        // autoplay BGM behind the activation gate.
+        if (!enabled) return@LaunchedEffect
         if (config.bgmEnabled && config.bgmPlaylist.isNotEmpty()) {
             try {
 

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellScreen.kt
@@ -128,8 +128,11 @@ fun ShellScreen(
         } else false
     }
 
-    var showSplash by remember { mutableStateOf(config.splashEnabled && splashMediaExists) }
-    var splashCountdown by remember { mutableIntStateOf(if (config.splashEnabled && splashMediaExists) config.splashDuration else 0) }
+    // Splash starts only once activation has resolved (preview parity): an activation-gated
+    // app must not play its splash behind the activation gate. Apps without an activation
+    // requirement keep the old immediate start.
+    var showSplash by remember { mutableStateOf(config.splashEnabled && splashMediaExists && !config.activationEnabled) }
+    var splashCountdown by remember { mutableIntStateOf(if (showSplash) config.splashDuration else 0) }
     var originalOrientation by remember { mutableIntStateOf(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) }
 
     LaunchedEffect(showSplash) {
@@ -259,6 +262,13 @@ fun ShellScreen(
             }
         }
 
+        if (isActivated) {
+            showSplash = config.splashEnabled && splashMediaExists
+            if (showSplash) {
+                splashCountdown = config.splashDuration
+            }
+        }
+
         AppLogger.d("ShellActivity", "LaunchedEffect: showSplash=$showSplash, splashCountdown=$splashCountdown")
 
     }
@@ -351,7 +361,7 @@ fun ShellScreen(
         }
     }
 
-    val bgmState = rememberBgmPlayerState(context, config)
+    val bgmState = rememberBgmPlayerState(context, config, enabled = isActivated)
 
     val webViewCallbacks = remember {
         createShellWebViewCallbacks(

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -160,6 +160,8 @@ fun SplashLauncherScreen(
 
     var showAnnouncementDialog by remember { mutableStateOf(false) }
 
+    val scope = rememberCoroutineScope()
+
     var showSplash by remember { mutableStateOf(false) }
     var countdown by remember { mutableIntStateOf(
         if (splashType == SplashType.VIDEO) ((videoEndMs - videoStartMs) / 1000).toInt() else splashDuration
@@ -168,7 +170,11 @@ fun SplashLauncherScreen(
     LaunchedEffect(isActivated) {
         if (isActivated) {
 
-            if (announcementEnabled && announcement.title.isNotEmpty()) {
+            // Respect showOnce/version pinning like the in-app announcement paths; without
+            // this gate the dialog re-appeared on every clone launch.
+            val announceNow = announcementEnabled && announcement.title.isNotEmpty() &&
+                com.webtoapp.WebToAppApplication.announcement.shouldShowAnnouncement(activationAppId, announcement)
+            if (announceNow) {
                 showAnnouncementDialog = true
             } else {
 
@@ -183,6 +189,9 @@ fun SplashLauncherScreen(
 
     fun onAnnouncementDismiss() {
         showAnnouncementDialog = false
+        scope.launch {
+            com.webtoapp.WebToAppApplication.announcement.markAnnouncementShown(activationAppId, announcement.version)
+        }
         if (hasValidSplash && splashPath != null) {
             showSplash = true
         } else {

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -145,6 +145,15 @@ class WebViewActivity : AppCompatActivity() {
 
     internal var enableBackStatePreservation: Boolean = false
 
+    // Follow-system dark mode of the app currently being previewed, resolved from the
+    // intent-carried preview app or (after load) the saved app; consumed by
+    // onConfigurationChanged because uiMode changes do not recreate this activity.
+    private var activeFollowSystemDarkMode: Boolean? = null
+
+    // Saved app resolved by WebViewScreen for app-id launches (null for preview/test intents);
+    // lets Activity-level handlers (back behavior) see the effective config.
+    private var resolvedSavedApp: WebApp? = null
+
     private var immersiveFullscreenEnabled: Boolean = false
     private var showStatusBarInFullscreen: Boolean = false
     internal var showNavigationBarInFullscreen: Boolean = false
@@ -741,6 +750,7 @@ class WebViewActivity : AppCompatActivity() {
         } else null
 
         enableBackStatePreservation = previewApp?.webViewConfig?.enableBackStatePreservation ?: false
+        activeFollowSystemDarkMode = previewApp?.webViewConfig?.followSystemDarkMode
         com.webtoapp.core.engine.GeckoViewEngine.applyEnterpriseRootsEnabled(
             previewApp?.apkExportConfig?.networkTrustConfig?.trustUserCa == true
         )
@@ -792,17 +802,32 @@ class WebViewActivity : AppCompatActivity() {
                     statusBarAutoColor = color
                     refreshStatusBarAppearance()
                 },
+                onSavedAppLoaded = { app ->
+                    resolvedSavedApp = app
+                    // App-id launches resolve these from the saved config; the onCreate pass
+                    // only covers intent-carried preview apps.
+                    if (previewApp == null) {
+                        enableBackStatePreservation = app.webViewConfig.enableBackStatePreservation
+                        activeFollowSystemDarkMode = app.webViewConfig.followSystemDarkMode
+                        com.webtoapp.core.engine.GeckoViewEngine.applyEnterpriseRootsEnabled(
+                            app.apkExportConfig?.networkTrustConfig?.trustUserCa == true
+                        )
+                    }
+                },
                 onWebViewCreated = { wv, loadedApp ->
                     webView = wv
 
                     wv.onResume()
                     wv.resumeTimers()
 
+                    // Download location config follows the same preview/intent-vs-appid
+                    // sourcing as the bridges below.
+                    val effectiveDownloadConfig = previewApp?.webViewConfig ?: loadedApp?.webViewConfig
                     val downloadBridge = com.webtoapp.core.webview.DownloadBridge(
                         this@WebViewActivity,
                         lifecycleScope,
-                        previewApp?.webViewConfig?.downloadLocationMode ?: com.webtoapp.data.model.DownloadLocationMode.SYSTEM_DOWNLOAD,
-                        previewApp?.webViewConfig?.customDownloadDirUri ?: ""
+                        effectiveDownloadConfig?.downloadLocationMode ?: com.webtoapp.data.model.DownloadLocationMode.SYSTEM_DOWNLOAD,
+                        effectiveDownloadConfig?.customDownloadDirUri ?: ""
                     )
                     wv.addJavascriptInterface(downloadBridge, com.webtoapp.core.webview.DownloadBridge.JS_INTERFACE_NAME)
 
@@ -842,7 +867,7 @@ class WebViewActivity : AppCompatActivity() {
                         mediaSessionBridge = mediaBridge
                     }
 
-                    if (previewApp?.translateEnabled == true) {
+                    if (previewApp?.translateEnabled == true || loadedApp?.translateEnabled == true) {
                         val translateBridge = com.webtoapp.core.webview.TranslateBridge(wv, lifecycleScope)
                         wv.addJavascriptInterface(
                             translateBridge,
@@ -880,7 +905,8 @@ class WebViewActivity : AppCompatActivity() {
                         val wv = webView
                         // "Exit app" back behavior (#151): leave immediately instead of walking
                         // web history (preview parity with the generated shell).
-                        if (previewApp?.webViewConfig?.backButtonBehavior == "EXIT") {
+                        val backBehaviorConfig = previewApp ?: resolvedSavedApp
+                        if (backBehaviorConfig?.webViewConfig?.backButtonBehavior == "EXIT") {
                             finish()
                             return
                         }
@@ -965,6 +991,22 @@ class WebViewActivity : AppCompatActivity() {
         }
     }
 
+    override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // The manifest declares uiMode in configChanges, so switching the system dark/light
+        // theme does NOT recreate this activity. The WebView's dark-mode switch must be
+        // re-derived explicitly (parity with ShellActivity / WebViewManager.refreshSystemDarkMode).
+        try {
+            val wv = webView
+            val follow = activeFollowSystemDarkMode
+            if (wv != null && follow != null) {
+                com.webtoapp.core.webview.WebViewManager.refreshSystemDarkMode(wv, follow)
+            }
+        } catch (e: Exception) {
+            AppLogger.w("WebViewActivity", "onConfigurationChanged: refresh dark mode failed", e)
+        }
+    }
+
     override fun onResume() {
         super.onResume()
         webView?.onResume()
@@ -1036,6 +1078,7 @@ fun WebViewScreen(
     testModuleIds: List<String>? = null,
     onStatusBarConfigChanged: ((com.webtoapp.data.model.StatusBarColorMode, String?, Boolean?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType, com.webtoapp.data.model.StatusBarColorMode, String?, Boolean, com.webtoapp.data.model.StatusBarBackgroundType) -> Unit)? = null,
     onStatusBarAutoColorChanged: ((String?) -> Unit)? = null,
+    onSavedAppLoaded: ((WebApp) -> Unit)? = null,
     onWebViewCreated: (WebView, WebApp?) -> Unit,
     onFileChooser: (ValueCallback<Array<Uri>>?, WebChromeClient.FileChooserParams?) -> Boolean,
     onShowCustomView: (View, WebChromeClient.CustomViewCallback?) -> Unit,
@@ -1318,6 +1361,8 @@ fun WebViewScreen(
                     subscriptionUrls = app.adBlockSubscriptions
                 )
 
+                onSavedAppLoaded?.invoke(app)
+
                 if (app.activationEnabled) {
 
                     if (app.activationRequireEveryTime) {
@@ -1405,7 +1450,8 @@ fun WebViewScreen(
                     }
                     com.webtoapp.data.model.OrientationMode.AUTO -> {
 
-                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                        // USER (not SENSOR) to match ShellScreen's AUTO handling.
+                        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
                     }
                     com.webtoapp.data.model.OrientationMode.PORTRAIT -> {
                         if (com.webtoapp.util.TvUtils.isTv(context)) {
@@ -1427,7 +1473,9 @@ fun WebViewScreen(
                     com.webtoapp.data.model.ScreenAwakeMode.TIMED -> {
                         activity.window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
-                        val timeoutMs = app.webViewConfig.screenAwakeTimeoutMinutes * 60 * 1000L
+                        // Unset minutes fall back to 30 like the exported shell does.
+                        val timeoutMinutes = app.webViewConfig.screenAwakeTimeoutMinutes
+                        val timeoutMs = (if (timeoutMinutes > 0) timeoutMinutes else 30) * 60 * 1000L
                         kotlinx.coroutines.MainScope().launch {
                             kotlinx.coroutines.delay(timeoutMs)
                             activity.window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -2989,6 +3037,7 @@ fun WebViewScreen(
                     val shellConfig = com.webtoapp.core.shell.ShellConfig(
                         appName = mwApp.name,
                         appType = "MULTI_WEB",
+                        engineType = mwApp.apkExportConfig?.engineType ?: "SYSTEM_WEBVIEW",
                         multiWebConfig = com.webtoapp.core.shell.MultiWebShellConfig(
                             sites = multiWebConfig.sites.map { site ->
                                 val siteShellConfig = if (site.sourceAppId > 0) {


### PR DESCRIPTION
## Summary

Third batch of preview-vs-export parity fixes (follow-up to #622, #626), covering the remaining safe alignments from the systematic audit. No config model or shell JSON schema changes.

### Exported APK matches preview

- **Splash gated on activation.** `ShellScreen` initialized `showSplash` from config alone, so activation-gated apps played their splash on top of the activation dialog. Splash now starts only after activation resolves; apps without an activation requirement keep the immediate start.
- **BGM gated on activation.** `rememberBgmPlayerState` gains an `enabled` flag; `ShellScreen` passes `isActivated`, so BGM no longer autoplays behind the activation gate and starts once activation succeeds.

### Preview matches exported APK

- **App-id preview launches now apply saved-config behaviors** that were sourced exclusively from intent-carried `previewApp` JSON: back-button EXIT, back-state preservation, download location mode, translate bridge, enterprise-CA trust, follow-system dark mode. `WebViewScreen` gained an `onSavedAppLoaded` callback; the Activity applies these once the saved app resolves (and keeps a `resolvedSavedApp` reference for the back handler).
- **System dark/light switches refresh the WebView live.** `WebViewActivity` declares `uiMode` in `configChanges` so it is never recreated on theme changes; `onConfigurationChanged` now re-derives dark mode via `WebViewManager.refreshSystemDarkMode`, same as `ShellActivity`.
- **Orientation AUTO** maps to `USER` (was `SENSOR`), matching ShellScreen.
- **TIMED keep-screen-on** falls back to 30 minutes when minutes are unset (was a 0 ms timeout that cleared the flag immediately).
- **MULTI_WEB preview honors `engineType`**: the inline preview `ShellConfig` passes it through instead of forcing SYSTEM_WEBVIEW.

### Clone launcher

- `SplashLauncherActivity` announcements respect showOnce/version pinning (`shouldShowAnnouncement`) and record the shown version on dismissal; previously the dialog re-appeared on every clone launch.

### Investigated, intentionally unchanged

pip `installDeps` hardcode on export (hasPipDeps is auto-derived from requirements.txt existence — equivalent) and mapper catch-default mismatches (only reachable with hand-corrupted JSON).

Fixes #627

## Test plan

- [x] `:app:compileStandardDebugKotlin` green
- [x] `:app:testStandardDebugUnitTest` full suite green locally
- [x] `:app:checkConfigFieldDrift` green
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` template rebuilt; synced sources verified to contain the changes
- [ ] CI (`Android CI Build / check`) green on this PR