### PR TITLE
fix(ci): stop merge pushes from cancelling packaging runs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -11,8 +11,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: android-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group per ref AND event type: routine pushes to the same branch still cancel
+  # their superseded check runs, but a workflow_dispatch packaging run is never
+  # cancelled by a merge push landing on the same ref mid-build.
+  group: android-ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

The workflow's `concurrency` group is keyed only by workflow + ref with `cancel-in-progress: true`. A `workflow_dispatch` packaging run on `main` therefore gets cancelled the moment any merge/push lands on `main` mid-build — three release builds for v2.5.4 were lost this way (each killed ~20 minutes in by a runner shutdown signal).

The group now includes the event type and only auto-cancels same-event runs: rapid pushes to the same branch still supersede stale checks, but a packaging run is never cancelled by an unrelated push.

## Test plan

- [x] YAML validated by the CI trigger on this PR (pull_request event → its own group, cancel-in-progress false)
- [ ] CI (`Android CI Build / check`) green on this PR