### PR TITLE
fix(ai-find): stop the WebView from swallowing backspace in the find bar

### DIFF
--- a/app/src/main/java/com/webtoapp/ui/shell/FindInPageBar.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/FindInPageBar.kt
@@ -13,6 +13,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
@@ -39,6 +42,8 @@ fun FindInPageBar(
     var activeMatchOrdinal by remember { mutableIntStateOf(-1) }
     var numberOfMatches by remember { mutableIntStateOf(0) }
     var doneCounting by remember { mutableStateOf(true) }
+    val inputFocusRequester = remember { FocusRequester() }
+    var inputFocused by remember { mutableStateOf(false) }
 
     // Listen for engine-side counting results while the bar is up; detach (and drop
     // the highlights) when it goes away.
@@ -58,6 +63,11 @@ fun FindInPageBar(
         }
     }
 
+    // Cursor ready as soon as the bar opens.
+    LaunchedEffect(webView) {
+        if (webView != null) inputFocusRequester.requestFocus()
+    }
+
     // Live search as the query changes (debounced), like Chrome's find bar.
     LaunchedEffect(query, webView) {
         val wv = webView ?: return@LaunchedEffect
@@ -71,6 +81,10 @@ fun FindInPageBar(
         kotlinx.coroutines.delay(300)
         try {
             wv.findAllAsync(query)
+            // findAllAsync makes the WebView steal view focus from this input, which
+            // swallowed the backspace key (type worked, delete did not). Re-claim it
+            // after each search unless the user moved focus away on purpose.
+            if (!inputFocused) inputFocusRequester.requestFocus()
         } catch (e: Exception) {
             AppLogger.w("FindInPageBar", "findAllAsync failed", e)
         }
@@ -105,7 +119,10 @@ fun FindInPageBar(
                         style = MaterialTheme.typography.bodySmall
                     )
                 },
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(inputFocusRequester)
+                    .onFocusChanged { inputFocused = it.isFocused },
                 singleLine = true,
                 textStyle = MaterialTheme.typography.bodySmall,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),

--- a/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/shell/ShellActivity.kt
@@ -194,8 +194,26 @@ class ShellActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Forward keys to the page only when focus actually belongs to the page (the WebView /
+     * browser surface, or no app UI is focused). While a find session is active, Chromium's
+     * WebView consumes DEL unconditionally, so blindly forwarding ate the backspace of app
+     * UI like the find-in-page input.
+     */
+    private fun isFocusInsidePageView(): Boolean {
+        var view = currentFocus ?: return true
+        val pageView = browserSurface?.view ?: webView
+        while (view is View) {
+            if (view is WebView || (pageView != null && view == pageView)) return true
+            view = view.parent as? View ?: return false
+        }
+        return false
+    }
+
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (shouldForwardKeyToWebView(event) && (browserSurface?.dispatchKeyEvent(event) == true || webView?.dispatchKeyEvent(event) == true)) {
+        if (shouldForwardKeyToWebView(event) && isFocusInsidePageView() &&
+            (browserSurface?.dispatchKeyEvent(event) == true || webView?.dispatchKeyEvent(event) == true)
+        ) {
             return true
         }
 

--- a/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/com/webtoapp/ui/webview/WebViewActivity.kt
@@ -969,8 +969,23 @@ class WebViewActivity : AppCompatActivity() {
         }
     }
 
+    /**
+     * Forward keys to the page only when focus actually belongs to the page (the WebView
+     * itself, or no app UI is focused — e.g. arrow/space scrolling right after launch).
+     * While a find session is active, Chromium's WebView consumes DEL unconditionally, so
+     * blindly forwarding ate the backspace of app UI like the find-in-page input.
+     */
+    private fun isFocusInsideWebView(): Boolean {
+        var view = currentFocus ?: return true
+        while (view is View) {
+            if (view is WebView) return true
+            view = view.parent as? View ?: return false
+        }
+        return false
+    }
+
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (shouldForwardKeyToWebView(event) && webView?.dispatchKeyEvent(event) == true) {
+        if (shouldForwardKeyToWebView(event) && isFocusInsideWebView() && webView?.dispatchKeyEvent(event) == true) {
             return true
         }
         return super.dispatchKeyEvent(event)


### PR DESCRIPTION
## Summary

Fixes the find bar regression: the input could type but **not delete**. With a find session active, `webView.dispatchKeyEvent(KEYCODE_DEL)` returns true unconditionally, and both activities forwarded every key to the WebView at the top of `dispatchKeyEvent` — before the focused field ever saw it. IME commits bypass that path (input connection), hence typing worked while deleting did not.

### Fix

- `WebViewActivity` + `ShellActivity`: forward keys to the page only when focus belongs to the page (`isFocusInsideWebView` / `isFocusInsidePageView` — WebView/browser-surface focused, or nothing focused so arrow/space page scrolling still works right after launch).
- `FindInPageBar`: requests input focus on open and re-claims it after each `findAllAsync` (the search steals view focus), keeping the cursor ready.

### Evidence matrix (emulator)

| Scenario | DEL |
|---|---|
| System search field (control) | works |
| Console input, find bar closed | works |
| Console input, find bar open + live query | eaten |
| Find bar input, live query, field focused, counter live | eaten |

Post-fix: type → DEL ×3 deletes per character; counter tracks (1/2); prev/next cycle matches.

Fixes #648

## Test plan

- [x] Emulator end-to-end: typing, backspace ×3, counter, prev/next all verified
- [x] `:app:assembleStandardDebug` green; full unit suite + template rebuild + drift check green locally
- [ ] CI (`Android CI Build / check`) green on this PR