### PR TITLE
chore: rename release to 2.5.4 (versionCode 60)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ rest.
 
 > **English** · [简体中文](#贡献-webtoapp中文)
 
-This guide targets **WebToApp 2.6.0** (`versionCode 60`).
+This guide targets **WebToApp 2.5.4** (`versionCode 60`).
 
 ---
 
@@ -219,7 +219,7 @@ logged and otherwise disregarded.
 非常感谢你愿意花时间。WebToApp 的迭代速度取决于"小而聚焦"的贡献——下面三条路
 里挑一条走，其他的先忽略。
 
-本指南对应 **WebToApp 2.6.0**（`versionCode 60`）。
+本指南对应 **WebToApp 2.5.4**（`versionCode 60`）。
 
 ### 你想做什么？
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
 
         targetSdk = 35
         versionCode = 60
-        versionName = "2.6.0"
+        versionName = "2.5.4"
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "false")
 
         vectorDrawables {

--- a/shell/build.gradle.kts
+++ b/shell/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
         targetSdk = 28
         versionCode = 60
-        versionName = "2.6.0"
+        versionName = "2.5.4"
 
         buildConfigField("boolean", "SHELL_RUNTIME_ONLY", "true")
 


### PR DESCRIPTION
## Summary

Follow-up to #644: the version name should follow the project's patch-increment cadence — this release cycle ships as **2.5.4**, not 2.6.0. versionCode stays 60 (monotonic). The premature `v2.6.0` tag has been deleted; `v2.5.4` will be tagged after merge.

Fixes #643

## Test plan

- [x] Version references updated in `app/build.gradle.kts`, `shell/build.gradle.kts`, `CONTRIBUTING.md` (EN + ZH)
- [ ] CI (`Android CI Build / check`) green on this PR