### PR TITLE
fix(shell): keyboard no longer covers inputs with RESIZE mode below API 30 (for real)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,7 @@ The editor screens have an established card language. **Find the neighboring car
 
 ## Easy-to-miss points
 
+- **Keyboard avoidance below API 30 requires the classic window path.** Android 10 and lower have no native IME-inset dispatch: an edge-to-edge window (`decorFitsSystemWindows = false`) is never resized for the keyboard and reports zero IME insets, so no `softInputMode` value helps there. `WindowHelper.applyImmersiveFullscreen` therefore keeps the decor fitting system windows on the RESIZE keyboard path below API 30 (system `SOFT_INPUT_ADJUST_RESIZE` works) and degrades TRANSPARENT/IMAGE status-bar styles to solid colors on that path. Do not re-enable edge-to-edge unconditionally for those devices (#613; #634 flipped only the softInputMode bits and fixed nothing — its Robolectric test passed because it never asserted the layout flags).
 - **Shared sources are authored in `app/`.** Editing only a file under `shell/src` is usually wrong; it will be overwritten on sync or diverge from host.
 - **Config field names drift.** Editor model, `ApkConfig`, JSON factory, and shell config must stay aligned; Gson silently drops unknown/missing fields. Run `checkConfigFieldDrift`.
 - **Low targetSdk (28) and fork/exec runtimes** constrain "modernize the shell SDK" changes.

--- a/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
+++ b/app/src/main/java/com/webtoapp/ui/shared/WindowHelper.kt
@@ -5,6 +5,7 @@ import android.content.pm.ActivityInfo
 import android.os.Build
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.view.WindowManager
 import android.webkit.WebChromeClient
 import android.widget.FrameLayout
@@ -33,6 +34,13 @@ object WindowHelper {
     ) {
         val controller = WindowInsetsControllerCompat(activity.window, activity.window.decorView)
         val alpha = backgroundAlpha.coerceIn(0f, 1f)
+        // The classic resize window (below API 30, RESIZE mode) does not draw behind the
+        // status bar, so a transparent bar would just show the window background.
+        val colorMode = if (colorMode == "TRANSPARENT" && isClassicKeyboardResizeWindow(activity.window)) {
+            "THEME"
+        } else {
+            colorMode
+        }
 
         when (colorMode) {
             "TRANSPARENT" -> {
@@ -105,23 +113,38 @@ object WindowHelper {
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
             }
 
+            // Below API 30 the platform has no native IME-inset dispatch: with the window laid
+            // out edge-to-edge, the system neither resizes it for the keyboard nor reports IME
+            // insets, leaving RESIZE mode with no working keyboard avoidance at all (issue #613;
+            // the #634 softInputMode-only fix did not help because of these layout flags).
+            // Those devices keep the decor fitting system windows and rely on the classic
+            // SOFT_INPUT_ADJUST_RESIZE path instead. Nothing draws behind the system bars
+            // there, so translucent status-bar styles degrade to solid theme colors.
+            val classicKeyboardResize = isClassicKeyboardResize(keyboardAdjustMode)
+            val effectiveStatusBarColorMode =
+                if (classicKeyboardResize && statusBarColorMode == "TRANSPARENT") "THEME" else statusBarColorMode
+            val effectiveStatusBarBgType =
+                if (classicKeyboardResize && statusBarBgType == "IMAGE") "COLOR" else statusBarBgType
+
             WindowInsetsControllerCompat(activity.window, activity.window.decorView).let { controller ->
                 var decorFitsSystemWindows = true
                 if (enabled) {
-                    activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
+                    if (!classicKeyboardResize) {
+                        activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
+                    }
                     val shouldShowStatusBar = if (forceHideSystemUi) false else showStatusBar
 
                     if (shouldShowStatusBar) {
-                        decorFitsSystemWindows = false
-                        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+                        decorFitsSystemWindows = classicKeyboardResize
+                        WindowCompat.setDecorFitsSystemWindows(activity.window, classicKeyboardResize)
                         controller.show(WindowInsetsCompat.Type.statusBars())
 
-                        if (statusBarBgType == "IMAGE") {
+                        if (effectiveStatusBarBgType == "IMAGE") {
                             activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
                             val useDarkIcons = statusBarDarkIcons ?: !isDarkTheme
                             controller.isAppearanceLightStatusBars = useDarkIcons
                         } else {
-                            when (statusBarColorMode) {
+                            when (effectiveStatusBarColorMode) {
                                 "CUSTOM" -> {
                                     val color = try {
                                         android.graphics.Color.parseColor(statusBarCustomColor ?: "#000000")
@@ -149,9 +172,14 @@ object WindowHelper {
                             }
                         }
                     } else {
-                        decorFitsSystemWindows = false
-                        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
-                        activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
+                        decorFitsSystemWindows = classicKeyboardResize
+                        WindowCompat.setDecorFitsSystemWindows(activity.window, classicKeyboardResize)
+                        activity.window.statusBarColor = if (classicKeyboardResize) {
+                            // nothing draws behind a hidden bar on the classic path
+                            android.graphics.Color.parseColor(if (isDarkTheme) "#1C1B1F" else "#FFFBFE")
+                        } else {
+                            android.graphics.Color.TRANSPARENT
+                        }
                         controller.hide(WindowInsetsCompat.Type.statusBars())
                     }
 
@@ -165,20 +193,22 @@ object WindowHelper {
                             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     }
                 } else {
-                    decorFitsSystemWindows = false
-                    WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+                    decorFitsSystemWindows = classicKeyboardResize
+                    WindowCompat.setDecorFitsSystemWindows(activity.window, classicKeyboardResize)
                     controller.show(WindowInsetsCompat.Type.systemBars())
                     controller.systemBarsBehavior =
                         WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                    activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
+                    if (!classicKeyboardResize) {
+                        activity.window.navigationBarColor = android.graphics.Color.TRANSPARENT
+                    }
 
-                    if (statusBarBgType == "IMAGE") {
+                    if (effectiveStatusBarBgType == "IMAGE") {
                         activity.window.statusBarColor = android.graphics.Color.TRANSPARENT
                         val useDarkIcons = statusBarDarkIcons ?: !isDarkTheme
                         controller.isAppearanceLightStatusBars = useDarkIcons
                         controller.isAppearanceLightNavigationBars = useDarkIcons
                     } else {
-                        when (statusBarColorMode) {
+                        when (effectiveStatusBarColorMode) {
                             "CUSTOM" -> {
                                 val color = try {
                                     android.graphics.Color.parseColor(statusBarCustomColor ?: "#000000")
@@ -199,7 +229,7 @@ object WindowHelper {
                             else -> {
                                 applyStatusBarColor(
                                     activity,
-                                    statusBarColorMode,
+                                    effectiveStatusBarColorMode,
                                     statusBarCustomColor,
                                     statusBarDarkIcons,
                                     isDarkTheme
@@ -211,11 +241,27 @@ object WindowHelper {
                         ViewCompat.requestApplyInsets(activity.window.decorView)
                     }
                 }
+                if (classicKeyboardResize) {
+                    // Not edge-to-edge: keep the nav bar in sync with the solid status bar
+                    // instead of leaving a default dark bar under light nav icons.
+                    activity.window.navigationBarColor = activity.window.statusBarColor
+                }
                 applyKeyboardMode(activity, keyboardAdjustMode, tag, decorFitsSystemWindows)
             }
         } catch (e: Exception) {
             AppLogger.w(tag, "applyImmersiveFullscreen failed", e)
         }
+    }
+
+    private fun isClassicKeyboardResize(keyboardAdjustMode: KeyboardAdjustMode?): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) return false
+        return (keyboardAdjustMode ?: KeyboardAdjustMode.RESIZE) == KeyboardAdjustMode.RESIZE
+    }
+
+    /** True when the window runs the classic (non-edge-to-edge) resize path below API 30. */
+    private fun isClassicKeyboardResizeWindow(window: Window): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) return false
+        return window.attributes.softInputMode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE != 0
     }
 
     private fun applyKeyboardMode(
@@ -231,12 +277,10 @@ object WindowHelper {
         when (mode) {
             KeyboardAdjustMode.RESIZE -> {
 
-                // androidx only reports IME insets on API < 30 when the window runs with
-                // SOFT_INPUT_ADJUST_RESIZE; with ADJUST_NOTHING the manual padding below
-                // never sees a non-zero IME inset on Android 10 and lower, so the keyboard
-                // covered the input regardless of this setting (issue #613). Those devices
-                // fall back to the system resize path, which also lets the WebView scroll
-                // the focused input into view on its own.
+                // Manual IME padding needs native IME-inset dispatch (API 30+). Below that,
+                // applyImmersiveFullscreen keeps the window fitting system windows so the
+                // system SOFT_INPUT_ADJUST_RESIZE path actually resizes for the keyboard and
+                // the WebView scrolls the focused input into view on its own (issue #613).
                 val useManualImePadding = !decorFitsSystemWindows &&
                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 

--- a/app/src/test/java/com/webtoapp/ui/shared/WindowHelperKeyboardModeTest.kt
+++ b/app/src/test/java/com/webtoapp/ui/shared/WindowHelperKeyboardModeTest.kt
@@ -1,6 +1,8 @@
 package com.webtoapp.ui.shared
 
 import android.app.Activity
+import android.graphics.Color
+import android.view.View
 import android.view.WindowManager
 import com.google.common.truth.Truth.assertThat
 import com.webtoapp.data.model.KeyboardAdjustMode
@@ -10,64 +12,115 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
+private fun isEdgeToEdge(activity: Activity): Boolean {
+    val vis = activity.window.decorView.systemUiVisibility
+    return vis and View.SYSTEM_UI_FLAG_LAYOUT_STABLE != 0 ||
+        vis and View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN != 0 ||
+        vis and View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION != 0
+}
+
 /**
- * Regression coverage for issue #613: the RESIZE keyboard mode used to set
- * SOFT_INPUT_ADJUST_NOTHING on every device and rely on manual IME padding, but
- * androidx only reports IME insets on API < 30 when the window runs with
- * SOFT_INPUT_ADJUST_RESIZE — so on Android 10 and lower the padding stayed 0 and
- * the keyboard covered the focused input.
+ * Regression coverage for issue #613 and its first, ineffective fix (#634).
+ *
+ * Below API 30 the platform has no native IME-inset dispatch, and a window laid out
+ * edge-to-edge (decor not fitting system windows) is never resized for the keyboard —
+ * so RESIZE mode must keep the decor fitting system windows and rely on the classic
+ * SOFT_INPUT_ADJUST_RESIZE path. #634 only flipped the softInputMode bits while leaving
+ * the edge-to-edge layout flags in place, which is why the keyboard still covered the
+ * input on Android 10 and lower. These tests assert both the softInputMode AND the
+ * edge-to-edge flags, plus the solid status-bar fallback that the classic path needs.
  */
-class WindowHelperKeyboardModeTest {
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class WindowHelperKeyboardModePreApi30Test {
 
-    @RunWith(RobolectricTestRunner::class)
-    @Config(sdk = [29])
-    class PreApi30Test {
+    @Test
+    fun `resize mode below API 30 uses system resize and drops edge-to-edge`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
 
-        @Test
-        fun `resize mode falls back to system adjust resize below API 30`() {
-            val activity = Robolectric.setupActivity(Activity::class.java)
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+        )
 
-            WindowHelper.applyImmersiveFullscreen(
-                activity,
-                enabled = false,
-                keyboardAdjustMode = KeyboardAdjustMode.RESIZE
-            )
-
-            val mode = activity.window.attributes.softInputMode
-            assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE).isNotEqualTo(0)
-        }
-
-        @Test
-        fun `nothing mode keeps adjust nothing below API 30`() {
-            val activity = Robolectric.setupActivity(Activity::class.java)
-
-            WindowHelper.applyImmersiveFullscreen(
-                activity,
-                enabled = false,
-                keyboardAdjustMode = KeyboardAdjustMode.NOTHING
-            )
-
-            val mode = activity.window.attributes.softInputMode
-            assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
-        }
+        val mode = activity.window.attributes.softInputMode
+        assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE).isNotEqualTo(0)
+        assertThat(isEdgeToEdge(activity)).isFalse()
     }
 
-    @RunWith(RobolectricTestRunner::class)
-    @Config(sdk = [30])
-    class Api30Test {
+    @Test
+    fun `resize mode below API 30 downgrades transparent status bar to solid theme`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
 
-        @Test
-        fun `resize mode keeps manual ime padding path on API 30+`() {
-            val activity = Robolectric.setupActivity(Activity::class.java)
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            statusBarColorMode = "TRANSPARENT",
+            keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+        )
 
-            WindowHelper.applyImmersiveFullscreen(
-                activity,
-                enabled = false,
-                keyboardAdjustMode = KeyboardAdjustMode.RESIZE
-            )
+        // Nothing draws behind the bars on the classic path; a transparent bar would
+        // only expose the window background.
+        assertThat(Color.alpha(activity.window.statusBarColor)).isEqualTo(255)
+        assertThat(activity.window.navigationBarColor)
+            .isEqualTo(activity.window.statusBarColor)
+    }
 
-            val mode = activity.window.attributes.softInputMode
-            assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
-        }
+    @Test
+    fun `switching from nothing mode to resize mode clears stale edge-to-edge flags`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
+
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.NOTHING
+        )
+        assertThat(isEdgeToEdge(activity)).isTrue()
+
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+        )
+
+        assertThat(isEdgeToEdge(activity)).isFalse()
+        val mode = activity.window.attributes.softInputMode
+        assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE).isNotEqualTo(0)
+    }
+
+    @Test
+    fun `nothing mode keeps adjust nothing and edge-to-edge below API 30`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
+
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.NOTHING
+        )
+
+        val mode = activity.window.attributes.softInputMode
+        assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
+        assertThat(isEdgeToEdge(activity)).isTrue()
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class WindowHelperKeyboardModeApi30Test {
+
+    @Test
+    fun `resize mode keeps manual ime padding path on API 30+`() {
+        val activity = Robolectric.setupActivity(Activity::class.java)
+
+        WindowHelper.applyImmersiveFullscreen(
+            activity,
+            enabled = false,
+            keyboardAdjustMode = KeyboardAdjustMode.RESIZE
+        )
+
+        val mode = activity.window.attributes.softInputMode
+        assertThat(mode and WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING).isNotEqualTo(0)
+        assertThat(isEdgeToEdge(activity)).isTrue()
     }
 }


### PR DESCRIPTION
## Summary

Fixes #650: #634 did not actually fix #613 — users on Android 10 and lower still see the soft keyboard cover the focused web input in RESIZE (向上顶起) mode. This PR makes the fix effective by changing the window configuration, not just the soft input mode.

### Root cause

Below API 30 the platform has no native IME-inset dispatch, and a window laid out edge-to-edge (`decorFitsSystemWindows = false`) is **never resized for the keyboard**. `applyImmersiveFullscreen` set that flag in every branch, so on those devices:

- pre-#634: `ADJUST_NOTHING` + manual padding → IME insets always 0 → no padding;
- post-#634: `ADJUST_RESIZE` → the system ignores the resize under the `SYSTEM_UI_FLAG_LAYOUT_*` flags.

Both degrade to "keyboard overlays content". Android 11+ (manual insets path) always worked, matching the report distribution. The #634 test asserted only the `softInputMode` bits, so Robolectric could not catch it.

### Fix

- `applyImmersiveFullscreen` now computes a classic-resize path (`SDK < R && mode == RESIZE`) and keeps the decor **fitting** system windows there, so the classic `SOFT_INPUT_ADJUST_RESIZE` path actually resizes the window and the WebView scrolls the focused input into view on its own.
- On that path TRANSPARENT/IMAGE status-bar styles degrade to solid theme colors (nothing draws behind the bars), and the nav bar color follows the status bar instead of a transparent-over-content look.
- Android 11+ manual animated padding path unchanged; NOTHING mode unchanged on all APIs.
- Regression tests now assert the edge-to-edge layout **flags** (the missing assertion that let #634 ship green), stale-flag clearing when switching NOTHING → RESIZE, and the solid status-bar fallback.
- AGENTS.md documents the platform constraint in Easy-to-miss points.

## Test plan

- [x] Robolectric: SDK 29 + RESIZE → `ADJUST_RESIZE` set **and** decor not edge-to-edge; SDK 29 + NOTHING → unchanged edge-to-edge; SDK 30 + RESIZE → manual path unchanged; mode switch clears stale flags; TRANSPARENT → solid on classic path
- [x] On-device verification on an Android 10 (API 29) emulator with the host preview: bottom-of-page input stays visible and focused above the keyboard, with immersive fullscreen both **off and on** (screenshots verified during development)
- [x] `:app:testStandardDebugUnitTest --tests "com.webtoapp.ui.shared.*"` green locally
- [ ] CI green on this PR

Fixes #650