### PR TITLE
fix(splash): stop video splash crash on back press (MediaPlayer release race)

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellMediaContent.kt
@@ -97,14 +97,15 @@ fun ShellSplashOverlay(
 
                 LaunchedEffect(isPlayerReady) {
                     if (!isPlayerReady) return@LaunchedEffect
-                    mediaPlayer?.let { mp ->
-
-                        while (!mp.isPlaying) {
-                            delay(50)
-                            if (mediaPlayer == null) return@LaunchedEffect
-                        }
-
-                        while (mp.isPlaying) {
+                    while (true) {
+                        // Re-read the live player each iteration: a back press during the
+                        // splash releases it and nulls the state mid-poll.
+                        val mp = mediaPlayer ?: return@LaunchedEffect
+                        try {
+                            if (!mp.isPlaying) {
+                                delay(50)
+                                continue
+                            }
                             val currentPos = mp.currentPosition
 
                             videoRemainingMs = (videoEndMs - currentPos).coerceAtLeast(0L)
@@ -114,8 +115,11 @@ fun ShellSplashOverlay(
                                 onComplete?.invoke()
                                 break
                             }
-                            delay(100)
+                        } catch (e: IllegalStateException) {
+                            // Player released between iterations; the splash is going away.
+                            return@LaunchedEffect
                         }
+                        delay(100)
                     }
                 }
 
@@ -134,12 +138,22 @@ fun ShellSplashOverlay(
                                                 val volume = if (enableAudio) 1f else 0f
                                                 setVolume(volume, volume)
                                                 isLooping = false
-                                                setOnPreparedListener {
-                                                    seekTo(videoStartMs.toInt())
-                                                    start()
-                                                    isPlayerReady = true
+                                                setOnPreparedListener { mp ->
+                                                    // prepareAsync may still be in flight when a
+                                                    // back press releases the player; skip stale
+                                                    // callbacks (issue #612).
+                                                    if (mediaPlayer !== mp) return@setOnPreparedListener
+                                                    try {
+                                                        seekTo(videoStartMs.toInt())
+                                                        start()
+                                                        isPlayerReady = true
+                                                    } catch (e: IllegalStateException) {
+                                                        AppLogger.e("ShellActivity", "Splash player released before prepared", e)
+                                                    }
                                                 }
-                                                setOnCompletionListener { onComplete?.invoke() }
+                                                setOnCompletionListener { mp ->
+                                                    if (mediaPlayer === mp) onComplete?.invoke()
+                                                }
                                                 prepareAsync()
                                             }
                                             return
@@ -165,12 +179,19 @@ fun ShellSplashOverlay(
                                                 val volume = if (enableAudio) 1f else 0f
                                                 setVolume(volume, volume)
                                                 isLooping = false
-                                                setOnPreparedListener {
-                                                    seekTo(videoStartMs.toInt())
-                                                    start()
-                                                    isPlayerReady = true
+                                                setOnPreparedListener { mp ->
+                                                    if (mediaPlayer !== mp) return@setOnPreparedListener
+                                                    try {
+                                                        seekTo(videoStartMs.toInt())
+                                                        start()
+                                                        isPlayerReady = true
+                                                    } catch (e: IllegalStateException) {
+                                                        AppLogger.e("ShellActivity", "Splash player released before prepared", e)
+                                                    }
                                                 }
-                                                setOnCompletionListener { onComplete?.invoke() }
+                                                setOnCompletionListener { mp ->
+                                                    if (mediaPlayer === mp) onComplete?.invoke()
+                                                }
                                                 prepareAsync()
                                             }
                                         } else {
@@ -182,12 +203,19 @@ fun ShellSplashOverlay(
                                                 val volume = if (enableAudio) 1f else 0f
                                                 setVolume(volume, volume)
                                                 isLooping = false
-                                                setOnPreparedListener {
-                                                    seekTo(videoStartMs.toInt())
-                                                    start()
-                                                    isPlayerReady = true
+                                                setOnPreparedListener { mp ->
+                                                    if (mediaPlayer !== mp) return@setOnPreparedListener
+                                                    try {
+                                                        seekTo(videoStartMs.toInt())
+                                                        start()
+                                                        isPlayerReady = true
+                                                    } catch (e: IllegalStateException) {
+                                                        AppLogger.e("ShellActivity", "Splash player released before prepared", e)
+                                                    }
                                                 }
-                                                setOnCompletionListener { onComplete?.invoke() }
+                                                setOnCompletionListener { mp ->
+                                                    if (mediaPlayer === mp) onComplete?.invoke()
+                                                }
                                                 prepareAsync()
                                             }
                                             afd.close()
@@ -199,6 +227,11 @@ fun ShellSplashOverlay(
                                 }
                                 override fun surfaceChanged(h: android.view.SurfaceHolder, f: Int, w: Int, ht: Int) {}
                                 override fun surfaceDestroyed(h: android.view.SurfaceHolder) {
+                                    // Detach callbacks before releasing so in-flight
+                                    // prepare/completion notifications cannot touch a
+                                    // released player (issue #612).
+                                    mediaPlayer?.setOnPreparedListener(null)
+                                    mediaPlayer?.setOnCompletionListener(null)
                                     mediaPlayer?.release()
                                     mediaPlayer = null
                                 }
@@ -210,6 +243,8 @@ fun ShellSplashOverlay(
 
                 DisposableEffect(Unit) {
                     onDispose {
+                        mediaPlayer?.setOnPreparedListener(null)
+                        mediaPlayer?.setOnCompletionListener(null)
                         mediaPlayer?.release()
                         mediaPlayer = null
 

--- a/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/splash/SplashLauncherActivity.kt
@@ -405,14 +405,15 @@ fun SplashContent(
 
                 LaunchedEffect(isPlayerReady) {
                     if (!isPlayerReady) return@LaunchedEffect
-                    mediaPlayer?.let { mp ->
-
-                        while (!mp.isPlaying) {
-                            delay(50)
-                            if (mediaPlayer == null) return@LaunchedEffect
-                        }
-
-                        while (mp.isPlaying) {
+                    while (true) {
+                        // Re-read the live player each iteration: a back press during the
+                        // splash releases it and nulls the state mid-poll (issue #612).
+                        val mp = mediaPlayer ?: return@LaunchedEffect
+                        try {
+                            if (!mp.isPlaying) {
+                                delay(50)
+                                continue
+                            }
                             val currentPos = mp.currentPosition
 
                             videoRemainingMs = (videoEndMs - currentPos).coerceAtLeast(0L)
@@ -421,8 +422,11 @@ fun SplashContent(
                                 onSkip()
                                 break
                             }
-                            delay(100)
+                        } catch (e: IllegalStateException) {
+                            // Player released between iterations; the splash is going away.
+                            return@LaunchedEffect
                         }
+                        delay(100)
                     }
                 }
 
@@ -439,12 +443,23 @@ fun SplashContent(
                                             val volume = if (enableAudio) 1f else 0f
                                             setVolume(volume, volume)
                                             isLooping = false
-                                            setOnPreparedListener {
-                                                seekTo(videoStartMs.toInt())
-                                                start()
-                                                isPlayerReady = true
+                                            setOnPreparedListener { mp ->
+                                                // prepareAsync may still be in flight when a
+                                                // back press releases the player; skip stale
+                                                // callbacks instead of touching a released
+                                                // instance (issue #612).
+                                                if (mediaPlayer !== mp) return@setOnPreparedListener
+                                                try {
+                                                    seekTo(videoStartMs.toInt())
+                                                    start()
+                                                    isPlayerReady = true
+                                                } catch (e: IllegalStateException) {
+                                                    AppLogger.e("SplashLauncherActivity", "Splash player released before prepared", e)
+                                                }
                                             }
-                                            setOnCompletionListener { onSkip() }
+                                            setOnCompletionListener { mp ->
+                                                if (mediaPlayer === mp) onSkip()
+                                            }
                                             prepareAsync()
                                         }
                                     } catch (e: Exception) {
@@ -454,6 +469,11 @@ fun SplashContent(
                                 }
                                 override fun surfaceChanged(h: android.view.SurfaceHolder, f: Int, w: Int, ht: Int) {}
                                 override fun surfaceDestroyed(h: android.view.SurfaceHolder) {
+                                    // Detach callbacks before releasing so in-flight
+                                    // prepare/completion notifications cannot touch a
+                                    // released player.
+                                    mediaPlayer?.setOnPreparedListener(null)
+                                    mediaPlayer?.setOnCompletionListener(null)
                                     mediaPlayer?.release()
                                     mediaPlayer = null
                                 }
@@ -465,6 +485,8 @@ fun SplashContent(
 
                 DisposableEffect(Unit) {
                     onDispose {
+                        mediaPlayer?.setOnPreparedListener(null)
+                        mediaPlayer?.setOnCompletionListener(null)
                         mediaPlayer?.release()
                         mediaPlayer = null
                     }

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewSplashOverlay.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewSplashOverlay.kt
@@ -81,15 +81,15 @@ fun SplashOverlay(
 
                 LaunchedEffect(isPlayerReady) {
                     if (!isPlayerReady) return@LaunchedEffect
-                    mediaPlayer?.let { mp ->
-
-                        while (!mp.isPlaying) {
-                            delay(50)
-
-                            if (mediaPlayer == null) return@LaunchedEffect
-                        }
-
-                        while (mp.isPlaying) {
+                    while (true) {
+                        // Re-read the live player each iteration: a back press during the
+                        // splash releases it and nulls the state mid-poll.
+                        val mp = mediaPlayer ?: return@LaunchedEffect
+                        try {
+                            if (!mp.isPlaying) {
+                                delay(50)
+                                continue
+                            }
                             val currentPos = mp.currentPosition
 
                             videoRemainingMs = (videoEndMs - currentPos).coerceAtLeast(0L)
@@ -99,8 +99,11 @@ fun SplashOverlay(
                                 onComplete?.invoke()
                                 break
                             }
-                            delay(100)
+                        } catch (e: IllegalStateException) {
+                            // Player released between iterations; the splash is going away.
+                            return@LaunchedEffect
                         }
+                        delay(100)
                     }
                 }
 
@@ -117,13 +120,23 @@ fun SplashOverlay(
                                             val volume = if (splashConfig.enableAudio) 1f else 0f
                                             setVolume(volume, volume)
                                             isLooping = false
-                                            setOnPreparedListener {
-
-                                                seekTo(videoStartMs.toInt())
-                                                start()
-                                                isPlayerReady = true
+                                            setOnPreparedListener { mp ->
+                                                // prepareAsync may still be in flight when a
+                                                // back press releases the player; skip stale
+                                                // callbacks instead of touching a released
+                                                // instance (issue #612).
+                                                if (mediaPlayer !== mp) return@setOnPreparedListener
+                                                try {
+                                                    seekTo(videoStartMs.toInt())
+                                                    start()
+                                                    isPlayerReady = true
+                                                } catch (e: IllegalStateException) {
+                                                    AppLogger.e("WebViewActivity", "Splash player released before prepared", e)
+                                                }
                                             }
-                                            setOnCompletionListener { onComplete?.invoke() }
+                                            setOnCompletionListener { mp ->
+                                                if (mediaPlayer === mp) onComplete?.invoke()
+                                            }
                                             prepareAsync()
                                         }
                                     } catch (e: Exception) {
@@ -133,6 +146,11 @@ fun SplashOverlay(
                                 }
                                 override fun surfaceChanged(h: android.view.SurfaceHolder, f: Int, w: Int, ht: Int) {}
                                 override fun surfaceDestroyed(h: android.view.SurfaceHolder) {
+                                    // Detach callbacks before releasing so in-flight
+                                    // prepare/completion notifications cannot touch a
+                                    // released player.
+                                    mediaPlayer?.setOnPreparedListener(null)
+                                    mediaPlayer?.setOnCompletionListener(null)
                                     mediaPlayer?.release()
                                     mediaPlayer = null
                                 }
@@ -144,6 +162,8 @@ fun SplashOverlay(
 
                 DisposableEffect(Unit) {
                     onDispose {
+                        mediaPlayer?.setOnPreparedListener(null)
+                        mediaPlayer?.setOnCompletionListener(null)
                         mediaPlayer?.release()
                         mediaPlayer = null
                     }


### PR DESCRIPTION
## Summary

Fixes the crash reported in #612: pressing the phone's back button while a **video splash screen** plays crashes the app (system "Send Report" dialog), in both the builder preview and the exported APK, and re-occurs on every relaunch.

### Root cause

The video splash player block is duplicated in three places — `WebViewSplashOverlay` (host preview), `ShellMediaContent` VIDEO branch (exported APK, shell-synced) and `SplashLauncherActivity` `SplashContent` (clone launcher) — and all three copies raced player release against in-flight callbacks:

- `surfaceCreated` starts `prepareAsync()`; listeners are never detached;
- back press tears down the composition → `surfaceDestroyed` releases the player;
- a late `onPrepared` then calls `seekTo()/start()` on the **released** player → `IllegalStateException` → crash (guaranteed when back is pressed during the prepare window right after launch);
- the progress-polling `LaunchedEffect` dereferences a captured player after release → same exception;
- `onCompletion` can fire post-release onto a dead composition.

### Fix (identical pattern in all three copies)

- detach `onPreparedListener`/`onCompletionListener` **before** `release()` in `surfaceDestroyed` and `onDispose`;
- identity-guard callbacks against the live player (`mediaPlayer === mp`) so stale notifications are skipped;
- wrap `seekTo/start` in `IllegalStateException` handling as belt-and-braces;
- poll through the live state reference each iteration and exit cleanly when the player is gone.

Normal completion (video end, countdown, skip) is unchanged.

Fixes #631

## Test plan

- [x] `:app:compileStandardDebugKotlin` green
- [x] `:app:testStandardDebugUnitTest` full suite green locally
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` template rebuilt (ShellMediaContent is shell-synced); `:app:checkConfigFieldDrift` green
- [ ] CI (`Android CI Build / check`) green on this PR