### PR TITLE
feat(adblock): first-class custom hosts sources, selectable per app

### DIFF
--- a/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
+++ b/app/src/main/java/com/webtoapp/core/adblock/AdBlocker.kt
@@ -673,6 +673,10 @@ class AdBlocker {
 
     private val sourceRuleCounts = mutableMapOf<String, Int>()
 
+    /** Display names for user-imported (custom) sources, keyed by source key. Preset
+     *  sources resolve their names from [getPopularHostsSources] instead. */
+    private val customSourceNames = mutableMapOf<String, String>()
+
     private val networkBlockFilters = mutableListOf<NetworkFilter>()
     private val networkExceptionFilters = mutableListOf<NetworkFilter>()
 
@@ -971,6 +975,7 @@ class AdBlocker {
                 enabledHostsSources.remove(sourceKey)
             }
             rebuildHostsFromSourceContents(context)
+            saveSourcesRegistry(context)
             invalidateCache()
             Result.success(Unit)
         } catch (e: Exception) {
@@ -983,8 +988,10 @@ class AdBlocker {
             enabledHostsSources.remove(sourceKey)
             disabledHostsSources.remove(sourceKey)
             sourceRuleCounts.remove(sourceKey)
+            customSourceNames.remove(sourceKey)
             AdBlockFilterCache.removeSourceContent(context, sourceKey)
             rebuildHostsFromSourceContents(context)
+            saveSourcesRegistry(context)
             invalidateCache()
             Result.success(Unit)
         } catch (e: Exception) {
@@ -1154,6 +1161,43 @@ class AdBlocker {
     fun getAllDownloadedSourceKeys(): Set<String> = enabledHostsSources + disabledHostsSources
     fun isHostsSourceDownloaded(url: String): Boolean =
         enabledHostsSources.contains(url) || disabledHostsSources.contains(url)
+
+    /**
+     * User-imported sources (file picks / custom URLs) as listable entries, i.e. registry
+     * keys that are not one of the preset [getPopularHostsSources] URLs. Preset sources
+     * keep their hardcoded [HostsSource] metadata; custom ones resolve their display name
+     * from the import-time metadata (registry v2) with structural fallbacks.
+     */
+    fun getCustomHostsSources(): List<HostsSource> {
+        val presetUrls = getPopularHostsSources().map { it.url }.toSet()
+        return (enabledHostsSources + disabledHostsSources)
+            .filter { it !in presetUrls }
+            .map { key ->
+                HostsSource(
+                    name = customSourceNames[key] ?: fallbackSourceName(key),
+                    url = key,
+                    description = key
+                )
+            }
+            .sortedBy { it.name.lowercase() }
+    }
+
+    private fun fallbackSourceName(key: String): String {
+        if (key.startsWith("file:")) {
+            return extractSourceDisplayName(key)
+                ?: java.util.Locale.ROOT.let { key.removePrefix("file:").takeLast(48) }
+        }
+        return runCatching { java.net.URI(key).host }.getOrNull()
+            ?: key.takeLast(48)
+    }
+
+    private fun extractSourceDisplayName(rawUri: String): String? {
+        val raw = rawUri.substringAfterLast('/')
+            .substringBefore('?')
+            .substringBefore('#')
+        val decoded = android.net.Uri.decode(raw).trim()
+        return decoded.ifBlank { null }
+    }
 
     private fun parseAndAddRule(rawRule: String) {
         val rule = rawRule.trim()
@@ -1673,7 +1717,15 @@ class AdBlocker {
             enabledHostsSources.add(sourceKey)
             disabledHostsSources.remove(sourceKey)
             sourceRuleCounts[sourceKey] = count
+            val resolverDisplayName = context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val idx = cursor.getColumnIndex(android.provider.OpenableColumns.DISPLAY_NAME)
+                if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx)?.trim() else null
+            }
+            customSourceNames[sourceKey] = resolverDisplayName
+                ?: extractSourceDisplayName(uri.toString())
+                ?: "custom-filters"
             AdBlockFilterCache.saveSourceContent(context, sourceKey, content)
+            saveSourcesRegistry(context)
             Result.success(count)
         } catch (e: Exception) {
             Result.failure(e)
@@ -1686,7 +1738,8 @@ class AdBlocker {
     suspend fun importHostsFromUrl(
         url: String,
         context: Context? = null,
-        onProgress: ((DownloadProgress) -> Unit)?
+        displayName: String? = null,
+        onProgress: ((DownloadProgress) -> Unit)? = null
     ): Result<Int> = withContext(Dispatchers.IO) {
         try {
 
@@ -1753,6 +1806,9 @@ class AdBlocker {
             enabledHostsSources.add(url)
             disabledHostsSources.remove(url)
             sourceRuleCounts[url] = 0
+            if (!displayName.isNullOrBlank()) {
+                customSourceNames[url] = displayName
+            }
             if (context != null) {
                 saveSourcesRegistry(context)
             }
@@ -1862,11 +1918,11 @@ class AdBlocker {
             buildString {
                 enabledHostsSources.forEach { url ->
                     val count = sourceRuleCounts[url] ?: 0
-                    appendLine("$url\t$count\t1")
+                    appendLine("$url\t$count\t1\t${customSourceNames[url] ?: ""}")
                 }
                 disabledHostsSources.forEach { url ->
                     val count = sourceRuleCounts[url] ?: 0
-                    appendLine("$url\t$count\t0")
+                    appendLine("$url\t$count\t0\t${customSourceNames[url] ?: ""}")
                 }
             }.trimEnd()
         )
@@ -1924,6 +1980,8 @@ class AdBlocker {
                     enabledHostsSources.add(url)
                 }
                 sourceRuleCounts[url] = count
+                // Optional 4th column (registry v2): display name for custom sources.
+                parts.getOrNull(3)?.takeIf { it.isNotBlank() }?.let { customSourceNames[url] = it }
             }
     }
 

--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -3008,6 +3008,7 @@ object Strings {
     val hostsRulesCount: String get() = StringsD.hostsRulesCount
     val importFromUrl: String get() = StringsD.importFromUrl
     val popularHostsSources: String get() = StringsD.popularHostsSources
+    val customHostsSources: String get() = StringsD.customHostsSources
     val importHostsUrl: String get() = StringsD.importHostsUrl
     val importHostsUrlHint: String get() = StringsD.importHostsUrlHint
     val importHostsSuccess: String get() = StringsD.importHostsSuccess
@@ -42838,6 +42839,19 @@ object StringsD {
         AppLanguage.RUSSIAN -> "Популярные источники Hosts"
         AppLanguage.JAPANESE -> "人気のHostsソース"
         AppLanguage.KOREAN -> "인기 Hosts 소스"
+    }
+
+    val customHostsSources: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "自定义源"
+        AppLanguage.ENGLISH -> "Custom Sources"
+        AppLanguage.ARABIC -> "مصادر مخصصة"
+        AppLanguage.PORTUGUESE -> "Fontes Personalizadas"
+        AppLanguage.SPANISH -> "Fuentes Personalizadas"
+        AppLanguage.FRENCH -> "Sources Personnalisées"
+        AppLanguage.GERMAN -> "Eigene Quellen"
+        AppLanguage.RUSSIAN -> "Пользовательские источники"
+        AppLanguage.JAPANESE -> "カスタムソース"
+        AppLanguage.KOREAN -> "사용자 지정 소스"
     }
 
     val importHostsUrl: String get() = when (Strings.lang) {

--- a/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/CreateAppWebViewCards.kt
@@ -444,15 +444,19 @@ fun AdBlockCard(
     val subscriptions = editState.adBlockSubscriptions
     val context = LocalContext.current
     val adBlocker = remember { com.webtoapp.WebToAppApplication.adBlock }
-    val allSources = remember { com.webtoapp.core.adblock.AdBlocker.getPopularHostsSources() }
     var hostsEpoch by remember { mutableStateOf(0) }
+    // Preset sources plus the user's custom imports (file picks / custom URLs) so the
+    // per-app subscription selector can reference anything loaded in Hosts Blocking (#623).
+    val allSources = remember(hostsEpoch) {
+        com.webtoapp.core.adblock.AdBlocker.getPopularHostsSources() + adBlocker.getCustomHostsSources()
+    }
     LaunchedEffect(Unit) {
         // Lightweight metadata-only hydration — just enough to know which sources are downloaded.
         // A full loadHostsRules() here loaded the entire filter DB on scroll and could OOM (#356).
         adBlocker.hydrateSourcesMetadata(context)
         hostsEpoch += 1
     }
-    val downloadedSources = remember(allSources, hostsEpoch) {
+    val downloadedSources = remember(allSources) {
         allSources.filter { adBlocker.isHostsSourceDownloaded(it.url) }
     }
     val validSubscriptions = subscriptions.filter { url -> downloadedSources.any { it.url == url } }

--- a/app/src/main/java/com/webtoapp/ui/screens/HostsAdBlockScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/HostsAdBlockScreen.kt
@@ -101,6 +101,7 @@ fun HostsAdBlockScreen(onBack: () -> Unit) {
     var enabledSources by remember { mutableStateOf(emptySet<String>()) }
     var disabledSources by remember { mutableStateOf(emptySet<String>()) }
     var sourceCounts by remember { mutableStateOf(emptyMap<String, Int>()) }
+    var customSources by remember { mutableStateOf(emptyList<HostsSource>()) }
     var query by rememberSaveable { mutableStateOf("") }
     var filter by rememberSaveable { mutableStateOf(HostsFilter.ALL.name) }
     var showUrlDialog by remember { mutableStateOf(false) }
@@ -120,6 +121,7 @@ fun HostsAdBlockScreen(onBack: () -> Unit) {
         disabledSources = adBlocker.getDisabledHostsSources()
         val keys = adBlocker.getAllDownloadedSourceKeys()
         sourceCounts = keys.associateWith { adBlocker.getSourceRuleCount(it) }
+        customSources = adBlocker.getCustomHostsSources()
     }
 
     val filePickerLauncher = rememberLauncherForActivityResult(
@@ -330,6 +332,50 @@ fun HostsAdBlockScreen(onBack: () -> Unit) {
                         isDownloading = isDownloading,
                         progress = progress,
                         ruleCount = ruleCount,
+                        onImport = { importSource(source) },
+                        onCancel = {
+                            downloadJobs[source.url]?.cancel()
+                            downloadProgress.remove(source.url)
+                            downloadJobs.remove(source.url)
+                        },
+                        onToggleEnabled = { checked ->
+                            scope.launch {
+                                adBlocker.setHostsSourceEnabled(context, source.url, checked)
+                                adBlocker.saveHostsRules(context)
+                                refreshState()
+                                snackbarHostState.showSnackbar(
+                                    if (checked) Strings.hostsSourceEnabled else Strings.hostsSourceDisabled
+                                )
+                            }
+                        },
+                        onDelete = { showDeleteSourceDialog = source }
+                    )
+                }
+            }
+
+            if (customSources.isNotEmpty()) {
+                item(key = "custom-sources-title") {
+                    Text(
+                        Strings.customHostsSources,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                items(customSources, key = { it.url }) { source ->
+                    val enabled = enabledSources.contains(source.url)
+                    val isDownloading = downloadProgress.containsKey(source.url)
+                    val progress = downloadProgress[source.url]
+                    val ruleCount = sourceCounts[source.url] ?: 0
+                    val isFileSource = source.url.startsWith("file:")
+
+                    HostsSourceCard(
+                        source = source,
+                        isDownloaded = true,
+                        isEnabled = enabled,
+                        isDownloading = isDownloading,
+                        progress = progress,
+                        ruleCount = ruleCount,
+                        showRetry = !isFileSource,
                         onImport = { importSource(source) },
                         onCancel = {
                             downloadJobs[source.url]?.cancel()
@@ -612,7 +658,8 @@ private fun HostsSourceCard(
     onImport: () -> Unit,
     onCancel: () -> Unit,
     onToggleEnabled: (Boolean) -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    showRetry: Boolean = true
 ) {
     WtaCard(tone = WtaCardTone.Surface) {
         Column(
@@ -695,14 +742,16 @@ private fun HostsSourceCard(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        FilledTonalButton(
-                            onClick = onImport,
-                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Icon(Icons.Outlined.Refresh, null, Modifier.size(16.dp))
-                            Spacer(Modifier.width(4.dp))
-                            Text(Strings.retry, style = MaterialTheme.typography.labelMedium)
+                        if (showRetry) {
+                            FilledTonalButton(
+                                onClick = onImport,
+                                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Icon(Icons.Outlined.Refresh, null, Modifier.size(16.dp))
+                                Spacer(Modifier.width(4.dp))
+                                Text(Strings.retry, style = MaterialTheme.typography.labelMedium)
+                            }
                         }
                         FilledTonalButton(
                             onClick = onDelete,

--- a/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
+++ b/app/src/test/java/com/webtoapp/core/adblock/AdBlockerCustomSourcesTest.kt
@@ -1,0 +1,120 @@
+package com.webtoapp.core.adblock
+
+import android.content.Context
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+/**
+ * Regression coverage for issue #623: user-imported custom filter sources must carry
+ * display metadata (registry v2), be listable via [AdBlocker.getCustomHostsSources]
+ * (excluding presets), survive restarts through the registry, be deletable, and be
+ * consumable per-app through the same subscription path as URL sources.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class AdBlockerCustomSourcesTest {
+
+    private lateinit var context: Context
+    private lateinit var adBlocker: AdBlocker
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        adBlocker = AdBlocker()
+        AdBlockFilterCache.clearCache(context)
+    }
+
+    @Test
+    fun `file import records a display name and lists a custom source`() = runBlocking {
+        val uri = Uri.parse("content://media/external/filters/my-blocklist.txt")
+        Shadows.shadowOf(context.contentResolver).registerInputStream(
+            uri,
+            "||ads.example.test^\n||tracker.example.test^".byteInputStream()
+        )
+
+        val result = adBlocker.importHostsFromFile(context, uri)
+
+        assertThat(result.isSuccess).isTrue()
+        val custom = adBlocker.getCustomHostsSources()
+        assertThat(custom).hasSize(1)
+        assertThat(custom.first().url).isEqualTo("file:$uri")
+        assertThat(custom.first().name).isEqualTo("my-blocklist.txt")
+    }
+
+    @Test
+    fun `url import with display name is listed and persists across restart`() = runBlocking {
+        val url = "https://filters.example.test/custom.txt"
+        val content = "||ads.example.test^"
+        AdBlockFilterCache.cacheUrlContent(context, url, content)
+
+        adBlocker.importHostsFromUrl(url, context, displayName = "My Custom List")
+        adBlocker.saveHostsRules(context)
+
+        assertThat(adBlocker.getCustomHostsSources().map { it.name }).containsExactly("My Custom List")
+
+        // Simulate a restart: a fresh instance rehydrates the registry from disk.
+        val fresh = AdBlocker()
+        fresh.hydrateSourcesMetadata(context)
+        val restored = fresh.getCustomHostsSources()
+        assertThat(restored).hasSize(1)
+        assertThat(restored.first().name).isEqualTo("My Custom List")
+        assertThat(restored.first().url).isEqualTo(url)
+    }
+
+    @Test
+    fun `preset urls are never listed as custom sources`() = runBlocking {
+        val preset = AdBlocker.getPopularHostsSources().first()
+        AdBlockFilterCache.cacheUrlContent(context, preset.url, "||ads.example.test^")
+
+        adBlocker.importHostsFromUrl(preset.url, context, displayName = preset.name)
+
+        assertThat(adBlocker.isHostsSourceDownloaded(preset.url)).isTrue()
+        assertThat(adBlocker.getCustomHostsSources()).isEmpty()
+    }
+
+    @Test
+    fun `removeHostsSource drops the custom source and its name`() = runBlocking {
+        val url = "https://filters.example.test/custom.txt"
+        AdBlockFilterCache.cacheUrlContent(context, url, "||ads.example.test^")
+        adBlocker.importHostsFromUrl(url, context, displayName = "Doomed List")
+        assertThat(adBlocker.getCustomHostsSources()).hasSize(1)
+
+        adBlocker.removeHostsSource(context, url)
+        adBlocker.saveHostsRules(context)
+
+        assertThat(adBlocker.getCustomHostsSources()).isEmpty()
+        assertThat(adBlocker.isHostsSourceDownloaded(url)).isFalse()
+
+        val fresh = AdBlocker()
+        fresh.hydrateSourcesMetadata(context)
+        assertThat(fresh.getCustomHostsSources()).isEmpty()
+    }
+
+    @Test
+    fun `file source key is consumable through the per-app subscription path`() = runBlocking {
+        val uri = Uri.parse("content://media/external/filters/block.txt")
+        Shadows.shadowOf(context.contentResolver).registerInputStream(
+            uri,
+            "||ads.example.test^".byteInputStream()
+        )
+        adBlocker.importHostsFromFile(context, uri)
+        val fileKey = "file:$uri"
+
+        adBlocker.prepareRuntimeFilters(
+            context = context,
+            enabled = true,
+            customRules = emptyList(),
+            subscriptionUrls = listOf(fileKey)
+        )
+
+        assertThat(adBlocker.shouldBlock("https://ads.example.test/banner.js", resourceType = "script")).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #623. Custom filter imports were second-class citizens in both directions the reporter described:

- the **Hosts Blocking** list only rendered the hardcoded preset sources — custom imports showed up solely as a count in the top summary, with no card, no enable/disable, no delete;
- the **per-app subscription selector** enumerated presets exclusively, and its validity filter dropped non-preset subscription URLs outright, so a custom list could never be attached to an app even manually.

### Root cause

The sources registry (`adblock_hosts_sources.txt`) stored only `key \t ruleCount \t enabledFlag` — no display metadata — and both UIs hardcoded the preset source list. The engine side needed no changes: `prepareRuntimeFilters` and `compileRulesText` already resolve **any** source key through `loadSourceContent` (file-based keys read the source-content cache, URLs read the download cache), and `removeHostsSource` with full rebuild already existed unused by the UI.

### What this does

- **Registry v2**: optional 4th column stores the custom source's display name; hydration stays backward compatible with the old 3-column format. File imports record the picked file's name (content-resolver `DISPLAY_NAME`, falling back to the URI segment); URL imports take an optional display name and fall back to the URL host.
- **Hosts Blocking → Custom Sources section**: custom imports render as the same source cards as presets — enable/disable toggle (rebuilds the compiled rules), rule count, delete via the existing confirmation dialog (which now also clears the stored name and persists the registry). Retry is hidden for file-based imports where re-picking the file is required.
- **Per-app selector**: lists presets **plus downloaded custom sources**, so a custom list can finally be attached to an individual app; selected-name lookup works for them too.
- **Persistence fixes riding along**: `setHostsSourceEnabled` and `removeHostsSource` previously mutated memory without rewriting the registry file — a toggle or delete was silently reverted on process restart. Both now persist.

Fixes #623

## Test plan

- [x] New `AdBlockerCustomSourcesTest`: file-import naming, URL-import naming + registry restart round-trip, preset exclusion, deletion clearing name and registry, and per-app consumption of a `file:` source key through `prepareRuntimeFilters`
- [x] Existing `AdBlockerHostRuntimeTest` / `AdBlockerTest` green
- [x] `:app:testStandardDebugUnitTest` full suite green locally
- [x] `:shell:assembleRelease :app:syncShellTemplateApk` template rebuilt (`core/adblock` is shell-synced); `:app:checkConfigFieldDrift` green
- [ ] CI (`Android CI Build / check`) green on this PR