### PR TITLE
chore: bump version to 2.6.0 (versionCode 60)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.5.3** (`versionCode 59`).
+This guide targets **WebToApp 2.6.0** (`versionCode 60`).
 
 ---
 
@@ -219,7 +219,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.5.3**（`versionCode 59`）。
+本指南对应 **WebToApp 2.6.0**（`versionCode 60`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
         minSdk = 23
 
         targetSdk = 35
-        versionCode = 59
-        versionName = "2.5.3"
+        versionCode = 60
+        versionName = "2.6.0"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         minSdk = 23
 
         targetSdk = 28
-        versionCode = 59
-        versionName = "2.5.3"
+        versionCode = 60
+        versionName = "2.6.0"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## Summary

Version bump for the 2.6.0 release cycle: app/shell gradle versionCode/Name plus the CONTRIBUTING version references (EN + ZH).

Highlights of the cycle: native find-in-page bottom bar (#635), first-class custom hosts sources (#637), AI provider catalog trim with three custom API formats (#640), and crash/parity fixes for activation, announcements, floating window, video splash, and keyboard handling (#622, #626, #628, #630, #632, #634, #642).

Fixes #643

## Test plan

- [x] `:app:compileStandardDebugKotlin` green (CI will run the full suite)
- [ ] CI (`Android CI Build / check`) green on this PR