### PR TITLE
fix(ai): stop hardcoding the OpenAI-compat wording in the custom provider form

### DIFF
--- a/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
+++ b/app/src/main/java/com/webtoapp/core/i18n/Strings.kt
@@ -2504,13 +2504,13 @@ object Strings {
     val editApiKey: String get() = StringsC.editApiKey
     val addApiKey: String get() = StringsC.addApiKey
     val getApiKey: String get() = StringsC.getApiKey
-    val openAiCompatibleHint: String get() = StringsC.openAiCompatibleHint
+    val customBaseUrlHint: String get() = StringsC.customBaseUrlHint
     val apiFormat: String get() = StringsC.apiFormat
     val apiKeyAliasPlaceholder: String get() = StringsC.apiKeyAliasPlaceholder
     val modelsEndpoint: String get() = StringsC.modelsEndpoint
     val modelsEndpointHint: String get() = StringsC.modelsEndpointHint
     val chatEndpoint: String get() = StringsC.chatEndpoint
-    val chatEndpointHint: String get() = StringsC.chatEndpointHint
+    fun chatEndpointDefaultHint(defaultEndpoint: String): String = StringsC.chatEndpointDefaultHint(defaultEndpoint)
     val selectApiKey: String get() = StringsC.selectApiKey
     val batchSelectModels: String get() = StringsC.batchSelectModels
     val selectedModelsCount: String get() = StringsC.selectedModelsCount
@@ -36287,17 +36287,30 @@ object StringsC {
         AppLanguage.KOREAN -> "API 키 받기"
     }
 
-    val openAiCompatibleHint: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "OpenAI 兼容接口地址"
-        AppLanguage.ENGLISH -> "OpenAI compatible endpoint"
-        AppLanguage.ARABIC -> "نقطة نهاية متوافقة مع OpenAI"
-        AppLanguage.PORTUGUESE -> "Endpoint compatível com OpenAI"
-        AppLanguage.SPANISH -> "Endpoint compatible con OpenAI"
-        AppLanguage.FRENCH -> "Endpoint compatible OpenAI"
-        AppLanguage.GERMAN -> "OpenAI-kompatibler Endpoint"
-        AppLanguage.RUSSIAN -> "Endpoint, совместимый с OpenAI"
-        AppLanguage.JAPANESE -> "OpenAI互換エンドポイント"
-        AppLanguage.KOREAN -> "OpenAI 호환 엔드포인트"
+    val customBaseUrlHint: String get() = when (Strings.lang) {
+        AppLanguage.CHINESE -> "API 根地址，不含 /v1 等路径"
+        AppLanguage.ENGLISH -> "API base URL, without the /v1 path"
+        AppLanguage.ARABIC -> "عنوان URL الأساسي لواجهة برمجة التطبيقات، بدون المسار /v1"
+        AppLanguage.PORTUGUESE -> "URL base da API, sem o caminho /v1"
+        AppLanguage.SPANISH -> "URL base de la API, sin la ruta /v1"
+        AppLanguage.FRENCH -> "URL de base de l'API, sans le chemin /v1"
+        AppLanguage.GERMAN -> "API-Basis-URL ohne den /v1-Pfad"
+        AppLanguage.RUSSIAN -> "Базовый URL API без пути /v1"
+        AppLanguage.JAPANESE -> "APIのベースURL（/v1 などのパスは含めない）"
+        AppLanguage.KOREAN -> "API 기본 URL, /v1 경로 제외"
+    }
+
+    fun chatEndpointDefaultHint(defaultEndpoint: String): String = when (Strings.lang) {
+        AppLanguage.CHINESE -> "默认：$defaultEndpoint"
+        AppLanguage.ENGLISH -> "Default: $defaultEndpoint"
+        AppLanguage.ARABIC -> "الافتراضي: $defaultEndpoint"
+        AppLanguage.PORTUGUESE -> "Padrão: $defaultEndpoint"
+        AppLanguage.SPANISH -> "Predeterminado: $defaultEndpoint"
+        AppLanguage.FRENCH -> "Par défaut : $defaultEndpoint"
+        AppLanguage.GERMAN -> "Standard: $defaultEndpoint"
+        AppLanguage.RUSSIAN -> "По умолчанию: $defaultEndpoint"
+        AppLanguage.JAPANESE -> "デフォルト: $defaultEndpoint"
+        AppLanguage.KOREAN -> "기본값: $defaultEndpoint"
     }
 
     val apiFormat: String get() = when (Strings.lang) {
@@ -36365,18 +36378,6 @@ object StringsC {
         AppLanguage.KOREAN -> "채팅 엔드포인트"
     }
 
-    val chatEndpointHint: String get() = when (Strings.lang) {
-        AppLanguage.CHINESE -> "默认: /v1/chat/completions"
-        AppLanguage.ENGLISH -> "Default: /v1/chat/completions"
-        AppLanguage.ARABIC -> "الافتراضي: /v1/chat/completions"
-        AppLanguage.PORTUGUESE -> "Padrão: /v1/chat/completions"
-        AppLanguage.SPANISH -> "Predeterminado: /v1/chat/completions"
-        AppLanguage.FRENCH -> "Par défaut : /v1/chat/completions"
-        AppLanguage.GERMAN -> "Standard: /v1/chat/completions"
-        AppLanguage.RUSSIAN -> "По умолчанию: /v1/chat/completions"
-        AppLanguage.JAPANESE -> "デフォルト: /v1/chat/completions"
-        AppLanguage.KOREAN -> "기본값: /v1/chat/completions"
-    }
 
     val selectApiKey: String get() = when (Strings.lang) {
         AppLanguage.CHINESE -> "选择 API Key"

--- a/app/src/main/java/com/webtoapp/ui/screens/AiSettingsScreen.kt
+++ b/app/src/main/java/com/webtoapp/ui/screens/AiSettingsScreen.kt
@@ -559,6 +559,13 @@ private fun AddApiKeyDialog(
     var customModelsEndpoint by remember { mutableStateOf(initialConfig?.customModelsEndpoint ?: "") }
     var customChatEndpoint by remember { mutableStateOf(initialConfig?.customChatEndpoint ?: "") }
     var selectedApiFormat by remember { mutableStateOf(initialConfig?.apiFormat ?: ApiFormat.OPENAI_COMPATIBLE) }
+    // Default chat endpoint for CUSTOM endpoints follows the selected wire format and
+    // mirrors ApiKeyConfig.getEffectiveChatEndpoint()'s CUSTOM branch.
+    val customDefaultChatEndpoint = when (selectedApiFormat) {
+        ApiFormat.ANTHROPIC -> "/v1/messages"
+        ApiFormat.OPENAI_RESPONSES -> "/v1/responses"
+        else -> "/v1/chat/completions"
+    }
     var alias by remember { mutableStateOf(initialConfig?.alias ?: "") }
     var showApiKey by remember { mutableStateOf(false) }
     var testResult by remember { mutableStateOf<String?>(null) }
@@ -700,7 +707,7 @@ private fun AddApiKeyDialog(
                         label = { Text("Base URL") },
                         placeholder = { Text("https://api.example.com") },
                         singleLine = true,
-                        supportingText = { Text(Strings.openAiCompatibleHint) },
+                        supportingText = { Text(Strings.customBaseUrlHint) },
                         modifier = Modifier.fillMaxWidth()
                     )
 
@@ -767,9 +774,9 @@ private fun AddApiKeyDialog(
                                 value = customChatEndpoint,
                                 onValueChange = { customChatEndpoint = it },
                                 label = { Text(Strings.chatEndpoint) },
-                                placeholder = { Text("/v1/chat/completions") },
+                                placeholder = { Text(customDefaultChatEndpoint) },
                                 singleLine = true,
-                                supportingText = { Text(Strings.chatEndpointHint) },
+                                supportingText = { Text(Strings.chatEndpointDefaultHint(customDefaultChatEndpoint)) },
                                 modifier = Modifier.fillMaxWidth()
                             )
                         }


### PR DESCRIPTION
## Summary

Follow-up to #639: the custom provider form's Base URL supporting text was hardcoded to "OpenAI compatible endpoint", and the chat endpoint hint/placeholder to `/v1/chat/completions` — stale now that a custom endpoint can speak three wire formats (Chat Completions, Anthropic Messages, Responses).

- Base URL hint becomes a neutral "API base URL, without the /v1 path" (`openAiCompatibleHint` renamed to `customBaseUrlHint`; the old string had exactly one consumer).
- Chat endpoint placeholder and supporting text follow the selected `ApiFormat` (`/v1/messages`, `/v1/responses`, `/v1/chat/completions`), mirroring `ApiKeyConfig.getEffectiveChatEndpoint()`'s CUSTOM branch. Implemented with a new parameterized string `chatEndpointDefaultHint(endpoint)` (10 languages); the dead fixed `chatEndpointHint` block is removed.

Fixes #641

## Test plan

- [x] `:app:compileStandardDebugKotlin` green
- [x] i18n suite (`com.webtoapp.core.i18n.*`, incl. translation parity) green
- [x] `:app:testStandardDebugUnitTest` full suite green locally; template rebuilt; drift check green
- [ ] CI (`Android CI Build / check`) green on this PR