### PR TITLE
fix(shell): keyboard no longer covers inputs with RESIZE mode below API 30

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -2,6 +2,7 @@ package com.webtoapp.ui.shared
 
 import android.app.Activity
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -230,7 +231,16 @@ object WindowHelper {
         when (mode) {
             KeyboardAdjustMode.RESIZE -> {
 
-                if (decorFitsSystemWindows) {
+                // androidx only reports IME insets on API < 30 when the window runs with
+                // SOFT_INPUT_ADJUST_RESIZE; with ADJUST_NOTHING the manual padding below
+                // never sees a non-zero IME inset on Android 10 and lower, so the keyboard
+                // covered the input regardless of this setting (issue #613). Those devices
+                // fall back to the system resize path, which also lets the WebView scroll
+                // the focused input into view on its own.
+                val useManualImePadding = !decorFitsSystemWindows &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+
+                if (!useManualImePadding) {
                     @Suppress("DEPRECATION")
                     activity.window.setSoftInputMode(
                         WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE or

--- a/app/src/test/java/com/webtoapp/ui/shared/WindowHelperKeyboardModeTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shared/WindowHelperKeyboardModeTest.kt
@@ -1,0 +1,73 @@
+package com.webtoapp.ui.shared
+
+import android.app.Activity
+import android.view.WindowManager
+import com.google.common.truth.Truth.assertThat
+import com.webtoapp.data.model.KeyboardAdjustMode
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression coverage for issue #613: the RESIZE keyboard mode used to set
+ * SOFT_INPUT_ADJUST_NOTHING on every device and rely on manual IME padding, but
+ * androidx only reports IME insets on API < 30 when the window runs with
+ * SOFT_INPUT_ADJUST_RESIZE — so on Android 10 and lower the padding stayed 0 and
+ * the keyboard covered the focused input.
+ */
+class WindowHelperKeyboardModeTest {
+
+    @RunWith(RobolectricTestRunner::class)
+    @Config(sdk = [29])
+    class PreApi30Test {
+
+        @Test
+        fun `resize mode falls back to system adjust resize below API 30`() {
+            val activity = Robolectric.setupActivity(Activity::class.java)
+
+            WindowHelper.applyImmersiveFullscreen(
+                activity,
+                enabled = false,
+                keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+            )
+
+            val mode = activity.window.attributes.softInputMode
+            assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE).isNotEqualTo(0)
+        }
+
+        @Test
+        fun `nothing mode keeps adjust nothing below API 30`() {
+            val activity = Robolectric.setupActivity(Activity::class.java)
+
+            WindowHelper.applyImmersiveFullscreen(
+                activity,
+                enabled = false,
+                keyboardAdjustMode = KeyboardAdjustMode.NOTHING
+            )
+
+            val mode = activity.window.attributes.softInputMode
+            assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
+        }
+    }
+
+    @RunWith(RobolectricTestRunner::class)
+    @Config(sdk = [30])
+    class Api30Test {
+
+        @Test
+        fun `resize mode keeps manual ime padding path on API 30+`() {
+            val activity = Robolectric.setupActivity(Activity::class.java)
+
+            WindowHelper.applyImmersiveFullscreen(
+                activity,
+                enabled = false,
+                keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+            )
+
+            val mode = activity.window.attributes.softInputMode
+            assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #613: with the push-up keyboard option (键盘调整模式 → RESIZE) selected, the soft keyboard still covered the focused web input on some devices, and switching kernels/settings didn't help.

### Root cause

`applyImmersiveFullscreen` sets `decorFitsSystemWindows=false` in every branch, so RESIZE always takes the edge-to-edge path: `SOFT_INPUT_ADJUST_NOTHING` + manual bottom padding on `android.R.id.content` driven by `WindowInsetsCompat.Type.ime()`. But **androidx only reports IME insets on API < 30 when the window runs with `SOFT_INPUT_ADJUST_RESIZE`** (native IME-insets dispatch starts at API 30). With `ADJUST_NOTHING`, on Android 10 and lower `getInsets(Type.ime())` is always 0, so the padding never applied and the insets-animation callbacks (including the scroll-input-into-view helper) never fired — RESIZE silently degraded to NOTHING on those devices. Android 11+ works, matching the "some devices" nature of the report. Kernel switching can't help: the padding sits above the kernel, and the JS scroll assist only recognizes `android.webkit.WebView`.

### Fix

`applyKeyboardMode` now gates the manual-padding path on API 30+ (`Build.VERSION_CODES.R`). Below API 30 it uses the system `SOFT_INPUT_ADJUST_RESIZE` path — the system resizes the window and the WebView scrolls the focused input into view on its own. No `FLAG_FULLSCREEN` is involved, so system resize works under the edge-to-edge layout flags. Android 11+ behavior is unchanged; `NOTHING` mode is untouched on all APIs.

Fixes #613

## Test plan

- [x] New Robolectric regression tests: SDK 29 + RESIZE → window ends in `SOFT_INPUT_ADJUST_RESIZE`; SDK 30 + RESIZE → `SOFT_INPUT_ADJUST_NOTHING` (manual path); NOTHING unchanged
- [x] `:app:testStandardDebugUnitTest` full suite green locally
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` template rebuilt (`ui/shared` is shell-synced); `:app:checkConfigFieldDrift` green
- [ ] CI (`Android CI Build / check`) green on this PR